### PR TITLE
test: expand Memos memo compatibility fixtures

### DIFF
--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -121,6 +121,166 @@ describe("Memos-compatible API contract", () => {
     expect(updated.visibility).toBe("public");
   });
 
+  it("covers the complete memo CRUD contract and field mutations", async () => {
+    const created = await json(
+      await fetchApp("http://flaremo.test/api/v1/memos", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          content: "complete CRUD #alpha",
+          visibility: "private",
+          source: "compat-fixture",
+          payload: { tags: ["alpha"], client_id: "fixture-client" },
+        }),
+      }),
+      201,
+    );
+
+    const fetched = await json(
+      await fetchApp(`http://flaremo.test/api/v1/${created.name}`),
+    );
+    expect(fetched).toEqual(created);
+
+    const updated = await json(
+      await fetchApp(`http://flaremo.test/api/v1/${created.name}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          content: "updated CRUD #beta",
+          visibility: "protected",
+          status: "archived",
+          pinned: true,
+          payload: { tags: ["beta"], client_id: "updated-client" },
+        }),
+      }),
+    );
+    expect(updated).toMatchObject({
+      name: created.name,
+      id: created.id,
+      content: "updated CRUD #beta",
+      visibility: "protected",
+      state: "archived",
+      pinned: true,
+      creator: created.creator,
+      payload: { tags: ["beta"], client_id: "updated-client" },
+    });
+    expect(Date.parse(updated.update_time)).toBeGreaterThanOrEqual(
+      Date.parse(created.update_time),
+    );
+
+    const trashed = await json(
+      await fetchApp(`http://flaremo.test/api/v1/${created.name}`, {
+        method: "DELETE",
+      }),
+    );
+    expect(trashed).toMatchObject({
+      name: created.name,
+      state: "trashed",
+      pinned: true,
+    });
+
+    const hardDeleted = await json(
+      await fetchApp(`http://flaremo.test/api/v1/${created.name}?hard=true`, {
+        method: "DELETE",
+      }),
+    );
+    expect(hardDeleted).toEqual({ ok: true });
+    expect(
+      (await fetchApp(`http://flaremo.test/api/v1/${created.name}`)).status,
+    ).toBe(404);
+  });
+
+  it("combines state, visibility, pinned, tag, pagination, and ordering", async () => {
+    const normalAlpha = await createMemoWith({
+      content: "normal alpha #alpha",
+      visibility: "private",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    const publicAlpha = await createMemoWith({
+      content: "public alpha #alpha",
+      visibility: "public",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    const archivedBeta = await createMemoWith({
+      content: "archived beta #beta",
+      visibility: "protected",
+    });
+
+    await json(
+      await fetchApp(`http://flaremo.test/api/v1/${publicAlpha.name}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ pinned: true }),
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await json(
+      await fetchApp(`http://flaremo.test/api/v1/${archivedBeta.name}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: "archived",
+          content: "archived beta revised #beta",
+        }),
+      }),
+    );
+
+    const alpha = await listMemos("state=normal&tag=alpha");
+    expect(alpha.memos.map((memo: { name: string }) => memo.name)).toEqual([
+      publicAlpha.name,
+      normalAlpha.name,
+    ]);
+    expect(
+      alpha.memos.every(
+        (memo: { payload: { tags?: string[] }; state: string }) =>
+          memo.state === "normal" && memo.payload.tags?.includes("alpha"),
+      ),
+    ).toBe(true);
+
+    const archived = await listMemos("state=archived&tag=beta");
+    expect(archived.memos).toHaveLength(1);
+    expect(archived.memos[0]).toMatchObject({
+      name: archivedBeta.name,
+      state: "archived",
+      visibility: "protected",
+      pinned: false,
+    });
+
+    for (const orderBy of [
+      "created_at asc",
+      "created_at desc",
+      "updated_at asc",
+      "updated_at desc",
+    ]) {
+      const names: string[] = [];
+      let pageToken: string | undefined;
+      do {
+        const params = new URLSearchParams({
+          include_deleted: "true",
+          order_by: orderBy,
+          page_size: "1",
+        });
+        if (pageToken) params.set("page_token", pageToken);
+        const page = await listMemos(params.toString());
+        names.push(...page.memos.map((memo: { name: string }) => memo.name));
+        pageToken = page.next_page_token;
+      } while (pageToken);
+
+      expect(new Set(names)).toEqual(
+        new Set([normalAlpha.name, publicAlpha.name, archivedBeta.name]),
+      );
+      expect(names[0]).toBe(publicAlpha.name);
+    }
+
+    const firstPage = await listMemos(
+      "include_deleted=true&page_size=1&order_by=created_at%20asc",
+    );
+    const mismatchedToken = await fetchApp(
+      `http://flaremo.test/api/v1/memos?include_deleted=true&page_size=1&order_by=created_at%20desc&page_token=${encodeURIComponent(firstPage.next_page_token)}`,
+    );
+    expect(mismatchedToken.status).toBe(400);
+  });
+
   it("roundtrips attachments through export and import", async () => {
     const memo = await createMemo("exportable memo #bundle");
     const formData = new FormData();
@@ -296,6 +456,27 @@ async function createMemo(content: string) {
     }),
     201,
   );
+}
+
+async function createMemoWith(input: {
+  content: string;
+  visibility: "private" | "protected" | "public";
+}) {
+  return json(
+    await fetchApp("http://flaremo.test/api/v1/memos", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    }),
+    201,
+  );
+}
+
+async function listMemos(query: string) {
+  return json<{
+    memos: Array<Record<string, unknown>>;
+    next_page_token?: string;
+  }>(await fetchApp(`http://flaremo.test/api/v1/memos?${query}`));
 }
 
 async function json<T = Record<string, unknown>>(


### PR DESCRIPTION
## Summary

- cover complete memo create/get/list/patch/delete behavior
- assert mutations for content, visibility, state, pinned and payload fields
- cover combined state/tag filtering and all supported orderings
- verify pagination has no gaps or duplicates and rejects mismatched cursors

## Validation

- `pnpm verify`

Closes #4