### PR TITLE
docs: add Cloudflare Access setup guide

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -59,15 +59,72 @@ pnpm deploy:dry-run
 
 ## Cloudflare Access
 
-FlareMo 不在应用里做实例级登录。生产实例应该由 Cloudflare Access 保护。
+FlareMo 不在应用里做实例级登录。生产实例应该由 Cloudflare Access 保护，不要再给 FlareMo 增加应用内 Bearer token、登录页或自建会话网关。
 
-建议配置：
+Access 的推荐边界是：
 
-- 人类访问：Access identity policy。
-- 脚本、MCP 和 Memos-compatible 客户端：Access Service Token。
-- 公开分享：对公开分享路径配置 bypass policy。
+- 人类访问：`Allow` identity policy。
+- 脚本、MCP 和 Memos-compatible 客户端：`Service Auth` policy + Access Service Token。
+- 公开分享和静态资源：最窄路径的 `Bypass` policy。
 
-脚本访问示例：
+### 1. 创建 Access application
+
+Cloudflare Dashboard 里进入 `Zero Trust` -> `Access` -> `Applications` -> `Add an application`，选择 `Self-hosted`。
+
+建议填写：
+
+| 字段 | 建议值 |
+| --- | --- |
+| Application name | `FlareMo` |
+| Application domain | 你的生产域名，例如 `notes.example.com` |
+| Session duration | 个人实例可用 `24h` 或 `1 week` |
+
+如果先使用 `workers.dev` 或 Worker Preview URL，可以在 Worker 的 `Settings` -> `Domains & Routes` 里启用 Cloudflare Access，再进入 Access 管理策略。正式使用时更推荐绑定自定义域名，再保护这个域名。
+
+### 2. 配置人类访问 policy
+
+给根域名配置一个 `Allow` policy，只放你自己或明确允许的人。
+
+推荐规则：
+
+| 项 | 建议 |
+| --- | --- |
+| Policy action | `Allow` |
+| Include | 你的邮箱、邮箱域名、GitHub/Google/SSO identity group，或 One-time PIN 的指定邮箱 |
+| Exclude | 不需要时留空；不要用 `Everyone` 保护根路径 |
+
+这个 policy 负责浏览器访问 FlareMo Web UI。通过后，用户会拿到 Cloudflare Access session cookie。
+
+### 3. 创建 Service Token
+
+脚本、MCP、Memos-compatible 客户端通常没有浏览器登录流程，应该使用 Access Service Token。
+
+在 Cloudflare Dashboard 里进入 `Zero Trust` -> `Access` -> `Service Auth` -> `Service Tokens`，创建一个 token，例如：
+
+```text
+FlareMo API clients
+```
+
+保存创建时显示的 `Client ID` 和 `Client Secret`。`Client Secret` 只显示一次，写到本地密码管理器或部署环境变量里，不要提交到仓库。
+
+本地建议使用：
+
+```bash
+export FLAREMO_ACCESS_CLIENT_ID="<client-id>"
+export FLAREMO_ACCESS_CLIENT_SECRET="<client-secret>"
+```
+
+### 4. 配置机器访问 policy
+
+回到 FlareMo Access application，新增一个 policy：
+
+| 项 | 建议 |
+| --- | --- |
+| Policy action | `Service Auth` |
+| Include | 刚创建的 Service Token |
+| Require | 可选；固定网络可加 IP/Country 等额外限制 |
+
+机器客户端请求时发送 Cloudflare Access 要求的两个 header：
 
 ```bash
 curl "$FLAREMO_URL/api/v1/memos" \
@@ -75,13 +132,70 @@ curl "$FLAREMO_URL/api/v1/memos" \
   -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET"
 ```
 
