### PR TITLE
ops: add remote restore drill

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -123,6 +123,28 @@ pnpm backup:drill
 
 它会导出本地 D1 持久业务表（跳过可重建的 FTS5 虚拟索引）、生成按表依赖排序的数据恢复文件、用 migrations 在隔离目录创建恢复 schema、导入数据、验证业务表与重建后的 FTS 索引、检查远端 migration 状态、确认 `flaremo-attachments` R2 bucket 存在，并在 `backups/` 下生成演练报告。`backups/` 是本地输出目录，不提交到 Git。
 
+真实 Cloudflare 资源演练需要先创建临时 D1 和 R2，并明确传入目标，脚本不会猜测或覆盖生产绑定：
+
+```bash
+export FLAREMO_RESTORE_DATABASE="flaremo-restore-drill-YYYYMMDD"
+export FLAREMO_RESTORE_DATABASE_ID="<temporary-d1-id>"
+export FLAREMO_RESTORE_BUCKET="flaremo-restore-drill-YYYYMMDD"
+pnpm backup:drill:remote
+```
+
+远端演练会导出生产 D1 持久数据，对临时 D1 应用 migrations，按依赖顺序恢复数据，比较所有业务表和 FTS 计数，并按 D1 中仍有效的 `r2_key` 逐个复制、下载和校验 R2 对象。最后脚本生成指向临时 D1/R2 的 Wrangler 配置并执行 deploy dry-run，但不会部署，也不会修改 `wrangler.jsonc`。
+
+脚本故意不自动删除目标资源。检查 `backups/remote-restore-*/report.md` 后，使用明确名称删除：
+
+```bash
+pnpm exec wrangler d1 delete "$FLAREMO_RESTORE_DATABASE"
+pnpm exec wrangler r2 bucket delete "$FLAREMO_RESTORE_BUCKET"
+```
+
+如果生产 D1 当前没有有效附件记录，R2 复制计数为 0 是正确结果；演练仍会验证源 bucket、目标 bucket 和恢复后的 attachment 元数据计数。不要扫描或复制 D1 未引用的未知对象。
+
+最近一次真实演练：2026-07-23。生产 D1 的 1 个用户、2 条 memo 和对应 FTS 行被恢复到临时 D1，源/目标业务表计数完全一致；生产当时没有有效 attachment，因此 R2 引用对象复制数为 0。指向临时 D1/R2 的 deploy dry-run 成功，随后临时资源被显式删除。
+
 ## 线上排障
 
 查看 Worker 日志：

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "verify": "node ./scripts/preflight.mjs",
     "release": "node ./scripts/release.mjs",
     "backup:drill": "node ./scripts/backup-drill.mjs",
+    "backup:drill:remote": "node ./scripts/remote-restore-drill.mjs",
     "screenshots": "node ./scripts/capture-screenshots.mjs",
     "db:generate": "drizzle-kit generate",
     "migrate:local": "wrangler d1 migrations apply DB --local",

