### PR TITLE
[codex] Release FlareMo v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 FlareMo 使用 SemVer。每个 release 都要写清楚升级影响、Cloudflare 资源变化和 Memos 兼容面变化。
 
+## v0.2.1
+
+开发工具链安全补丁。这个版本把已经合并到 `main` 的依赖修复纳入正式发布，不改变 v0.2.0 的生产功能、数据模型或 Cloudflare 资源。
+
+### 已修复
+
+- 使用 pnpm parent-scoped override，将 `drizzle-kit` 旧加载器链中的传递依赖从受影响的 `esbuild@0.18.20` 固定到已修复的 `0.25.12`。
+- 重新生成 lockfile，移除旧 esbuild 及其平台二进制包；GitHub Dependabot 未解决告警恢复为 0。
+- 放宽 Miniflare hook 和 Playwright 本地服务器/单测试超时，避免低性能或多任务开发机上的发布门禁被环境启动速度误判为回归。
+- root、Web、Worker、contracts、db、domain、memos、OpenAPI 和 MCP 版本统一到 `0.2.1`。
+
+### Cloudflare、数据库与兼容影响
+
+- 不新增 D1 migration，不改变 D1、R2、Access、Cron 或 Worker 运行逻辑。
+- 不改变 `/api/app/*`、Memos-compatible `/api/v1/*`、OpenAPI 或 MCP 的行为合同。
+- 生产部署可以直接覆盖 v0.2.0，无需调整资源绑定或执行数据库迁移。
+
+### 升级说明
+
+```bash
+pnpm install
+pnpm verify
+pnpm deploy:dry-run
+pnpm deploy
+```
+
 ## v0.2.0
 
 完整知识管理与数据可靠性版本。这个版本把搜索、附件、分享、关系、历史版本、导入导出和前端详情页一起补齐，并继续保持 Workers + D1 + R2 + Cloudflare Access 的原生架构。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flaremo/web",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/worker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -26,10 +26,10 @@ CF-Access-Client-Secret
 
 | 工具 / 路径 | 类型 | 测试版本 | 请求路径 | 是否需要 Access Service Token | 当前状态 | 证据 |
 | --- | --- | --- | --- | --- | --- | --- |
-| curl / HTTP script | 通用脚本 | FlareMo `0.2.0` | `/api/v1/memos`、`/api/v1/attachments`、`/api/v1/export`、`/api/v1/import` | 生产 Access 后面需要 | 可用 | `apps/worker/src/api.test.ts` 覆盖 memo CRUD、分页、搜索、附件、分享、revisions、export/import。 |
-| OpenAPI consumers | API schema 工具 | FlareMo `0.2.0` | `/openapi.json` | 生产 Access 后面需要 | 可用 | `apps/worker/src/memos-compatibility.test.ts` 断言公开路径写入 OpenAPI。 |
-| FlareMo MCP endpoint | MCP 客户端 | FlareMo `0.2.0` | `/api/v1/mcp` | 生产 Access 后面需要 | 可用 | `apps/worker/src/api.test.ts` 调用 `tools/list` 并断言 `create_memo`。 |
-| Public share reader | 浏览器 / curl | FlareMo `0.2.0` | `/share/*`、`/api/public/shares/*` | 不需要，需 Access bypass | 可用 | Worker 测试覆盖 token 隔离、撤销和附件读取。 |
+| curl / HTTP script | 通用脚本 | FlareMo `0.2.1` | `/api/v1/memos`、`/api/v1/attachments`、`/api/v1/export`、`/api/v1/import` | 生产 Access 后面需要 | 可用 | `apps/worker/src/api.test.ts` 覆盖 memo CRUD、分页、搜索、附件、分享、revisions、export/import。 |
+| OpenAPI consumers | API schema 工具 | FlareMo `0.2.1` | `/openapi.json` | 生产 Access 后面需要 | 可用 | `apps/worker/src/memos-compatibility.test.ts` 断言公开路径写入 OpenAPI。 |
+| FlareMo MCP endpoint | MCP 客户端 | FlareMo `0.2.1` | `/api/v1/mcp` | 生产 Access 后面需要 | 可用 | `apps/worker/src/api.test.ts` 调用 `tools/list` 并断言 `create_memo`。 |
+| Public share reader | 浏览器 / curl | FlareMo `0.2.1` | `/share/*`、`/api/public/shares/*` | 不需要，需 Access bypass | 可用 | Worker 测试覆盖 token 隔离、撤销和附件读取。 |
 
 ## 第三方客户端待测矩阵
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaremo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/contracts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/src/openapi.ts
+++ b/packages/contracts/src/openapi.ts
@@ -21,7 +21,7 @@ import {
   updateMemoSchema,
 } from "./memos";
 
-export const FLAREMO_API_VERSION = "0.2.0";
+export const FLAREMO_API_VERSION = "0.2.1";
 
 type JsonSchema = Record<string, unknown>;
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/db",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/domain",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/memos/package.json
+++ b/packages/memos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/memos",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 30_000,
+  timeout: 60_000,
   expect: {
     timeout: 10_000,
   },
@@ -22,7 +22,7 @@ export default defineConfig({
     command: "node ./scripts/e2e-server.mjs",
     gracefulShutdown: { signal: "SIGTERM", timeout: 5_000 },
     url: "http://127.0.0.1:18787",
-    timeout: 120_000,
+    timeout: 180_000,
     reuseExistingServer: false,
   },
 });

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -6,7 +6,7 @@ import { join } from "node:path";
 const version = process.argv[2];
 
 if (!version || !/^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
-  console.error("Usage: pnpm release v0.2.0");
+  console.error("Usage: pnpm release vX.Y.Z");
   process.exit(1);
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     fileParallelism: false,
-    hookTimeout: 30_000,
-    testTimeout: 30_000,
+    hookTimeout: 60_000,
+    testTimeout: 60_000,
     exclude: [
       "**/node_modules/**",
       "**/.git/**",


### PR DESCRIPTION
## 变更

- 将已经合并到 `main` 的 esbuild 传递依赖安全修复正式发布为 FlareMo `v0.2.1`。
- 同步 root、Web、Worker、contracts、db、domain、memos、OpenAPI 与 Memos 生态文档版本号。
- 增加 `v0.2.1` changelog，并把 release 脚本 usage 改为通用 SemVer 示例。
- 放宽 Miniflare 与 Playwright 启动/测试超时，提升低性能或多任务开发环境中的发布门禁稳定性；不改变生产运行逻辑。

## 影响范围

- [ ] Web UI
- [ ] `/api/app/*`
- [ ] Memos-compatible `/api/v1/*`
- [ ] D1 / Drizzle migration
- [ ] R2 / attachments
- [x] Cloudflare Access / deploy
- [x] Docs

## 验证

本地已通过：

```bash
pnpm verify
pnpm deploy:dry-run
pnpm backup:drill
git diff --check
```

测试结果：Worker 13/13、Memos adapter 3/3、Web 1/1、Playwright 10/10。

## 升级说明

不需要执行 D1 migration，不需要调整 Access policy，也不改变 D1、R2、Cron 或其他 Cloudflare 资源绑定。合并后可直接运行：

```bash
pnpm deploy
pnpm release v0.2.1
```

Closes #23