### PR TITLE
docs: document PR workflow and deploy checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,33 @@ pnpm deploy:dry-run
 - `Temp/` 是参考仓库目录，不能提交。
 - 不使用 GitHub Actions 作为项目 CI；提交前在本地跑 `pnpm verify`。
 
+## Issue 和 PR 流程
+
+`main` 永远代表可发布状态。不要直接在 `main` 上做功能或文档任务；除非是维护者明确要求的紧急修正，否则都按 issue 分支和 PR 流程走。
+
+标准流程：
+
+```text
+issue -> branch -> commit -> push -> PR -> squash merge -> delete branch -> update local main
+```
+
+操作规则：
+
+- 开始任务前先切回最新 `main`：`git switch main && git pull --ff-only`。
+- 从 `main` 创建短生命周期分支。推荐前缀：`docs/*`、`test/*`、`feat/*`、`fix/*`、`ops/*`、`codex/*`。
+- 一个 PR 只处理一个 issue，或一组强相关 issue；不要把无关清理混进同一个 PR。
+- PR body 必须写验证命令和 issue 关系。能完整关闭时写 `Closes #N`；只能推进上下文时写 `Refs #N`。
+- 合并使用 squash merge；合并后删除远端任务分支。
+- 合并后本地执行 `git switch main && git pull --ff-only`，确认 `main` 已包含合并提交。
+
+验证强度按改动类型选择：
+
+- 纯文档、拼写、链接：`pnpm format:check`。
+- 部署、Wrangler、D1、R2、Access 相关文档或配置：`pnpm format:check` 和 `pnpm deploy:dry-run`。
+- API、domain service、Memos 兼容、测试夹具：`pnpm verify`。
+- UI 改动：`pnpm verify`，再用 `pnpm dev` 检查桌面和移动端。
+- 真实 Cloudflare 资源演练：`pnpm verify`、`pnpm deploy:dry-run`，再执行对应的远端 D1/R2/Access 验证。
+
 ## 验收口径
 
 改动完成前至少跑：

--- a/README.en.md
+++ b/README.en.md
@@ -16,6 +16,8 @@
   <img src="./docs/assets/flaremo-mobile.png" alt="FlareMo mobile timeline" width="220">
 </p>
 
+The screenshots show the current backend-backed timeline, editor, filtering, and mobile navigation. Features that are not implemented yet, such as AI review, semantic search, and messaging-app capture, are not exposed as placeholder UI.
+
 ## What It Does
 
 - Quick memo capture with tags and attachments.
@@ -64,6 +66,15 @@ pnpm deploy
 ```
 
 Full deployment docs: [docs/en/deploy.md](./docs/en/deploy.md).
+
+### Pre-deployment Checklist
+
+- Wrangler is logged in to the target Cloudflare account: `pnpm exec wrangler whoami`.
+- `wrangler.jsonc` uses `DB` as the D1 binding and contains the target D1 `database_id`.
+- `wrangler.jsonc` uses `ATTACHMENTS` as the R2 binding, and the target bucket exists.
+- Remote D1 migrations will be applied after the first deploy: `pnpm migrate:remote`.
+- Cloudflare Access policies are planned for human access, Service Tokens, and public share bypass routes.
+- The release gate has passed: `pnpm verify` and `pnpm deploy:dry-run`.
 
 ## Auth Boundary
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   <img src="./docs/assets/flaremo-mobile.png" alt="FlareMo mobile timeline" width="220">
 </p>
 
+截图展示的是当前已接上后端的时间线、编辑、筛选和移动端导航体验；未实现的 AI 回顾、语义搜索、微信输入等能力不会出现在界面里。
+
 ---
 
 ## 为什么做这个项目
@@ -126,6 +128,15 @@ pnpm deploy
 ```
 
 完整部署说明见 [docs/deploy.md](./docs/deploy.md)。英文部署说明见 [docs/en/deploy.md](./docs/en/deploy.md)。Deploy Button 的实测记录见 [docs/deploy-button-test.md](./docs/deploy-button-test.md)。
+
+**部署前检查清单**
+
+- Wrangler 已登录目标 Cloudflare 账号：`pnpm exec wrangler whoami`。
+- `wrangler.jsonc` 里的 D1 binding 是 `DB`，并已填入目标 D1 的 `database_id`。
+- `wrangler.jsonc` 里的 R2 binding 是 `ATTACHMENTS`，目标 bucket 已创建。
+- 远端 D1 migrations 会在首次部署后执行：`pnpm migrate:remote`。
+- Cloudflare Access application 已规划好人类访问、Service Token 和公开分享 bypass。
+- 发布前已跑：`pnpm verify` 和 `pnpm deploy:dry-run`。
 
 ---
 


### PR DESCRIPTION
## Summary

- Document the standard issue -> branch -> PR -> squash merge workflow in `AGENTS.md`.
- Add validation levels for docs, deploy/Wrangler/Access changes, API changes, UI changes, and real Cloudflare resource drills.
- Clarify README screenshots as current backend-backed UI only.
- Add Chinese and English pre-deployment checklists covering Wrangler login, D1/R2 bindings, migrations, Access planning, and release gate commands.

## Issues

Closes #9
Refs #1

## Validation

```bash
pnpm format:check
pnpm deploy:dry-run
```

Both passed.
