### PR TITLE
feat: add Agent and Telegram ingestion path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ FlareMo 的部署被刻意做得很轻。两种方式，挑一种就行。
 
 仓库里带了一份 [docs/agent-deploy.md](./docs/agent-deploy.md)，是写给 Codex / Claude Code / Cursor 这类 Agent 用的部署 runbook。把仓库交给一个能跑命令的 Agent，它就能按 runbook 创建 D1 / R2 资源、填写 `database_id`、跑迁移、部署。你不用记命令，Agent 自己按步骤来。
 
+需要让 Agent、Telegram 或其他 IM 渠道直接写入笔记时，参考 [Agent 与 IM 渠道写入](./docs/agent-ingestion.md)。仓库提供一个经过测试的独立 Telegram Worker 示例，不会把渠道密钥或平台逻辑塞进 FlareMo 主 Worker。
+
 **手动部署**（想自己一步步来的话）先创建资源：
 
 ```bash

--- a/apps/telegram-bot/package.json
+++ b/apps/telegram-bot/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@flaremo/telegram-bot-example",
+  "version": "0.3.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "check": "tsc -b --pretty false",
+    "test": "vitest run --config ../../vitest.config.ts --passWithNoTests"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "5.20260708.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.0"
+  }
+}

--- a/apps/telegram-bot/src/index.test.ts
+++ b/apps/telegram-bot/src/index.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleTelegramWebhook, type TelegramBotEnv } from "./index";
+
+const env: TelegramBotEnv = {
+  FLAREMO_ACCESS_CLIENT_ID: "access-id",
+  FLAREMO_ACCESS_CLIENT_SECRET: "access-secret",
+  FLAREMO_URL: "https://flaremo.example.workers.dev/",
+  TELEGRAM_ALLOWED_CHAT_IDS: "42, 84",
+  TELEGRAM_WEBHOOK_SECRET: "telegram-secret",
+};
+
+describe("Telegram ingestion example", () => {
+  it("turns an allowed Telegram message into a structured FlareMo memo", async () => {
+    const fetcher = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ name: "memos/created" }, { status: 201 }),
+    );
+    const response = await handleTelegramWebhook(
+      telegramRequest({
+        update_id: 1001,
+        message: {
+          message_id: 7,
+          chat: { id: 42 },
+          text: "A useful link https://example.com/article",
+          forward_origin: { type: "channel" },
+        },
+      }),
+      env,
+      fetcher,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, memo: "memos/created" });
+    expect(fetcher).toHaveBeenCalledOnce();
+    const [url, init] = fetcher.mock.calls[0] ?? [];
+    expect(url).toBe("https://flaremo.example.workers.dev/api/v1/memos");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("CF-Access-Client-Id")).toBe("access-id");
+    expect(headers.get("CF-Access-Client-Secret")).toBe("access-secret");
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      content: "A useful link https://example.com/article",
+      source: "telegram",
+      payload: {
+        tags: ["telegram"],
+        client_id: "telegram:1001",
+        telegram: { chat_id: "42", message_id: 7, forwarded: true },
+      },
+    });
+  });
+
+  it("rejects invalid secrets and chats before calling FlareMo", async () => {
+    const fetcher = vi.fn();
+    const invalidSecret = await handleTelegramWebhook(
+      telegramRequest({ update_id: 1 }, "wrong"),
+      env,
+      fetcher,
+    );
+    expect(invalidSecret.status).toBe(401);
+
+    const deniedChat = await handleTelegramWebhook(
+      telegramRequest({
+        update_id: 2,
+        message: { chat: { id: 99 }, message_id: 1, text: "denied" },
+      }),
+      env,
+      fetcher,
+    );
+    expect(deniedChat.status).toBe(403);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+function telegramRequest(body: unknown, secret = "telegram-secret") {
+  return new Request("https://bot.example.workers.dev/", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-telegram-bot-api-secret-token": secret,
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/telegram-bot/src/index.ts
+++ b/apps/telegram-bot/src/index.ts
@@ -1,0 +1,110 @@
+export type TelegramBotEnv = {
+  FLAREMO_ACCESS_CLIENT_ID: string;
+  FLAREMO_ACCESS_CLIENT_SECRET: string;
+  FLAREMO_URL: string;
+  TELEGRAM_ALLOWED_CHAT_IDS: string;
+  TELEGRAM_WEBHOOK_SECRET: string;
+};
+
+type TelegramMessage = {
+  caption?: string;
+  chat?: { id?: number };
+  forward_origin?: unknown;
+  message_id?: number;
+  text?: string;
+};
+
+type TelegramUpdate = {
+  channel_post?: TelegramMessage;
+  edited_channel_post?: TelegramMessage;
+  edited_message?: TelegramMessage;
+  message?: TelegramMessage;
+  update_id?: number;
+};
+
+export default {
+  fetch(request: Request, env: TelegramBotEnv): Promise<Response> {
+    return handleTelegramWebhook(request, env);
+  },
+};
+
+export async function handleTelegramWebhook(
+  request: Request,
+  env: TelegramBotEnv,
+  fetcher: typeof fetch = fetch,
+) {
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+  if (
+    request.headers.get("x-telegram-bot-api-secret-token") !==
+    env.TELEGRAM_WEBHOOK_SECRET
+  ) {
+    return json({ error: "Invalid Telegram webhook secret" }, 401);
+  }
+
+  const update = (await request.json()) as TelegramUpdate;
+  const message =
+    update.message ??
+    update.edited_message ??
+    update.channel_post ??
+    update.edited_channel_post;
+  const chatId = message?.chat?.id;
+  if (!message || typeof chatId !== "number") {
+    return json({ ok: true, skipped: "unsupported_update" });
+  }
+  const allowedChatIds = new Set(
+    env.TELEGRAM_ALLOWED_CHAT_IDS.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+  if (!allowedChatIds.has(String(chatId))) {
+    return json({ error: "Telegram chat is not allowed" }, 403);
+  }
+
+  const content = (message.text ?? message.caption ?? "").trim();
+  if (!content) {
+    return json({ ok: true, skipped: "empty_message" });
+  }
+
+  const response = await fetcher(
+    `${env.FLAREMO_URL.replace(/\/$/, "")}/api/v1/memos`,
+    {
+      method: "POST",
+      headers: {
+        "CF-Access-Client-Id": env.FLAREMO_ACCESS_CLIENT_ID,
+        "CF-Access-Client-Secret": env.FLAREMO_ACCESS_CLIENT_SECRET,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        content,
+        visibility: "private",
+        source: "telegram",
+        payload: {
+          tags: ["telegram"],
+          client_id: `telegram:${update.update_id ?? message.message_id ?? "unknown"}`,
+          telegram: {
+            chat_id: String(chatId),
+            message_id: message.message_id,
+            forwarded: message.forward_origin !== undefined,
+          },
+        },
+      }),
+    },
+  );
+  if (!response.ok) {
+    return json(
+      {
+        error: "FlareMo rejected the memo",
+        status: response.status,
+      },
+      502,
+    );
+  }
+  const memo = (await response.json()) as { name?: string };
+  return json({ ok: true, memo: memo.name ?? null });
+}
+
+function json(body: unknown, status = 200) {
+  return Response.json(body, { status });
+}

--- a/apps/telegram-bot/tsconfig.json
+++ b/apps/telegram-bot/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/apps/telegram-bot/wrangler.jsonc
+++ b/apps/telegram-bot/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "flaremo-telegram-bot",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-10",
+  "vars": {
+    "FLAREMO_URL": "https://your-flaremo.example.workers.dev",
+    "TELEGRAM_ALLOWED_CHAT_IDS": "123456789"
+  }
+}

--- a/docs/agent-ingestion.md
+++ b/docs/agent-ingestion.md
@@ -1,0 +1,68 @@
+# Agent 与 IM 渠道写入
+
+FlareMo 不需要新增应用内 Bearer token，也不要求 Agent 经过浏览器登录。外部 Agent、自动化脚本和 IM Bot 使用现有 `/api/v1/memos` 或 `/api/v1/mcp`，并由 Cloudflare Access Service Token 保护。
+
+## Agent 直接提交
+
+先按 [部署指南](./deploy.md#3-创建-service-token) 创建 Access Service Token，然后：
+
+```bash
+curl -X POST "$FLAREMO_URL/api/v1/memos" \
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "content": "文章摘要与原始链接 #inbox",
+    "visibility": "private",
+    "source": "agent",
+    "payload": {
+      "tags": ["inbox"],
+      "client_id": "agent:source-message-id"
+    }
+  }'
+```
+
+写入成功后，该 memo 会直接出现在 Web 时间线。`source` 用于标记渠道；`payload.client_id` 建议保存渠道侧消息 ID，方便排查重试。当前 API 不把它当成唯一键，调用方仍应避免重复投递。
+
+需要工具发现能力时，可以连接 `/api/v1/mcp`，使用 `create_memo`、`list_memos`、`get_memo` 和 `search_memos`。
+
+## Telegram Bot 示例
+
+仓库中的 `apps/telegram-bot` 是一个独立 Cloudflare Worker 示例。它会：
+
+1. 校验 Telegram `secret_token` header；
+2. 只接受 `TELEGRAM_ALLOWED_CHAT_IDS` 白名单中的会话；
+3. 将文本、图片 caption 或转发内容写入 FlareMo；
+4. 使用 Access Service Token 穿过生产 Access 边界；
+5. 为 memo 添加 `telegram` 标签和来源元数据。
+
+配置公开变量：
+
+```bash
+cd apps/telegram-bot
+pnpm exec wrangler deploy --config wrangler.jsonc
+```
+
+真实地址和 chat id 写入 `wrangler.jsonc`，敏感值必须通过 secret 写入，不得提交：
+
+```bash
+pnpm exec wrangler secret put TELEGRAM_WEBHOOK_SECRET --config wrangler.jsonc
+pnpm exec wrangler secret put FLAREMO_ACCESS_CLIENT_ID --config wrangler.jsonc
+pnpm exec wrangler secret put FLAREMO_ACCESS_CLIENT_SECRET --config wrangler.jsonc
+```
+
+注册 Telegram webhook：
+
+```bash
+curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+  --data-urlencode "url=https://flaremo-telegram-bot.<account>.workers.dev/" \
+  --data-urlencode "secret_token=$TELEGRAM_WEBHOOK_SECRET"
+```
+
+`TELEGRAM_BOT_TOKEN` 只用于调用 Telegram 的 `setWebhook`，不需要存进 Worker。Telegram 的 webhook secret 与 Cloudflare Access Service Token 是两层不同的边界，不能互相替代。
+
+## 飞书、Discord 和 Slack
+
+其他渠道沿用同一模式：渠道 webhook Worker 负责验签、白名单、格式转换和重试控制；FlareMo 只接收标准 memo DTO。不要把每个平台的签名协议和密钥塞进 FlareMo 主 Worker。
+
+AI 摘要、正文抓取和标签提取属于可选派生步骤。即使模型失败，也应该允许保存原始文本或链接；AI 返回内容不得绕过 Access，也不得成为 D1 之外的权威数据源。

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -29,6 +29,7 @@ CF-Access-Client-Secret
 | curl / HTTP script | 通用脚本 | FlareMo `0.3.0` | `/api/v1/memos`、`/api/v1/attachments`、`/api/v1/export`、`/api/v1/import` | 生产 Access 后面需要 | 可用 | `apps/worker/src/api.test.ts` 覆盖 memo CRUD、分页、搜索、附件、分享、revisions、export/import。 |
 | OpenAPI consumers | API schema 工具 | FlareMo `0.3.0` | `/openapi.json` | 生产 Access 后面需要 | 可用 | `apps/worker/src/memos-compatibility.test.ts` 断言公开路径写入 OpenAPI。 |
 | FlareMo MCP endpoint | MCP 客户端 | FlareMo `0.3.0` | `/api/v1/mcp` | 生产 Access 后面需要 | 可用 | `apps/worker/src/api.test.ts` 调用 `tools/list` 并断言 `create_memo`。 |
+| FlareMo Telegram Worker example | Telegram Bot | FlareMo `0.3.0` | Telegram webhook -> `/api/v1/memos` | 需要 | 可用 | `apps/telegram-bot/src/index.test.ts` 断言 webhook secret、chat 白名单、Access headers 和结构化 memo 请求。 |
 | Public share reader | 浏览器 / curl | FlareMo `0.3.0` | `/share/*`、`/api/public/shares/*` | 不需要，需 Access bypass | 可用 | Worker 测试覆盖 token 隔离、撤销和附件读取。 |
 
 ## 第三方客户端待测矩阵
@@ -40,7 +41,7 @@ CF-Access-Client-Secret
 | memos-desktop | 桌面客户端 | https://github.com/xudaolong/memos-desktop | 待测 | 未确认 | 未确认 | 未测 | 验证 API base URL、自定义 Access headers、memo CRUD。 |
 | memos_wmp | 微信小程序 | https://github.com/Rabithua/memos_wmp | 待测 | 未确认 | 未确认 | 未测 | 验证小程序网络层是否允许添加 Access headers。 |
 | memoflow | 移动端客户端 | https://github.com/hzc073/memoflow | 待测 | 未确认 | 未确认 | 未测 | 验证登录模型、API base URL、memo CRUD 和附件路径。 |
-| telegramMemoBot | Telegram bot | https://github.com/qazxcdswe123/telegramMemoBot | 待测 | 未确认 | 未确认 | 未测 | 验证 bot 是否依赖 Memos PAT，能否改用 Access headers。 |
+| telegramMemoBot | 第三方 Telegram bot | https://github.com/qazxcdswe123/telegramMemoBot | 待测 | 未确认 | 未确认 | 未测 | 仓库自带示例已经可用；这个第三方项目仍需单独验证是否依赖 Memos PAT。 |
 | Dynos | 移动端客户端 | https://github.com/HonKLam/Dynos | 待测 | 未确认 | 未确认 | 未测 | 验证离线同步和 FlareMo API 子集的重叠范围。 |
 | mcp-server-memos | MCP server | https://github.com/LeslieLeung/mcp-server-memos | 待测 | 未确认 | 未确认 | 未测 | FlareMo 自带 MCP endpoint；仍可验证外部 MCP server 是否能作为兼容客户端使用。 |
 | memos-raycast | Raycast extension | https://github.com/JakeLaoyu/memos-raycast | 待测 | 未确认 | 未确认 | 未测 | 验证 Raycast preferences 是否能配置 Access headers。 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,18 @@ importers:
         specifier: ^4.110.0
         version: 4.110.0(@cloudflare/workers-types@5.20260708.1)
 
+  apps/telegram-bot:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 5.20260708.1
+        version: 5.20260708.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
+
   apps/web:
     dependencies:
       '@flaremo/contracts':
@@ -499,11 +511,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}

--- a/tests/e2e/memo-flow.spec.ts
+++ b/tests/e2e/memo-flow.spec.ts
@@ -18,6 +18,29 @@ test("creates a memo and filters it by tag", async ({ page }) => {
   await expect(page.getByText(content)).toBeVisible();
 });
 
+test("shows a memo submitted by an external agent in the timeline", async ({
+  page,
+}) => {
+  const marker = `Agent ingestion ${Date.now()}`;
+  const response = await page.request.post("/api/v1/memos", {
+    data: {
+      content: `${marker} #telegram`,
+      source: "telegram",
+      payload: {
+        tags: ["telegram"],
+        client_id: `telegram:${Date.now()}`,
+      },
+    },
+  });
+  expect(response.status()).toBe(201);
+
+  await page.goto("/");
+  await expect(
+    page.getByText(`${marker} #telegram`, { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("#telegram", { exact: true })).toBeVisible();
+});
+
 test("keeps filters in the URL and opens a Markdown memo detail", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- document direct Agent writes through the existing Access-protected API and MCP endpoint
- add a standalone Cloudflare Worker example for Telegram webhooks
- validate Telegram webhook secrets, chat allowlists and Cloudflare Access Service Token headers
- preserve channel metadata and tags in structured memo payloads
- prove externally submitted memos appear in the Web timeline

## Validation

- `pnpm verify`
- `pnpm deploy:dry-run`

Closes #13