-建议 bypass 的路径：
+MCP 示例：
+
+```bash
+curl "$FLAREMO_URL/api/v1/mcp" \
+  -H "content-type: application/json" \
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+不要把 Service Token 改造成 FlareMo 应用内 token。FlareMo 业务代码不读取、签发或存储这些凭据。
+
+### 5. 配置公开分享 bypass
+
+公开分享需要让未登录访客访问分享页和分享附件。Cloudflare Access 的路径策略会让更具体的路径覆盖根路径策略，因此给以下路径单独配置 `Bypass`：
 
 - `/share/*`
 - `/api/public/shares/*`
 - `/assets/*`
 
-Bypass 只跳过 Cloudflare Access，不跳过 FlareMo 的 share token、过期时间和 memo 状态校验。
+建议做法：
+
+| Path | Policy action | Include |
+| --- | --- | --- |
+| `/share/*` | `Bypass` | `Everyone` |
+| `/api/public/shares/*` | `Bypass` | `Everyone` |
+| `/assets/*` | `Bypass` | `Everyone` |
+
+只 bypass 这些公开路径，不要 bypass `/api/v1/*`、`/openapi.json` 或根路径。`Bypass` 会跳过 Access 强制认证，也不会产生 Access 访问日志；需要认证和审计的机器请求应使用 `Service Auth`，不要用 `Bypass`。
+
+Bypass 只跳过 Cloudflare Access，不跳过 FlareMo 的 share token、过期时间和 memo 状态校验。归档、回收站、删除或过期的分享仍应由 FlareMo 返回不可访问。
+
+### 6. 验证配置
+
+未登录浏览器访问根路径应该看到 Cloudflare Access 登录页：
+
+```bash
+curl -I "$FLAREMO_URL"
+```
+
+带 Service Token 的 API 请求应该进入 FlareMo：
+
+```bash
+curl "$FLAREMO_URL/api/v1/memos" \
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET"
+```
+
+公开分享路径应该不要求 Access 登录，但无效 token 仍不能读到内容：
+
+```bash
+curl -I "$FLAREMO_URL/share/not-a-real-token"
+curl -I "$FLAREMO_URL/api/public/shares/not-a-real-token"
+```
+
+## Access 配置检查清单
+
+- 根域名或 Worker URL 已创建 Cloudflare Access application。
+- 人类访问使用 `Allow` policy，范围只包含允许访问的人。
+- 脚本、MCP 和 Memos-compatible 客户端使用 `Service Auth` policy 和 Access Service Token。
+- `Client Secret` 没有写入仓库、issue、PR 或公开日志。
+- `/share/*`、`/api/public/shares/*`、`/assets/*` 有明确 `Bypass` policy。
+- 没有 bypass 根路径、`/api/v1/*` 或 `/openapi.json`。
+- FlareMo 没有新增应用内 Bearer token 登录。
 
 ## 本地开发
 

--- a/docs/en/deploy.md
+++ b/docs/en/deploy.md
@@ -35,15 +35,72 @@ pnpm deploy
 
 ## Cloudflare Access
 
-FlareMo expects production instances to be protected by Cloudflare Access.
+FlareMo expects production instances to be protected by Cloudflare Access. Do not add an app-level Bearer token, login page, or custom session gateway to FlareMo.
 
-Recommended policy split:
+Recommended boundary:
 
-- Human access: Access identity policy.
-- Scripts, MCP, and Memos-compatible clients: Access Service Token.
-- Public shares: explicit bypass policy for public share routes.
+- Human access: `Allow` identity policy.
+- Scripts, MCP, and Memos-compatible clients: `Service Auth` policy plus Access Service Token.
+- Public shares and static assets: narrowly scoped `Bypass` policies.
 
-Service Token example:
+### 1. Create an Access application
+
+In the Cloudflare Dashboard, go to `Zero Trust` -> `Access` -> `Applications` -> `Add an application`, then choose `Self-hosted`.
+
+Recommended values:
+
+| Field | Value |
+| --- | --- |
+| Application name | `FlareMo` |
+| Application domain | Your production hostname, for example `notes.example.com` |
+| Session duration | `24h` or `1 week` for a personal instance |
+
+If you are starting with a `workers.dev` or Worker Preview URL, enable Cloudflare Access from the Worker `Settings` -> `Domains & Routes` page, then manage the Access policies. For long-term use, prefer a custom hostname and protect that hostname.
+
+### 2. Configure the human access policy
+
+Add an `Allow` policy for the root application. Include only yourself or the people who should use this FlareMo instance.
+
+Recommended values:
+
+| Item | Value |
+| --- | --- |
+| Policy action | `Allow` |
+| Include | Your email, email domain, GitHub/Google/SSO group, or selected One-time PIN email |
+| Exclude | Usually empty; do not use `Everyone` for the root application |
+
+This policy protects the browser UI. Authenticated users receive a Cloudflare Access session cookie.
+
+### 3. Create a Service Token
+
+Scripts, MCP, and Memos-compatible clients usually cannot complete a browser login flow. Use an Access Service Token for those clients.
+
+In the Cloudflare Dashboard, go to `Zero Trust` -> `Access` -> `Service Auth` -> `Service Tokens`, then create a token such as:
+
+```text
+FlareMo API clients
+```
+
+Save the `Client ID` and `Client Secret` shown at creation time. The secret is only displayed once. Store it in a password manager or environment variables; never commit it.
+
+Local environment example:
+
+```bash
+export FLAREMO_ACCESS_CLIENT_ID="<client-id>"
+export FLAREMO_ACCESS_CLIENT_SECRET="<client-secret>"
+```
+
+### 4. Configure the machine access policy
+
+Return to the FlareMo Access application and add a policy:
+
+| Item | Value |
+| --- | --- |
+| Policy action | `Service Auth` |
+| Include | The Service Token you created |
+| Require | Optional; add IP/Country constraints if clients come from fixed networks |
+
+Machine clients authenticate with Cloudflare Access headers:
 
 ```bash
 curl "$FLAREMO_URL/api/v1/memos" \
@@ -51,13 +108,70 @@ curl "$FLAREMO_URL/api/v1/memos" \
   -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET"
 ```
 
-Recommended bypass paths:
+MCP example:
+
+```bash
+curl "$FLAREMO_URL/api/v1/mcp" \
+  -H "content-type: application/json" \
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Do not turn the Service Token into a FlareMo app token. FlareMo application code does not read, issue, or store these credentials.
+
+### 5. Configure public share bypass
+
+Public shares need unauthenticated access to the share page and shared attachments. Cloudflare Access path policies let more specific paths override the root application policy, so add explicit `Bypass` policies for:
 
 - `/share/*`
 - `/api/public/shares/*`
 - `/assets/*`
 
-The bypass only skips Cloudflare Access. FlareMo still validates share token, expiration time, and memo state.
+Recommended policies:
+
+| Path | Policy action | Include |
+| --- | --- | --- |
+| `/share/*` | `Bypass` | `Everyone` |
+| `/api/public/shares/*` | `Bypass` | `Everyone` |
+| `/assets/*` | `Bypass` | `Everyone` |
+
+Only bypass these public paths. Do not bypass `/api/v1/*`, `/openapi.json`, or the root application. `Bypass` disables Access enforcement and Access logging for matching requests; machine clients that need authentication and auditability should use `Service Auth`.
+
+The bypass only skips Cloudflare Access. FlareMo still validates share token, expiration time, and memo state. Archived, trashed, deleted, or expired shares must remain inaccessible.
+
+### 6. Verify the configuration
+
+Unauthenticated browser access to the root application should see Cloudflare Access:
+
+```bash
+curl -I "$FLAREMO_URL"
+```
+
+API requests with a Service Token should reach FlareMo:
+
+```bash
+curl "$FLAREMO_URL/api/v1/memos" \
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET"
+```
+
+Public share routes should not require Access login, but invalid share tokens still must not expose content:
+
+```bash
+curl -I "$FLAREMO_URL/share/not-a-real-token"
+curl -I "$FLAREMO_URL/api/public/shares/not-a-real-token"
+```
+
+## Access Checklist
+
+- The root hostname or Worker URL has a Cloudflare Access application.
+- Human access uses an `Allow` policy scoped to allowed users only.
+- Scripts, MCP, and Memos-compatible clients use a `Service Auth` policy and Access Service Token.
+- The `Client Secret` is not committed to the repository, issues, PRs, or public logs.
+- `/share/*`, `/api/public/shares/*`, and `/assets/*` have explicit `Bypass` policies.
+- The root application, `/api/v1/*`, and `/openapi.json` are not bypassed.
+- FlareMo has no app-level Bearer token login.
 
 ## Local Development
 


### PR DESCRIPTION
## Summary

- Add a step-by-step Cloudflare Access setup guide for FlareMo production instances.
- Document human `Allow` policy, machine-client `Service Auth` policy, Access Service Token headers, and narrowly scoped public share bypass routes.
- Sync the same guidance into the English deployment guide.

## Issue

Completed #2.

## Validation

```bash
pnpm format:check
pnpm verify
pnpm deploy:dry-run
```

All passed before opening this PR.
