### PR TITLE
ops(auth): configure production canonical origin

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -37,7 +37,7 @@
     "FLAREMO_SINGLE_USER_NAME": "FlareMo Owner",
     // Canonical origin used by Better Auth for callback and cookie checks.
     // Set this to the deployed origin; keep secrets out of this file.
-    "FLAREMO_PUBLIC_URL": "",
+    "FLAREMO_PUBLIC_URL": "https://flaremo.chendahuang.com",
     // Optional comma-separated additional browser origins for trusted clients.
     "FLAREMO_TRUSTED_ORIGINS": ""
   }


### PR DESCRIPTION
Sets FLAREMO_PUBLIC_URL to the confirmed canonical HTTPS origin https://flaremo.chendahuang.com. This is the origin Better Auth uses for callback and trusted Origin checks. It does not contain secrets, does not disable Cloudflare Access, and does not enable public signup.

Validation:
- pnpm format:check
- pnpm deploy:dry-run

Closes #42