--- a/scripts/remote-restore-drill.mjs
+++ b/scripts/remote-restore-drill.mjs
@@ -1,0 +1,298 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+const targetDatabase = requiredEnv("FLAREMO_RESTORE_DATABASE");
+const targetDatabaseId = requiredEnv("FLAREMO_RESTORE_DATABASE_ID");
+const targetBucket = requiredEnv("FLAREMO_RESTORE_BUCKET");
+const sourceDatabase = process.env.FLAREMO_SOURCE_DATABASE || "DB";
+const sourceBucket = process.env.FLAREMO_SOURCE_BUCKET || "flaremo-attachments";
+const stamp = new Date().toISOString().replaceAll(/[:.]/g, "-");
+const outputDir = resolve("backups", `remote-restore-${stamp}`);
+const dataDump = join(outputDir, "d1-data.sql");
+const orderedDump = join(outputDir, "d1-data-ordered.sql");
+const generatedConfig = join(outputDir, "wrangler.restore-drill.jsonc");
+const reportPath = join(outputDir, "report.md");
+const objectDir = join(outputDir, "r2");
+const backupTables = [
+  "users",
+  "memos",
+  "attachments",
+  "memo_relations",
+  "settings",
+  "shares",
+  "memo_tags",
+  "memo_revisions",
+];
+const tableArgs = backupTables.flatMap((table) => ["--table", table]);
+const steps = [];
+
+mkdirSync(objectDir, { recursive: true });
+const sourceConfig = readFileSync(resolve("wrangler.jsonc"), "utf8");
+const productionDatabaseId = sourceConfig.match(
+  /"database_id"\s*:\s*"([^"]+)"/,
+)?.[1];
+if (!productionDatabaseId) throw new Error("Could not locate production D1 id");
+const restoreConfig = sourceConfig
+  .replace(productionDatabaseId, targetDatabaseId)
+  .replace('"database_name": "flaremo"', `"database_name": "${targetDatabase}"`)
+  .replace(
+    `"bucket_name": "${sourceBucket}"`,
+    `"bucket_name": "${targetBucket}"`,
+  )
+  .replace(
+    '"./apps/worker/src/index.ts"',
+    `"${resolve("apps/worker/src/index.ts")}"`,
+  )
+  .replace('"./apps/web/dist"', `"${resolve("apps/web/dist")}"`)
+  .replace('"./migrations"', `"${resolve("migrations")}"`);
+writeFileSync(generatedConfig, restoreConfig);
+
+step("verify source and target resources", () => {
+  const databases = runWrangler(["d1", "list"], { capture: true }).stdout;
+  const buckets = runWrangler(["r2", "bucket", "list"], {
+    capture: true,
+  }).stdout;
+  for (const resource of [sourceBucket, targetBucket]) {
+    if (!buckets.includes(resource))
+      throw new Error(`Missing R2 bucket ${resource}`);
+  }
+  if (!databases.includes(targetDatabase)) {
+    throw new Error(`Missing D1 database ${targetDatabase}`);
+  }
+});
+
+step("export production D1 business data", () =>
+  runWrangler([
+    "d1",
+    "export",
+    sourceDatabase,
+    "--remote",
+    ...tableArgs,
+    "--no-schema",
+    "--output",
+    dataDump,
+    "--skip-confirmation",
+  ]),
+);
+
+step("order D1 inserts by foreign-key dependency", () => {
+  const dump = readFileSync(dataDump, "utf8");
+  const lines = ["PRAGMA defer_foreign_keys=TRUE;"];
+  for (const table of backupTables) {
+    lines.push(
+      ...dump
+        .split("\n")
+        .filter(
+          (line) =>
+            line.startsWith(`INSERT INTO "${table}" `) ||
+            line.startsWith(`INSERT INTO \`${table}\` `),
+        ),
+    );
+  }
+  writeFileSync(orderedDump, `${lines.join("\n")}\n`);
+});
+
+step("apply migrations to target D1", () =>
+  runWrangler([
+    "d1",
+    "migrations",
+    "apply",
+    "DB",
+    "--remote",
+    "--config",
+    generatedConfig,
+  ]),
+);
+
+step("restore production D1 data to target", () =>
+  runWrangler([
+    "d1",
+    "execute",
+    "DB",
+    "--remote",
+    "--file",
+    orderedDump,
+    "--yes",
+    "--config",
+    generatedConfig,
+  ]),
+);
+
+const sourceCounts = queryCounts(sourceDatabase);
+const targetCounts = queryCounts("DB", generatedConfig);
+step("compare source and target D1 counts", () => {
+  for (const key of Object.keys(sourceCounts)) {
+    if (sourceCounts[key] !== targetCounts[key]) {
+      throw new Error(
+        `${key} mismatch: source=${sourceCounts[key]} target=${targetCounts[key]}`,
+      );
+    }
+  }
+  if (targetCounts.memos !== targetCounts.fts) {
+    throw new Error("Target FTS index was not rebuilt from restored memos");
+  }
+});
+
+const attachments = query(
+  sourceDatabase,
+  "SELECT id, r2_key, content_type FROM attachments WHERE deleted_at IS NULL AND state = 'ready' ORDER BY id;",
+);
+step("restore and verify referenced R2 objects", () => {
+  for (const attachment of attachments) {
+    const key = String(attachment.r2_key);
+    const objectFile = join(objectDir, safeFilename(key));
+    const verifyFile = `${objectFile}.verify`;
+    runWrangler([
+      "r2",
+      "object",
+      "get",
+      `${sourceBucket}/${key}`,
+      "--remote",
+      "--file",
+      objectFile,
+    ]);
+    runWrangler([
+      "r2",
+      "object",
+      "put",
+      `${targetBucket}/${key}`,
+      "--remote",
+      "--file",
+      objectFile,
+      "--content-type",
+      String(attachment.content_type || "application/octet-stream"),
+    ]);
+    runWrangler([
+      "r2",
+      "object",
+      "get",
+      `${targetBucket}/${key}`,
+      "--remote",
+      "--file",
+      verifyFile,
+    ]);
+    if (sha256(objectFile) !== sha256(verifyFile)) {
+      throw new Error(`R2 checksum mismatch for ${key}`);
+    }
+  }
+});
+
+step("verify restored bindings with deploy dry-run", () => {
+  run("pnpm", ["--filter", "@flaremo/web", "build"]);
+  runWrangler(["deploy", "--config", generatedConfig, "--dry-run"]);
+});
+
+writeFileSync(
+  reportPath,
+  [
+    "# FlareMo Remote Restore Drill",
+    "",
+    `- Created at: ${new Date().toISOString()}`,
+    `- Source D1: ${sourceDatabase}`,
+    `- Target D1: ${targetDatabase} (${targetDatabaseId})`,
+    `- Source R2: ${sourceBucket}`,
+    `- Target R2: ${targetBucket}`,
+    `- Referenced R2 objects restored: ${attachments.length}`,
+    `- Source counts: ${JSON.stringify(sourceCounts)}`,
+    `- Target counts: ${JSON.stringify(targetCounts)}`,
+    "",
+    "## Steps",
+    "",
+    ...steps.map((item) => `- ${item}`),
+    "",
+    "The target resources are intentionally not deleted by the script. Inspect the report, then delete the temporary D1 database and R2 bucket explicitly.",
+    "",
+  ].join("\n"),
+);
+
+console.log(`Remote restore drill report: ${reportPath}`);
+
+function queryCounts(database, config) {
+  const rows = query(
+    database,
+    [
+      "SELECT",
+      "(SELECT COUNT(*) FROM users) AS users,",
+      "(SELECT COUNT(*) FROM memos) AS memos,",
+      "(SELECT COUNT(*) FROM memo_tags) AS tags,",
+      "(SELECT COUNT(*) FROM memo_revisions) AS revisions,",
+      "(SELECT COUNT(*) FROM attachments WHERE deleted_at IS NULL) AS attachments,",
+      "(SELECT COUNT(*) FROM memo_relations) AS relations,",
+      "(SELECT COUNT(*) FROM shares) AS shares,",
+      "(SELECT COUNT(*) FROM memos_fts) AS fts;",
+    ].join(" "),
+    config,
+  );
+  return rows[0] ?? {};
+}
+
+function query(database, command, config) {
+  const configArgs = config ? ["--config", config] : [];
+  const result = runWrangler(
+    [
+      "d1",
+      "execute",
+      database,
+      "--remote",
+      "--command",
+      command,
+      "--json",
+      ...configArgs,
+    ],
+    { capture: true },
+  );
+  const payload = JSON.parse(result.stdout);
+  if (!payload[0]?.success) throw new Error(`D1 query failed for ${database}`);
+  return payload[0].results ?? [];
+}
+
+function step(name, fn) {
+  try {
+    fn();
+    steps.push(`${name}: ok`);
+  } catch (error) {
+    steps.push(`${name}: failed`);
+    writeFileSync(
+      reportPath,
+      `# FlareMo Remote Restore Drill\n\nFailed step: ${name}\n\n${String(error)}\n`,
+    );
+    throw error;
+  }
+}
+
+function runWrangler(args, options) {
+  return run("pnpm", ["exec", "wrangler", ...args], options);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    shell: process.platform === "win32",
+  });
+  if (result.status !== 0) {
+    if (options.capture) {
+      process.stdout.write(result.stdout);
+      process.stderr.write(result.stderr);
+    }
+    throw new Error(`${command} ${args.join(" ")} failed (${result.status})`);
+  }
+  return result;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function safeFilename(key) {
+  return `${basename(key).replaceAll(/[^A-Za-z0-9_.-]/g, "_")}-${createHash("sha256").update(key).digest("hex").slice(0, 12)}`;
+}
+
+function sha256(path) {
+  if (!existsSync(path)) throw new Error(`Missing object file ${path}`);
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}


### PR DESCRIPTION
## Summary
- add a guarded remote D1/R2 restore drill command
- compare restored business and FTS counts and verify referenced R2 objects by checksum
- validate temporary bindings with a Wrangler deploy dry-run and document the real drill result

## Validation
- `pnpm verify`
- `pnpm deploy:dry-run`
- `FLAREMO_RESTORE_DATABASE=flaremo-restore-drill-20260723 FLAREMO_RESTORE_DATABASE_ID=9d2528b3-faf6-4f2d-8ca3-f7a07c358346 FLAREMO_RESTORE_BUCKET=flaremo-restore-drill-20260723 pnpm backup:drill:remote`
- confirmed the temporary D1 database and R2 bucket were deleted after the drill

Closes #3