### PR TITLE
fix: polish activity labels and composer focus

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -404,7 +404,7 @@ function FlareMoApp() {
               />
             </div>
           </header>
-          <main className="mx-auto min-h-0 w-full max-w-[640px] flex-1 overflow-y-auto px-5 pb-8 lg:px-3">
+          <main className="mx-auto min-h-0 w-full max-w-[640px] flex-1 overflow-y-auto px-5 pt-1 pb-8 lg:px-3">
             <SearchBox
               className="mb-3 md:hidden motion-safe:animate-[flaremo-rise_160ms_ease-out_both]"
               query={query}

--- a/apps/web/src/components/flaremo-explorer.tsx
+++ b/apps/web/src/components/flaremo-explorer.tsx
@@ -104,7 +104,7 @@ export function FlareMoExplorer({
           className="mt-2 grid grid-cols-12 gap-1 px-1 text-xs text-muted-foreground"
         >
           {monthLabels.map((month) => (
-            <span className="truncate" key={month.date}>
+            <span className="whitespace-nowrap" key={month.date}>
               {month.label}
             </span>
           ))}

--- a/apps/web/src/components/memo-composer.tsx
+++ b/apps/web/src/components/memo-composer.tsx
@@ -57,7 +57,7 @@ export function MemoComposer({ isPending, onSubmit }: MemoComposerProps) {
 
   return (
     <form
-      className="group relative flex w-full flex-col rounded-xl border border-border bg-card shadow-sm motion-safe:animate-[flaremo-rise_180ms_ease-out_both] motion-safe:transition-[border-color,box-shadow,transform] motion-safe:duration-200 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/30 focus-within:motion-safe:-translate-y-px"
+      className="group relative flex w-full flex-col rounded-xl border border-border bg-card shadow-sm motion-safe:animate-[flaremo-rise_180ms_ease-out_both] motion-safe:transition-[border-color,box-shadow] motion-safe:duration-200 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/30"
       onSubmit={(event) => {
         event.preventDefault();
         void submit();

--- a/tests/e2e/memo-flow.spec.ts
+++ b/tests/e2e/memo-flow.spec.ts
@@ -257,6 +257,41 @@ test("shows the installed version and safe update fallback", async ({
   ).toHaveAttribute("href", /docs\/update\.md$/);
 });
 
+test("keeps activity labels and the focused composer fully visible", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const monthLabels = page.locator(
+    '[data-testid="activity-heatmap"] + div span',
+  );
+  const visibleLabels = monthLabels.filter({ hasText: /\S/ });
+  await expect(visibleLabels.first()).toBeVisible();
+  for (const label of await visibleLabels.all()) {
+    const style = await label.evaluate((element) => ({
+      overflow: getComputedStyle(element).overflow,
+      textOverflow: getComputedStyle(element).textOverflow,
+    }));
+    expect(style.overflow).toBe("visible");
+    expect(style.textOverflow).not.toBe("ellipsis");
+  }
+
+  const composer = page.getByRole("textbox", { name: /new note|新笔记/i });
+  const composerForm = page.locator("form").filter({ has: composer });
+  await page.waitForTimeout(250);
+  const topBeforeFocus = await composerForm.evaluate(
+    (element) => element.getBoundingClientRect().top,
+  );
+  await composer.focus();
+  const header = page.locator("header").first();
+  const geometry = await Promise.all([
+    composerForm.evaluate((element) => element.getBoundingClientRect().top),
+    header.evaluate((element) => element.getBoundingClientRect().bottom),
+  ]);
+  expect(geometry[0]).toBe(topBeforeFocus);
+  expect(geometry[0]).toBeGreaterThan(geometry[1]);
+});
+
 test("keeps the mobile navigation usable", async ({ page }) => {
   for (let index = 0; index < 18; index += 1) {
     const response = await page.request.post("/api/app/memos", {


### PR DESCRIPTION
## Summary

- keep activity heatmap month labels fully visible
- stop the focused composer from moving beneath the header
- reserve space for the complete focus ring
- add end-to-end regression coverage

## Validation

- `pnpm verify`
- `pnpm deploy:dry-run`
- desktop visual check in Chinese
- mobile navigation coverage

Closes #27