### PR TITLE
test: verify full export import roundtrip

### DIFF
--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -10,61 +10,7 @@ let env: Env;
 
 describe("Memos-compatible API contract", () => {
   beforeEach(async () => {
-    mf = new Miniflare({
-      script: "export default { fetch() { return new Response('ok') } }",
-      modules: true,
-      compatibilityDate: "2026-07-10",
-      compatibilityFlags: ["nodejs_compat"],
-      d1Databases: {
-        DB: "flaremo-memos-compat-test",
-      },
-      r2Buckets: {
-        ATTACHMENTS: "flaremo-memos-compat-attachments-test",
-      },
-    });
-
-    const db = await mf.getD1Database("DB");
-    const r2 = await mf.getR2Bucket("ATTACHMENTS");
-    env = {
-      DB: db,
-      ATTACHMENTS: r2,
-      ASSETS: {
-        fetch: async () => new Response("asset", { status: 200 }),
-      } as Fetcher,
-      FLAREMO_SINGLE_USER_EMAIL: "owner@example.com",
-      FLAREMO_SINGLE_USER_NAME: "Owner",
-    };
-
-    await applyMigration(
-      db,
-      await readFile(
-        resolve(
-          import.meta.dirname,
-          "../../../migrations/0000_illegal_inhumans.sql",
-        ),
-        "utf8",
-      ),
-    );
-    await applyMigration(
-      db,
-      await readFile(
-        resolve(
-          import.meta.dirname,
-          "../../../migrations/0001_familiar_morph.sql",
-        ),
-        "utf8",
-      ),
-    );
-    await applyMigration(
-      db,
-      await readFile(
-        resolve(
-          import.meta.dirname,
-          "../../../migrations/0002_wooden_professor_monster.sql",
-        ),
-        "utf8",
-      ),
-    );
+    ({ mf, env } = await createTestRuntime("source"));
   });
 
   afterEach(async () => {
@@ -281,8 +227,9 @@ describe("Memos-compatible API contract", () => {
     expect(mismatchedToken.status).toBe(400);
   });
 
-  it("roundtrips attachments through export and import", async () => {
+  it("roundtrips memos, attachments, relations, and shares into an empty store", async () => {
     const memo = await createMemo("exportable memo #bundle");
+    const related = await createMemo("related memo #bundle");
     const formData = new FormData();
     formData.set("memo", memo.name);
     formData.set(
@@ -297,10 +244,31 @@ describe("Memos-compatible API contract", () => {
       }),
       201,
     );
+    await json(
+      await fetchApp(`http://flaremo.test/api/v1/${memo.name}/relations`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          relations: [{ related_memo: related.name, type: "reference" }],
+        }),
+      }),
+    );
+    const share = await json(
+      await fetchApp(`http://flaremo.test/api/v1/${memo.name}/shares`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      201,
+    );
 
     const bundle = await json(
       await fetchApp("http://flaremo.test/api/v1/export"),
     );
+    expect(bundle.memos).toHaveLength(2);
+    expect(bundle.attachments).toHaveLength(1);
+    expect(bundle.relations).toHaveLength(1);
+    expect(bundle.shares).toHaveLength(1);
     const exportedAttachment = bundle.attachments.find(
       (item: { name: string }) => item.name === attachment.name,
     );
@@ -311,6 +279,9 @@ describe("Memos-compatible API contract", () => {
       data_base64: "YnVuZGxlIGF0dGFjaG1lbnQ=",
     });
 
+    await mf.dispose();
+    ({ mf, env } = await createTestRuntime("restored"));
+
     const imported = await json(
       await fetchApp("http://flaremo.test/api/v1/import", {
         method: "POST",
@@ -318,10 +289,63 @@ describe("Memos-compatible API contract", () => {
         body: JSON.stringify(bundle),
       }),
     );
-    expect(imported.imported_memos).toBeGreaterThanOrEqual(1);
-    expect(imported.imported_attachments).toBeGreaterThanOrEqual(1);
+    expect(imported).toMatchObject({
+      imported_memos: 2,
+      imported_attachments: 1,
+      imported_relations: 1,
+      imported_shares: 1,
+      skipped_memos: 0,
+      overwritten_memos: 0,
+    });
 
-    const objectsAfterDuplicate = await env.ATTACHMENTS.list();
+    const restoredMemos = await listMemos("include_deleted=true&page_size=100");
+    expect(restoredMemos.memos.map((item) => item.content).sort()).toEqual([
+      "exportable memo #bundle",
+      "related memo #bundle",
+    ]);
+    const restoredMemo = restoredMemos.memos.find(
+      (item) => item.content === "exportable memo #bundle",
+    );
+    expect(restoredMemo).toBeTruthy();
+
+    const restoredAttachments = await json(
+      await fetchApp(
+        `http://flaremo.test/api/v1/${restoredMemo?.name}/attachments`,
+      ),
+    );
+    expect(restoredAttachments.attachments).toHaveLength(1);
+    const restoredBlob = await fetchApp(
+      `http://flaremo.test/api/v1/${restoredAttachments.attachments[0].name}/blob`,
+    );
+    expect(restoredBlob.status).toBe(200);
+    expect(await restoredBlob.text()).toBe("bundle attachment");
+
+    const relationContext = await json(
+      await fetchApp(
+        `http://flaremo.test/api/v1/${restoredMemo?.name}/relation-context`,
+      ),
+    );
+    expect(relationContext.relations).toHaveLength(1);
+    expect(relationContext.relations[0].memo.content).toBe(
+      "related memo #bundle",
+    );
+
+    const restoredShares = await json(
+      await fetchApp(`http://flaremo.test/api/v1/${restoredMemo?.name}/shares`),
+    );
+    expect(restoredShares.shares).toHaveLength(1);
+    expect(restoredShares.shares[0].token).not.toBe(share.token);
+    expect(restoredShares.shares[0].token).toEqual(expect.any(String));
+    const publicShare = await json(
+      await fetchApp(
+        `http://flaremo.test/api/public/shares/${restoredShares.shares[0].token}`,
+      ),
+    );
+    expect(publicShare.memo.content).toBe("exportable memo #bundle");
+    expect(publicShare.attachments).toHaveLength(1);
+
+    const objectsAfterImport = await env.ATTACHMENTS.list();
+    expect(objectsAfterImport.objects).toHaveLength(1);
     const skipped = await json(
       await fetchApp("http://flaremo.test/api/v1/import?conflict=skip", {
         method: "POST",
@@ -333,7 +357,7 @@ describe("Memos-compatible API contract", () => {
     expect(skipped.skipped_memos).toBeGreaterThanOrEqual(1);
     expect(skipped.imported_attachments).toBe(0);
     expect((await env.ATTACHMENTS.list()).objects).toHaveLength(
-      objectsAfterDuplicate.objects.length,
+      objectsAfterImport.objects.length,
     );
 
     const overwritten = await json(
@@ -346,7 +370,7 @@ describe("Memos-compatible API contract", () => {
     expect(overwritten.overwritten_memos).toBeGreaterThanOrEqual(1);
     expect(overwritten.imported_attachments).toBeGreaterThanOrEqual(1);
     expect((await env.ATTACHMENTS.list()).objects).toHaveLength(
-      objectsAfterDuplicate.objects.length,
+      objectsAfterImport.objects.length,
     );
   });
 
@@ -496,4 +520,41 @@ async function applyMigration(db: D1Database, sql: string) {
   for (const statement of statements) {
     await db.prepare(statement).run();
   }
+}
+
+async function createTestRuntime(suffix: string) {
+  const runtime = new Miniflare({
+    script: "export default { fetch() { return new Response('ok') } }",
+    modules: true,
+    compatibilityDate: "2026-07-10",
+    compatibilityFlags: ["nodejs_compat"],
+    d1Databases: { DB: `flaremo-memos-compat-${suffix}` },
+    r2Buckets: { ATTACHMENTS: `flaremo-memos-compat-attachments-${suffix}` },
+  });
+  const db = await runtime.getD1Database("DB");
+  for (const filename of [
+    "0000_illegal_inhumans.sql",
+    "0001_familiar_morph.sql",
+    "0002_wooden_professor_monster.sql",
+  ]) {
+    await applyMigration(
+      db,
+      await readFile(
+        resolve(import.meta.dirname, `../../../migrations/${filename}`),
+        "utf8",
+      ),
+    );
+  }
+  return {
+    mf: runtime,
+    env: {
+      DB: db,
+      ATTACHMENTS: await runtime.getR2Bucket("ATTACHMENTS"),
+      ASSETS: {
+        fetch: async () => new Response("asset", { status: 200 }),
+      } as Fetcher,
+      FLAREMO_SINGLE_USER_EMAIL: "owner@example.com",
+      FLAREMO_SINGLE_USER_NAME: "Owner",
+    } as Env,
+  };
 }


### PR DESCRIPTION
## Summary

- export a bundle containing memos, an R2 attachment, a relation and a public share
- restore the bundle into a completely empty D1/R2 runtime
- verify import counters, blob contents, relation context and regenerated share access
- retain skip and overwrite conflict coverage without duplicating R2 objects

## Validation

- `pnpm verify`

Closes #5