### PR TITLE
feat(memos): add current REST and streamable MCP compatibility

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -27,7 +27,7 @@ The screenshots show the current backend-backed timeline, editor, filtering, and
 - Memo detail pages with relations, backlinks, and revision restore.
 - Revocable public share links.
 - Memos-style import and export with conflict strategies.
-- Memos-compatible `/api/v1` memo, attachment, relation, share, import/export, OpenAPI, and MCP subset.
+- A current Memos-style camelCase/protobuf-JSON `/api/v1` subset for memos, attachments, relations, shares, auth facade, and PAT resources; the legacy snake_case wire remains available through an explicit header.
 - Chinese and English interface.
 
 FlareMo keeps the UI honest: if a feature is not wired to the backend, it does not appear as a fake entry point.
@@ -139,7 +139,7 @@ CF-Access-Client-Id
 CF-Access-Client-Secret
 ```
 
-`memos_pat_` is a FlareMo-native application credential, not proof of complete Memos Server auth parity. The Origin security direction follows the [Memos 0.30 MCP browser-origin model](https://usememos.com/docs/integrations/mcp), but the current `/api/v1/mcp` endpoint is FlareMo's existing JSON-RPC subset. The current Memos `/mcp` Streamable HTTP endpoint, auth facade, and current camelCase wire adapter remain tracked in [Issue #40](https://github.com/realchendahuang/FlareMo/issues/40).
+`memos_pat_` is a FlareMo-native application credential, not proof of complete Memos Server auth parity. The Origin security direction follows the [Memos 0.30 MCP browser-origin model](https://usememos.com/docs/integrations/mcp). The default `/api/v1` wire is now the implemented current camelCase/protobuf-JSON subset, while `X-FlareMo-Wire: legacy` keeps the older snake_case surface available. The Better Auth-backed auth facade and PAT resources are implemented as a subset; `accessToken` is an opaque session-backed token, not a native Memos JWT. The root `/mcp` endpoint is a stateless Streamable HTTP MCP tool subset. Complete Memos Server parity, full CEL/Connect/SSE, comments/reactions/shortcuts, and real smoke tests for third-party clients remain unfinished; see the [compatibility matrix](./docs/memos-compatibility.md) and [ecosystem matrix](./docs/memos-ecosystem.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ FlareMo 想回答另一个问题：**能不能只用一个免费 Cloudflare 账�
 - 记录详情、引用关系、反向链接和历史版本恢复。
 - 可撤销的公开分享链接。
 - 支持冲突策略的 Memos 数据导入导出。
-- Memos 兼容的 `/api/v1` memo / attachment / share 子集。
+- Memos current camelCase / protobuf-JSON 风格的 `/api/v1` memo、attachment、relation、share、auth facade 和 PAT 资源子集；旧 snake_case wire 通过显式 header 保留。
 - OpenAPI 输出。
 - MCP 端点。
 - 中英文界面。
@@ -177,7 +177,7 @@ curl "$FLAREMO_URL/api/v1/memos" \
   -H "Authorization: Bearer $FLAREMO_MEMOS_PAT"
 ```
 
-当前 MCP 访问示例（FlareMo 既有 JSON-RPC 子集）：
+旧版 MCP 访问示例（保留给已有 FlareMo 客户端）：
 
 ```bash
 curl "$FLAREMO_URL/api/v1/mcp" \
@@ -188,13 +188,23 @@ curl "$FLAREMO_URL/api/v1/mcp" \
   --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
+current Memos 风格的无状态 Streamable HTTP MCP 使用根路径 `/mcp`，支持 `initialize`、`notifications/initialized`、`tools/list` 和 `tools/call`。它仍是 FlareMo 的工具子集，不承诺 SSE、有状态 MCP session 或完整 Memos MCP method surface：
+
+```bash
+curl "$FLAREMO_URL/mcp" \
+  -H "content-type: application/json" \
+  -H "accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}'
+```
+
 建议只 bypass 的公开路径（如果启用 Access）：
 
 - `/share/*`
 - `/api/public/shares/*`
 - `/assets/*`
 
-分享内容仍由 FlareMo 的 share token、过期时间和 memo 状态校验。Origin 安全方向参考 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp)，但不代表协议已经兼容。Memos current `/mcp` Streamable HTTP、current camelCase wire adapter、Memos auth facade 和完整 server parity 仍由 [Issue #40](https://github.com/realchendahuang/FlareMo/issues/40) 追踪；#39 的 PAT/Bearer 基础不代表已经完成这些兼容面。
+分享内容仍由 FlareMo 的 share token、过期时间和 memo 状态校验。当前 `/api/v1` 默认是 current camelCase wire，`/mcp` 是无状态 Streamable HTTP MCP 子集；旧 snake_case API 可通过 `X-FlareMo-Wire: legacy` 或 legacy vendor `Accept` 显式选择。Better Auth-backed auth facade 和 PAT 资源已提供，但 `accessToken` 是 opaque session-backed token，不是 Memos 原生 JWT。完整 Memos Server parity、完整 CEL/Connect/SSE、comments/reactions/shortcuts，以及第三方客户端逐一实测仍未完成，详见 [兼容矩阵](./docs/memos-compatibility.md) 和 [生态实测矩阵](./docs/memos-ecosystem.md)。
 
 ---
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -347,6 +347,13 @@ async function apiRequest<T>(
   if (!(init.body instanceof FormData) && !headers.has("content-type")) {
     headers.set("content-type", "application/json");
   }
+  // The web app still consumes FlareMo's original snake_case DTOs for its
+  // /api/v1 attachment, share, relation, import, and export helpers. Keep
+  // that internal client explicit while external /api/v1 callers default to
+  // the current Memos-compatible wire.
+  if (path.startsWith("/api/v1/") && !headers.has("x-flaremo-wire")) {
+    headers.set("x-flaremo-wire", "legacy");
+  }
 
   const response = await fetch(path, {
     ...init,

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -122,7 +122,9 @@ describe("FlareMo Worker API", () => {
     expect(byTag.memos).toHaveLength(1);
 
     const openapi = await json(
-      await fetchApp("http://flaremo.test/openapi.json"),
+      await fetchApp("http://flaremo.test/openapi.json", {
+        headers: { "x-flaremo-wire": "legacy" },
+      }),
     );
     expect(openapi.paths["/api/v1/memos"]).toBeTruthy();
 
@@ -771,6 +773,9 @@ function fetchApp(
     (path.startsWith("/api/app/") || path.startsWith("/api/v1/"))
   ) {
     headers.set("cookie", sessionCookie);
+    if (path.startsWith("/api/v1/") && !headers.has("x-flaremo-wire")) {
+      headers.set("x-flaremo-wire", "legacy");
+    }
     if (!headers.has("origin") && isUnsafeMethod(init?.method)) {
       headers.set("origin", "http://flaremo.test");
     }

--- a/apps/worker/src/auth.test.ts
+++ b/apps/worker/src/auth.test.ts
@@ -359,7 +359,14 @@ async function signIn(username: string, password: string) {
 }
 
 function fetchRaw(path: string, init?: RequestInit) {
-  return app.fetch(new Request(`http://flaremo.test${path}`, init), env);
+  const headers = new Headers(init?.headers);
+  if (path.startsWith("/api/v1/") && !headers.has("x-flaremo-wire")) {
+    headers.set("x-flaremo-wire", "legacy");
+  }
+  return app.fetch(
+    new Request(`http://flaremo.test${path}`, { ...init, headers }),
+    env,
+  );
 }
 
 function authenticatedJsonHeaders(cookie: string): HeadersInit {

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -66,7 +66,30 @@ export type FlareMoAuth = {
     }) => Promise<MemosApiKey & { key: string }>;
     getSession: (input: {
       headers: Headers;
-    }) => Promise<{ user: { id: string } } | null>;
+      query?: {
+        disableCookieCache?: boolean;
+        disableRefresh?: boolean;
+      };
+    }) => Promise<{
+      session: { token: string; expiresAt: Date };
+      user: { id: string };
+    } | null>;
+    signInUsername: (input: {
+      body: {
+        username: string;
+        password: string;
+        rememberMe?: boolean;
+      };
+      headers: Headers;
+      asResponse: false;
+      returnHeaders: true;
+    }) => Promise<{
+      headers: Headers;
+      response: {
+        token: string;
+        user: { id: string };
+      };
+    }>;
     signUpEmail: (input: {
       body: {
         email: string;

--- a/apps/worker/src/context.ts
+++ b/apps/worker/src/context.ts
@@ -1,6 +1,7 @@
 import { createDb } from "@flaremo/db";
 import {
   ForbiddenError,
+  getFlaremoUserByAuthSessionToken,
   getFlaremoUserByAuthUserId,
   UnauthorizedError,
 } from "@flaremo/domain";
@@ -26,7 +27,17 @@ export async function getRequestContext(c: Context<HonoBindings>) {
   if (token) {
     assertTrustedBearerOrigin(c);
     if (!token.startsWith("memos_pat_")) {
-      throw new UnauthorizedError();
+      const session = await getFlaremoUserByAuthSessionToken(db, token);
+      if (!session) throw new UnauthorizedError();
+
+      return {
+        db,
+        user: session.user,
+        authUserId: session.authUserId,
+        credential: "session" as const,
+        bearerSession: true,
+        session: session.session,
+      };
     }
     const verification = await auth.api.verifyApiKey({
       body: {
@@ -49,6 +60,8 @@ export async function getRequestContext(c: Context<HonoBindings>) {
       user,
       authUserId: verification.key.referenceId,
       credential: "pat" as const,
+      bearerSession: false,
+      session: null,
     };
   }
 
@@ -83,6 +96,8 @@ export async function getBrowserRequestContext(
     user,
     authUserId: session.user.id,
     credential: "session" as const,
+    bearerSession: false,
+    session: null,
   };
 }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,4 +1,7 @@
-import { createOpenApiDocument } from "@flaremo/contracts";
+import {
+  createCurrentOpenApiDocument,
+  createOpenApiDocument,
+} from "@flaremo/contracts";
 import { createDb } from "@flaremo/db";
 import {
   finalizeAttachmentCleanup,
@@ -12,8 +15,12 @@ import type { FlareMoEnv } from "./env";
 import { accountApi } from "./routes/account-api";
 import { appApi } from "./routes/app-api";
 import { authApi } from "./routes/auth-api";
-import { mcpApi } from "./routes/mcp";
+import { mcpApi, mcpStreamableApi } from "./routes/mcp";
 import { memosApi } from "./routes/memos-api";
+import {
+  isLegacyWireRequest,
+  memosCurrentApi,
+} from "./routes/memos-current-api";
 import { publicApi } from "./routes/public-api";
 
 const app = new Hono<HonoBindings>();
@@ -43,18 +50,46 @@ app.use(
   }),
 );
 
+app.use(
+  "/mcp",
+  cors({
+    origin: (origin, c) => {
+      try {
+        return getTrustedOrigins(c.env).includes(origin) ? origin : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    credentials: false,
+    allowHeaders: ["content-type", "authorization", "accept", "mcp-session-id"],
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+  }),
+);
+
 app.route("/api/auth/flaremo", authApi);
 app.all("/api/auth/*", (c) => createFlareMoAuth(c.env).handler(c.req.raw));
 app.route("/api/app/account", accountApi);
 app.route("/api/app", appApi);
 app.route("/api/public", publicApi);
+app.route("/mcp", mcpStreamableApi);
+app.route("/api/v1", memosCurrentApi);
 app.route("/api/v1", memosApi);
 app.route("/api/v1", mcpApi);
 
-app.get("/openapi.json", (c) => c.json(createOpenApiDocument()));
+app.get("/openapi.json", (c) =>
+  c.json(
+    isLegacyWireRequest(c)
+      ? createOpenApiDocument()
+      : createCurrentOpenApiDocument(),
+  ),
+);
 app.get("/api/v1/openapi.json", async (c) => {
   await getRequestContext(c);
-  return c.json(createOpenApiDocument());
+  return c.json(
+    isLegacyWireRequest(c)
+      ? createOpenApiDocument()
+      : createCurrentOpenApiDocument(),
+  );
 });
 
 app.notFound((c) => {

--- a/apps/worker/src/mcp-streamable.test.ts
+++ b/apps/worker/src/mcp-streamable.test.ts
@@ -1,0 +1,159 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockedRequestContext = vi.hoisted(() => ({
+  getRequestContext: vi.fn(),
+}));
+
+vi.mock("./context", () => ({
+  getRequestContext: mockedRequestContext.getRequestContext,
+}));
+
+import { mcpApi, mcpStreamableApi } from "./routes/mcp";
+
+const app = new Hono();
+app.route("/mcp", mcpStreamableApi);
+
+const legacyApp = new Hono();
+legacyApp.route("/api/v1", mcpApi);
+
+describe("stateless Streamable HTTP MCP", () => {
+  beforeEach(() => {
+    mockedRequestContext.getRequestContext.mockResolvedValue({});
+  });
+
+  it.each([
+    "2025-03-26",
+    "2024-11-05",
+  ])("negotiates protocol version %s with JSON responses", async (protocolVersion) => {
+    const response = await post(app, "/mcp", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion,
+        capabilities: { tools: {} },
+        serverInfo: { name: "memos" },
+      },
+    });
+    expect(response.headers.has("mcp-session-id")).toBe(false);
+  });
+
+  it("acknowledges initialized notifications without creating a session", async () => {
+    const response = await post(app, "/mcp", {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    expect(response.status).toBe(202);
+    expect(await response.text()).toBe("");
+  });
+
+  it("lists only the current Memos-prefixed tools", async () => {
+    const response = await post(app, "/mcp", {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    const body = (await response.json()) as {
+      result: { tools: Array<{ name: string; inputSchema: unknown }> };
+    };
+
+    expect(body.result.tools.map((tool) => tool.name)).toEqual([
+      "memo_list_memos",
+      "memo_create_memo",
+      "memo_get_memo",
+      "memo_update_memo",
+      "memo_delete_memo",
+      "memo_list_memo_attachments",
+      "memo_set_memo_attachments",
+      "memo_list_memo_relations",
+      "memo_set_memo_relations",
+      "attachment_list_attachments",
+      "attachment_get_attachment",
+      "attachment_delete_attachment",
+      "auth_get_current_user",
+    ]);
+    expect(body.result.tools.every((tool) => tool.inputSchema)).toBe(true);
+  });
+
+  it("returns tool failures as an MCP result instead of a JSON-RPC error", async () => {
+    const response = await post(app, "/mcp", {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "not_a_real_tool",
+        arguments: {},
+      },
+    });
+    const body = (await response.json()) as {
+      error?: unknown;
+      result: {
+        isError: boolean;
+        content: Array<{ type: string; text: string }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]).toMatchObject({ type: "text" });
+    expect(body.result.content[0].text).toContain("Unknown tool");
+  });
+
+  it("keeps malformed tools/call params in the tool result envelope", async () => {
+    const response = await post(app, "/mcp", {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: null,
+    });
+    const body = (await response.json()) as {
+      error?: unknown;
+      result: { isError: boolean; content: Array<{ text: string }> };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toContain("params");
+  });
+
+  it("keeps the legacy JSON-RPC tool names on /api/v1/mcp", async () => {
+    const response = await post(legacyApp, "/api/v1/mcp", {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/list",
+    });
+    const body = (await response.json()) as {
+      result: { tools: Array<{ name: string }> };
+    };
+
+    expect(body.result.tools.map((tool) => tool.name)).toEqual([
+      "list_memos",
+      "create_memo",
+      "get_memo",
+      "search_memos",
+    ]);
+  });
+});
+
+async function post(target: Hono, path: string, payload: unknown) {
+  return target.request(`http://flaremo.test${path}`, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer memos_pat_test",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}

--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -385,7 +385,9 @@ describe("Memos-compatible API contract", () => {
 
   it("documents every supported public path in OpenAPI", async () => {
     const openapi = await json(
-      await fetchApp("http://flaremo.test/openapi.json"),
+      await fetchApp("http://flaremo.test/openapi.json", {
+        headers: { "x-flaremo-wire": "legacy" },
+      }),
     );
     expect(openapi.info.version).toBe(FLAREMO_API_VERSION);
     const paths = Object.keys(openapi.paths);
@@ -474,6 +476,368 @@ describe("Memos-compatible API contract", () => {
     );
     expect(privateBlob.status).toBe(404);
   });
+
+  it("serves the current camelCase REST facade on top of Better Auth", async () => {
+    const currentOpenapi = await fetchCurrent(
+      "http://flaremo.test/openapi.json",
+      undefined,
+      { authenticated: false },
+    );
+    expect(currentOpenapi.status).toBe(200);
+    expect(await currentOpenapi.json()).toMatchObject({
+      info: { title: "FlareMo current Memos-compatible API" },
+      paths: {
+        "/api/v1/auth/signin": expect.any(Object),
+        "/api/v1/memos": expect.any(Object),
+        "/mcp": expect.any(Object),
+      },
+    });
+
+    const legacyOpenapi = await fetchApp(
+      "http://flaremo.test/openapi.json",
+      { headers: { "x-flaremo-wire": "legacy" } },
+      { authenticated: false },
+    );
+    expect(legacyOpenapi.status).toBe(200);
+    expect(await legacyOpenapi.json()).toMatchObject({
+      info: { title: "FlareMo Memos-compatible API" },
+    });
+
+    const signInResponse = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/signin",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          passwordCredentials: {
+            username: "owner",
+            password: TEST_PASSWORD,
+          },
+        }),
+      },
+      { authenticated: false },
+    );
+    expect(signInResponse.status).toBe(200);
+    expect(signInResponse.headers.get("set-cookie")).toBeTruthy();
+    const signIn = (await signInResponse.json()) as {
+      accessToken: string;
+      user: { name: string; role: string; username: string };
+      accessTokenExpiresAt: string;
+    };
+    expect(signIn).toMatchObject({
+      accessToken: expect.any(String),
+      accessTokenExpiresAt: expect.any(String),
+      user: {
+        name: "users/owner",
+        role: "ADMIN",
+        username: "owner",
+      },
+    });
+
+    const bearer = { authorization: `Bearer ${signIn.accessToken}` };
+    const meResponse = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/me",
+      { headers: bearer },
+    );
+    expect(meResponse.status).toBe(200);
+    expect(await meResponse.json()).toMatchObject({
+      user: { name: "users/owner", username: "owner" },
+    });
+
+    const createdResponse = await fetchCurrent(
+      "http://flaremo.test/api/v1/memos",
+      {
+        method: "POST",
+        headers: { ...bearer, "content-type": "application/json" },
+        body: JSON.stringify({
+          memo: {
+            content: "current wire memo #current",
+            visibility: "PUBLIC",
+            property: { hasLink: true },
+            location: { placeholder: "Shanghai" },
+          },
+        }),
+      },
+    );
+    expect(createdResponse.status).toBe(200);
+    const created = (await createdResponse.json()) as {
+      name: string;
+      state: string;
+      visibility: string;
+      createTime: string;
+      updateTime: string;
+      tags: string[];
+      property: { hasLink: boolean };
+      location: { placeholder: string };
+    };
+    expect(created).toMatchObject({
+      name: expect.stringMatching(/^memos\//),
+      state: "NORMAL",
+      visibility: "PUBLIC",
+      createTime: expect.any(String),
+      updateTime: expect.any(String),
+      tags: ["current"],
+      property: { hasLink: true },
+      location: { placeholder: "Shanghai" },
+    });
+    expect(created).not.toHaveProperty("create_time");
+
+    const listed = (await (
+      await fetchCurrent(
+        "http://flaremo.test/api/v1/memos?pageSize=1&orderBy=create_time%20desc",
+        { headers: bearer },
+      )
+    ).json()) as { memos: Array<Record<string, unknown>> };
+    expect(listed.memos[0]).toMatchObject({
+      name: created.name,
+      visibility: "PUBLIC",
+    });
+
+    const updated = await fetchCurrent(
+      `http://flaremo.test/api/v1/${created.name}?updateMask=pinned,visibility`,
+      {
+        method: "PATCH",
+        headers: { ...bearer, "content-type": "application/json" },
+        body: JSON.stringify({
+          memo: {
+            name: created.name,
+            pinned: true,
+            visibility: "PROTECTED",
+          },
+        }),
+      },
+    );
+    expect(updated.status).toBe(200);
+    expect(await updated.json()).toMatchObject({
+      name: created.name,
+      pinned: true,
+      visibility: "PROTECTED",
+    });
+
+    const secondResponse = await fetchCurrent(
+      "http://flaremo.test/api/v1/memos",
+      {
+        method: "POST",
+        headers: { ...bearer, "content-type": "application/json" },
+        body: JSON.stringify({ memo: { content: "related memo" } }),
+      },
+    );
+    const second = (await secondResponse.json()) as { name: string };
+
+    const attachmentResponse = await fetchCurrent(
+      "http://flaremo.test/api/v1/attachments",
+      {
+        method: "POST",
+        headers: { ...bearer, "content-type": "application/json" },
+        body: JSON.stringify({
+          attachment: {
+            filename: "current.txt",
+            content: "aGVsbG8=",
+            type: "text/plain",
+            memo: created.name,
+          },
+        }),
+      },
+    );
+    expect(attachmentResponse.status).toBe(200);
+    const attachment = (await attachmentResponse.json()) as {
+      name: string;
+      size: string;
+      memo: string;
+      type: string;
+    };
+    expect(attachment).toMatchObject({
+      name: expect.stringMatching(/^attachments\//),
+      size: "5",
+      memo: created.name,
+      type: "text/plain",
+    });
+
+    const attachmentList = await fetchCurrent(
+      "http://flaremo.test/api/v1/attachments?pageSize=10",
+      { headers: bearer },
+    );
+    expect(attachmentList.status).toBe(200);
+    expect(await attachmentList.json()).toMatchObject({
+      attachments: [expect.objectContaining({ name: attachment.name })],
+    });
+
+    const relationResponse = await fetchCurrent(
+      `http://flaremo.test/api/v1/${created.name}/relations`,
+      {
+        method: "PATCH",
+        headers: { ...bearer, "content-type": "application/json" },
+        body: JSON.stringify({
+          name: created.name,
+          relations: [
+            {
+              memo: { name: created.name },
+              relatedMemo: { name: second.name },
+              type: "REFERENCE",
+            },
+          ],
+        }),
+      },
+    );
+    expect(relationResponse.status).toBe(200);
+    const relations = await fetchCurrent(
+      `http://flaremo.test/api/v1/${created.name}/relations`,
+      { headers: bearer },
+    );
+    expect(await relations.json()).toMatchObject({
+      relations: [
+        {
+          memo: { name: created.name },
+          relatedMemo: { name: second.name },
+          type: "REFERENCE",
+        },
+      ],
+    });
+
+    const shareResponse = await fetchCurrent(
+      `http://flaremo.test/api/v1/${created.name}/shares`,
+      {
+        method: "POST",
+        headers: { ...bearer, "content-type": "application/json" },
+        body: JSON.stringify({
+          parent: created.name,
+          memoShare: {},
+        }),
+      },
+    );
+    expect(shareResponse.status).toBe(200);
+    const share = (await shareResponse.json()) as { name: string };
+    const shareToken = share.name.split("/").at(-1);
+    expect(shareToken).toBeTruthy();
+    const publicShare = await fetchCurrent(
+      `http://flaremo.test/api/v1/shares/${shareToken}`,
+      undefined,
+      { authenticated: false },
+    );
+    expect(publicShare.status).toBe(200);
+    expect(await publicShare.json()).toMatchObject({ name: created.name });
+
+    const patCreate = await fetchCurrent(
+      "http://flaremo.test/api/v1/users/owner/personalAccessTokens",
+      {
+        method: "POST",
+        headers: { ...bearer, "content-type": "application/json" },
+        body: JSON.stringify({
+          description: "current test token",
+          expiresInDays: 0,
+        }),
+      },
+    );
+    expect(patCreate.status).toBe(200);
+    const pat = (await patCreate.json()) as {
+      personalAccessToken: { name: string };
+      token: string;
+    };
+    expect(pat.personalAccessToken.name).toContain(
+      "users/owner/personalAccessTokens/",
+    );
+    expect(pat.token).toMatch(/^memos_pat_/);
+
+    const patList = await fetchCurrent(
+      "http://flaremo.test/api/v1/users/owner/personalAccessTokens",
+      { headers: { authorization: `Bearer ${pat.token}` } },
+    );
+    expect(patList.status).toBe(200);
+    expect(await patList.json()).toMatchObject({
+      personalAccessTokens: [
+        expect.objectContaining({
+          description: "current test token",
+        }),
+      ],
+    });
+
+    const mcpHeaders = {
+      authorization: `Bearer ${pat.token}`,
+      "content-type": "application/json",
+      accept: "application/json",
+    };
+    const initialize = await fetchCurrent("http://flaremo.test/mcp", {
+      method: "POST",
+      headers: mcpHeaders,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-03-26" },
+      }),
+    });
+    expect(initialize.status).toBe(200);
+    expect(await initialize.json()).toMatchObject({
+      result: {
+        protocolVersion: "2025-03-26",
+        capabilities: { tools: {} },
+      },
+    });
+
+    const tools = await fetchCurrent("http://flaremo.test/mcp", {
+      method: "POST",
+      headers: mcpHeaders,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+      }),
+    });
+    const toolNames = (
+      (await tools.json()) as {
+        result: { tools: Array<{ name: string }> };
+      }
+    ).result.tools.map((tool) => tool.name);
+    expect(toolNames).toContain("memo_list_memos");
+    expect(toolNames).not.toContain("list_memos");
+
+    const toolCall = await fetchCurrent("http://flaremo.test/mcp", {
+      method: "POST",
+      headers: mcpHeaders,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "memo_create_memo",
+          arguments: { body: { content: "created through current MCP" } },
+        },
+      }),
+    });
+    expect(toolCall.status).toBe(200);
+    expect(await toolCall.json()).toMatchObject({
+      result: {
+        structuredContent: {
+          content: "created through current MCP",
+        },
+      },
+    });
+
+    const toolError = await fetchCurrent("http://flaremo.test/mcp", {
+      method: "POST",
+      headers: mcpHeaders,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "not_a_real_tool", arguments: {} },
+      }),
+    });
+    expect(await toolError.json()).toMatchObject({
+      result: {
+        isError: true,
+        content: [{ type: "text" }],
+      },
+    });
+
+    const unauthenticated = await fetchCurrent(
+      "http://flaremo.test/api/v1/memos",
+      undefined,
+      { authenticated: false },
+    );
+    expect(unauthenticated.status).toBe(401);
+    expect(await unauthenticated.json()).toMatchObject({ code: 16 });
+  });
 });
 
 function fetchApp(
@@ -488,11 +852,24 @@ function fetchApp(
     (path.startsWith("/api/app/") || path.startsWith("/api/v1/"))
   ) {
     headers.set("cookie", sessionCookie);
+    if (path.startsWith("/api/v1/") && !headers.has("x-flaremo-wire")) {
+      headers.set("x-flaremo-wire", "legacy");
+    }
     if (!headers.has("origin") && isUnsafeMethod(init?.method)) {
       headers.set("origin", "http://flaremo.test");
     }
   }
   return app.fetch(new Request(input, { ...init, headers }), env);
+}
+
+function fetchCurrent(
+  input: string,
+  init?: RequestInit,
+  options: { authenticated?: boolean } = {},
+) {
+  const headers = new Headers(init?.headers);
+  headers.set("x-flaremo-wire", "current");
+  return fetchApp(input, { ...init, headers }, options);
 }
 
 function isUnsafeMethod(method: string | undefined) {

--- a/apps/worker/src/routes/mcp.ts
+++ b/apps/worker/src/routes/mcp.ts
@@ -5,19 +5,40 @@ import {
   type ListMemosQuery,
   listMemosQuerySchema,
 } from "@flaremo/contracts";
-import { createMemo, getMemoById, listMemos } from "@flaremo/domain";
+import type { AttachmentRow, MemoRow, UserRow } from "@flaremo/db";
 import {
+  bindMemoAttachments,
+  createMemo,
+  finalizeAttachmentDelete,
+  getAttachmentById,
+  getMemoById,
+  hardDeleteMemo,
+  listAttachments,
+  listMemoAttachments,
+  listMemoRelations,
+  listMemos,
+  markAttachmentDeleting,
+  markMemoAttachmentsDeleting,
+  moveMemoToTrash,
+  replaceMemoRelations,
+  updateMemo,
+} from "@flaremo/domain";
+import {
+  currentAttachmentToDto,
+  currentMemoToDto,
+  currentUserToDto,
   memosToListResponse,
   memoToDto,
   parseMemosResourceName,
 } from "@flaremo/memos";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { z } from "zod";
 import {
   getRequestContext,
   type HonoBindings,
   type ReturnTypeOfRequestContext,
 } from "../context";
+import type { FlareMoEnv } from "../env";
 import { jsonError } from "../http";
 
 export const mcpApi = new Hono<HonoBindings>();
@@ -216,4 +237,1145 @@ async function callTool(
       message: `Unknown tool: ${name}`,
     },
   };
+}
+
+/*
+ * This app is intentionally separate from mcpApi above. The latter is the
+ * original /api/v1/mcp JSON-RPC subset and is kept for existing clients. The
+ * app below is the stateless Streamable HTTP surface that the main Worker can
+ * mount at /mcp without changing the legacy route.
+ */
+export const mcpStreamableApi = new Hono<HonoBindings>();
+
+type JsonObject = Record<string, unknown>;
+type McpId = string | number | null;
+
+const STREAMABLE_PROTOCOL_VERSIONS = ["2025-03-26", "2024-11-05"] as const;
+const DEFAULT_STREAMABLE_PROTOCOL_VERSION = STREAMABLE_PROTOCOL_VERSIONS[0];
+
+const streamableMcpRequestSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.string(), z.number(), z.null()]).optional(),
+  method: z.string().min(1),
+  params: z.record(z.string(), z.unknown()).optional(),
+});
+
+const streamableToolCallSchema = z.object({
+  name: z.string().trim().min(1),
+  arguments: z.record(z.string(), z.unknown()).optional(),
+});
+
+const currentMemoBodySchema = {
+  type: "object",
+  required: ["content"],
+  properties: {
+    name: { type: "string", description: "Memos resource name." },
+    content: { type: "string" },
+    visibility: {
+      type: "string",
+      enum: [
+        "VISIBILITY_UNSPECIFIED",
+        "PRIVATE",
+        "PROTECTED",
+        "PUBLIC",
+        "private",
+        "protected",
+        "public",
+      ],
+    },
+    state: {
+      type: "string",
+      enum: [
+        "STATE_UNSPECIFIED",
+        "NORMAL",
+        "ARCHIVED",
+        "TRASHED",
+        "DELETED",
+        "normal",
+        "archived",
+        "trashed",
+        "deleted",
+      ],
+    },
+    pinned: { type: "boolean" },
+    tags: { type: "array", items: { type: "string" } },
+    payload: { type: "object", additionalProperties: true },
+    property: { type: "object", additionalProperties: true },
+    location: {},
+    source: { type: "string" },
+  },
+  additionalProperties: true,
+};
+
+const resourceNameInput = {
+  type: "string",
+  minLength: 1,
+  description: "A Memos resource name, for example memos/<id>.",
+};
+
+const streamableTools: Array<{
+  name: string;
+  description: string;
+  inputSchema: JsonObject;
+}> = [
+  {
+    name: "memo_list_memos",
+    description:
+      "List the current user's memos. Supports the FlareMo-backed subset of the current Memos list contract.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pageSize: { type: "integer", minimum: 1, maximum: 100 },
+        pageToken: { type: "string" },
+        state: {
+          type: "string",
+          enum: [
+            "STATE_UNSPECIFIED",
+            "NORMAL",
+            "ARCHIVED",
+            "TRASHED",
+            "DELETED",
+          ],
+        },
+        orderBy: {
+          type: "string",
+          description:
+            "One supported ordering such as create_time desc or update_time asc.",
+        },
+        filter: {
+          type: "string",
+          description:
+            "Not implemented by FlareMo; use q for full-text and scope filters.",
+        },
+        showDeleted: { type: "boolean" },
+        q: { type: "string" },
+        tag: { type: "string" },
+        page_size: { type: "integer", minimum: 1, maximum: 100 },
+        page_token: { type: "string" },
+        include_deleted: { type: "boolean" },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_create_memo",
+    description:
+      "Create a memo for the authenticated FlareMo user. The current Memos body shape is supported.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        body: currentMemoBodySchema,
+        content: { type: "string" },
+        visibility: currentMemoBodySchema.properties.visibility,
+        state: currentMemoBodySchema.properties.state,
+        pinned: { type: "boolean" },
+        tags: { type: "array", items: { type: "string" } },
+        payload: { type: "object", additionalProperties: true },
+        property: { type: "object", additionalProperties: true },
+        location: {},
+        source: { type: "string" },
+        memoId: { type: "string" },
+        memo_id: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_get_memo",
+    description: "Get one memo by its Memos resource name.",
+    inputSchema: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: resourceNameInput,
+        memo: resourceNameInput,
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_update_memo",
+    description:
+      "Update a memo using the current Memos body/updateMask shape or the equivalent direct fields.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        memo: resourceNameInput,
+        name: resourceNameInput,
+        body: currentMemoBodySchema,
+        updateMask: { type: "string" },
+        update_mask: { type: "string" },
+        content: { type: "string" },
+        visibility: currentMemoBodySchema.properties.visibility,
+        state: currentMemoBodySchema.properties.state,
+        pinned: { type: "boolean" },
+        tags: { type: "array", items: { type: "string" } },
+        payload: { type: "object", additionalProperties: true },
+        property: { type: "object", additionalProperties: true },
+        location: {},
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_delete_memo",
+    description:
+      "Move a memo to trash, or permanently delete it when force is explicitly true.",
+    inputSchema: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: resourceNameInput,
+        memo: resourceNameInput,
+        force: { type: "boolean" },
+        hard: { type: "boolean" },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_list_memo_attachments",
+    description: "List ready attachments bound to one memo.",
+    inputSchema: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: resourceNameInput,
+        memo: resourceNameInput,
+        pageSize: { type: "integer", minimum: 1, maximum: 100 },
+        pageToken: { type: "string" },
+        page_size: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_set_memo_attachments",
+    description:
+      "Replace the attachment set of a memo. Each attachment is a resource name or an object containing name.",
+    inputSchema: {
+      type: "object",
+      required: ["name", "attachments"],
+      properties: {
+        name: resourceNameInput,
+        memo: resourceNameInput,
+        attachments: {
+          type: "array",
+          maxItems: 100,
+          items: {
+            anyOf: [
+              { type: "string" },
+              {
+                type: "object",
+                required: ["name"],
+                properties: { name: resourceNameInput },
+                additionalProperties: true,
+              },
+            ],
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_list_memo_relations",
+    description: "List relations owned by one memo.",
+    inputSchema: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: resourceNameInput,
+        memo: resourceNameInput,
+        pageSize: { type: "integer", minimum: 1, maximum: 100 },
+        pageToken: { type: "string" },
+        page_size: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "memo_set_memo_relations",
+    description:
+      "Replace all relations owned by one memo using current Memos relation objects or the FlareMo-compatible shape.",
+    inputSchema: {
+      type: "object",
+      required: ["name", "relations"],
+      properties: {
+        name: resourceNameInput,
+        memo: resourceNameInput,
+        relations: {
+          type: "array",
+          maxItems: 100,
+          items: {
+            type: "object",
+            required: ["relatedMemo", "type"],
+            properties: {
+              memo: { type: "object", additionalProperties: true },
+              relatedMemo: { type: "object", additionalProperties: true },
+              related_memo: resourceNameInput,
+              type: {
+                type: "string",
+                enum: [
+                  "TYPE_UNSPECIFIED",
+                  "REFERENCE",
+                  "COMMENT",
+                  "reference",
+                  "comment",
+                ],
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "attachment_list_attachments",
+    description:
+      "List ready attachments. FlareMo supports pageSize and optional memo filtering; unsupported current-Memos filters return a tool error.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pageSize: { type: "integer", minimum: 1, maximum: 100 },
+        pageToken: { type: "string" },
+        filter: { type: "string" },
+        orderBy: { type: "string" },
+        memo: resourceNameInput,
+        page_size: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "attachment_get_attachment",
+    description: "Get one attachment by its Memos resource name.",
+    inputSchema: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: { type: "string", minLength: 1 },
+        attachment: { type: "string", minLength: 1 },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "attachment_delete_attachment",
+    description: "Delete one attachment and its R2 object.",
+    inputSchema: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: { type: "string", minLength: 1 },
+        attachment: { type: "string", minLength: 1 },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "auth_get_current_user",
+    description:
+      "Return the authenticated FlareMo user's current-user resource.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+];
+
+mcpStreamableApi.post("/", async (c) => {
+  let context: ReturnTypeOfRequestContext;
+  try {
+    // This deliberately delegates PAT parsing, Origin checks, and session
+    // authentication to the same boundary as every other private route.
+    context = await getRequestContext(c);
+  } catch (error) {
+    return jsonError(c, error);
+  }
+
+  let rawRequest: unknown;
+  try {
+    rawRequest = await c.req.json();
+  } catch {
+    return streamableProtocolError(c, null, -32700, "Parse error");
+  }
+
+  const parsedRequest = streamableMcpRequestSchema.safeParse(rawRequest);
+  if (!parsedRequest.success) {
+    const method = isJsonObject(rawRequest) ? rawRequest.method : undefined;
+    if (method === "tools/call") {
+      return streamableToolError(
+        c,
+        requestIdOf(rawRequest),
+        formatZodError(parsedRequest.error),
+      );
+    }
+    return streamableProtocolError(
+      c,
+      requestIdOf(rawRequest),
+      -32600,
+      formatZodError(parsedRequest.error),
+    );
+  }
+
+  const request = parsedRequest.data;
+  const id = request.id ?? null;
+
+  if (request.method === "initialize") {
+    return c.json({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: negotiatedProtocolVersion(request.params),
+        capabilities: {
+          tools: {},
+        },
+        serverInfo: {
+          name: "memos",
+          version: FLAREMO_API_VERSION,
+        },
+      },
+    });
+  }
+
+  if (request.method === "notifications/initialized") {
+    // MCP notifications have no JSON-RPC response. 202 is the stateless
+    // Streamable HTTP acknowledgement and avoids manufacturing a response id.
+    if (request.id === undefined) return new Response(null, { status: 202 });
+    return c.json({ jsonrpc: "2.0", id, result: {} });
+  }
+
+  if (request.method === "tools/list") {
+    return c.json({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        tools: streamableTools.map((tool) => ({
+          ...tool,
+          outputSchema: {
+            type: "object",
+            additionalProperties: true,
+          },
+        })),
+      },
+    });
+  }
+
+  if (request.method === "tools/call") {
+    const parsedCall = streamableToolCallSchema.safeParse(request.params);
+    if (!parsedCall.success) {
+      return streamableToolError(c, id, formatZodError(parsedCall.error));
+    }
+
+    try {
+      const value = await callStreamableTool(
+        context,
+        c.env,
+        parsedCall.data.name,
+        parsedCall.data.arguments ?? {},
+      );
+      return streamableToolSuccess(c, id, value);
+    } catch (error) {
+      return streamableToolError(c, id, readableError(error));
+    }
+  }
+
+  return streamableProtocolError(c, id, -32601, "Method not found");
+});
+
+function streamableProtocolError(
+  c: Context<HonoBindings>,
+  id: McpId,
+  code: number,
+  message: string,
+) {
+  return c.json({
+    jsonrpc: "2.0",
+    id,
+    error: { code, message },
+  });
+}
+
+function streamableToolSuccess(
+  c: Context<HonoBindings>,
+  id: McpId,
+  value: unknown,
+) {
+  const structuredContent = normalizeStructuredContent(value);
+  return c.json({
+    jsonrpc: "2.0",
+    id,
+    result: {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(structuredContent),
+        },
+      ],
+      structuredContent,
+    },
+  });
+}
+
+function streamableToolError(
+  c: Context<HonoBindings>,
+  id: McpId,
+  message: string,
+) {
+  return c.json({
+    jsonrpc: "2.0",
+    id,
+    result: {
+      isError: true,
+      content: [{ type: "text", text: message }],
+      structuredContent: { error: { message } },
+    },
+  });
+}
+
+function requestIdOf(value: unknown): McpId {
+  if (!isJsonObject(value)) return null;
+  const id = value.id;
+  return typeof id === "string" || typeof id === "number" || id === null
+    ? id
+    : null;
+}
+
+function negotiatedProtocolVersion(params: JsonObject | undefined) {
+  const requested = params?.protocolVersion;
+  return typeof requested === "string" &&
+    STREAMABLE_PROTOCOL_VERSIONS.includes(
+      requested as (typeof STREAMABLE_PROTOCOL_VERSIONS)[number],
+    )
+    ? requested
+    : DEFAULT_STREAMABLE_PROTOCOL_VERSION;
+}
+
+function normalizeStructuredContent(value: unknown): JsonObject {
+  if (value === null || value === undefined) return { ok: true };
+  if (isJsonObject(value)) return value;
+  if (Array.isArray(value)) return { result: value };
+  return { result: value };
+}
+
+async function callStreamableTool(
+  context: ReturnTypeOfRequestContext,
+  env: FlareMoEnv,
+  name: string,
+  args: JsonObject,
+) {
+  switch (name) {
+    case "memo_list_memos":
+      return streamableListMemos(context, args);
+    case "memo_create_memo":
+      return streamableCreateMemo(context, args);
+    case "memo_get_memo":
+      return streamableGetMemo(context, args);
+    case "memo_update_memo":
+      return streamableUpdateMemo(context, args);
+    case "memo_delete_memo":
+      return streamableDeleteMemo(context, env, args);
+    case "memo_list_memo_attachments":
+      return streamableListMemoAttachments(context, args);
+    case "memo_set_memo_attachments":
+      return streamableSetMemoAttachments(context, args);
+    case "memo_list_memo_relations":
+      return streamableListMemoRelations(context, args);
+    case "memo_set_memo_relations":
+      return streamableSetMemoRelations(context, args);
+    case "attachment_list_attachments":
+      return streamableListAttachments(context, args);
+    case "attachment_get_attachment":
+      return streamableGetAttachment(context, args);
+    case "attachment_delete_attachment":
+      return streamableDeleteAttachment(context, env, args);
+    case "auth_get_current_user":
+      return { user: currentUserToMemosDto(context) };
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+async function streamableListMemos(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const filter = optionalString(args, "filter");
+  if (filter) {
+    throw new Error(
+      "The current Memos filter expression is not supported; use q for FlareMo search filters.",
+    );
+  }
+
+  const query = listMemosQuerySchema.parse({
+    page_size: pageSize(args),
+    page_token: optionalString(args, "pageToken", "page_token"),
+    order_by: normalizeOrderBy(
+      optionalString(args, "orderBy") ?? "created_at desc",
+    ),
+    state: normalizeMemoState(optionalString(args, "state")),
+    q: optionalString(args, "q"),
+    tag: optionalString(args, "tag"),
+    include_deleted:
+      optionalBoolean(args, "showDeleted") ??
+      optionalBoolean(args, "include_deleted") ??
+      false,
+  }) as ListMemosQuery;
+  const result = await listMemos(context.db, context.user, query);
+  return {
+    memos: result.memos.map((memo) =>
+      memoToCurrentMemosDto(memo, context.user),
+    ),
+    ...(result.nextPageToken ? { nextPageToken: result.nextPageToken } : {}),
+  };
+}
+
+async function streamableCreateMemo(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const input = mergedMemoInput(args);
+  assertUnsupportedMemoCollections(input);
+  const suppliedMemoId = firstDefined(input.memoId, input.memo_id);
+  if (suppliedMemoId !== undefined) {
+    throw new Error(
+      "memoId is not supported by FlareMo's domain service; omit it so the server can generate the resource name.",
+    );
+  }
+
+  const createInput = createMemoSchema.parse({
+    content: requiredString(input.content, "content"),
+    visibility: normalizeVisibility(input.visibility),
+    payload: memoPayloadFromInput(input),
+    source: optionalString(input, "source") ?? "mcp",
+  }) as CreateMemoInput;
+  let memo = await createMemo(context.db, context.user, createInput);
+
+  const followUp: Parameters<typeof updateMemo>[3] = {};
+  const state = normalizeMemoState(
+    firstDefined(input.state, input.status) as string | undefined,
+  );
+  if (state !== undefined) followUp.status = state;
+  const pinned = optionalBoolean(input, "pinned");
+  if (pinned !== undefined) followUp.pinned = pinned;
+  if (Object.keys(followUp).length > 0) {
+    memo = await updateMemo(context.db, context.user, memo.id, followUp);
+  }
+  return memoToCurrentMemosDto(memo, context.user);
+}
+
+async function streamableGetMemo(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const name = resourceName(args, "memo", "name");
+  const memo = await getMemoById(
+    context.db,
+    context.user,
+    parseMemosResourceName(name),
+  );
+  return memoToCurrentMemosDto(memo, context.user);
+}
+
+async function streamableUpdateMemo(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const input = mergedMemoInput(args);
+  assertUnsupportedMemoCollections(input);
+  const name = resourceName(args, "memo", "name", input);
+  const updateMask = optionalString(args, "updateMask", "update_mask");
+  const mutation = memoMutationFromInput(input, {
+    updateMask,
+    allowEmpty: false,
+  });
+  const memo = await updateMemo(
+    context.db,
+    context.user,
+    parseMemosResourceName(name),
+    mutation,
+  );
+  return memoToCurrentMemosDto(memo, context.user);
+}
+
+async function streamableDeleteMemo(
+  context: ReturnTypeOfRequestContext,
+  env: FlareMoEnv,
+  args: JsonObject,
+) {
+  const name = resourceName(args, "memo", "name");
+  const id = parseMemosResourceName(name);
+  const force =
+    optionalBoolean(args, "force") ?? optionalBoolean(args, "hard") ?? false;
+  if (!force) {
+    await moveMemoToTrash(context.db, context.user, id);
+    return { ok: true };
+  }
+
+  const attachments = await markMemoAttachmentsDeleting(
+    context.db,
+    context.user,
+    id,
+  );
+  const objectKeys = attachments
+    .filter((attachment) => attachment.state !== "missing")
+    .map((attachment) => attachment.r2Key);
+  if (objectKeys.length > 0) {
+    await env.ATTACHMENTS.delete(objectKeys);
+  }
+  await hardDeleteMemo(context.db, context.user, id);
+  return { ok: true };
+}
+
+async function streamableListMemoAttachments(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const pageToken = optionalString(args, "pageToken");
+  if (pageToken)
+    throw new Error("pageToken is not supported for memo attachments.");
+  const rows = await listMemoAttachments(
+    context.db,
+    context.user,
+    parseMemosResourceName(resourceName(args, "memo", "name")),
+  );
+  const size = pageSize(args);
+  return {
+    attachments: rows.slice(0, size).map(attachmentToCurrentMemosDto),
+  };
+}
+
+async function streamableSetMemoAttachments(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const rawAttachments = args.attachments;
+  if (!Array.isArray(rawAttachments) || rawAttachments.length > 100) {
+    throw new Error("attachments must be an array with at most 100 entries.");
+  }
+  const names = rawAttachments.map((attachment, index) => {
+    if (typeof attachment === "string") return attachment;
+    if (isJsonObject(attachment)) {
+      return requiredString(attachment.name, `attachments[${index}].name`);
+    }
+    throw new Error(`attachments[${index}] must be a resource name or object.`);
+  });
+  await bindMemoAttachments(
+    context.db,
+    context.user,
+    parseMemosResourceName(resourceName(args, "memo", "name")),
+    names,
+  );
+  return { ok: true };
+}
+
+async function streamableListMemoRelations(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const pageToken = optionalString(args, "pageToken");
+  if (pageToken)
+    throw new Error("pageToken is not supported for memo relations.");
+  const rows = await listMemoRelations(
+    context.db,
+    context.user,
+    parseMemosResourceName(resourceName(args, "memo", "name")),
+  );
+  return { relations: rows.map(relationToCurrentMemosDto) };
+}
+
+async function streamableSetMemoRelations(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const rawRelations = args.relations;
+  if (!Array.isArray(rawRelations) || rawRelations.length > 100) {
+    throw new Error("relations must be an array with at most 100 entries.");
+  }
+  const targetName = parseMemosResourceName(resourceName(args, "memo", "name"));
+  const relations = rawRelations.map((rawRelation, index) => {
+    if (!isJsonObject(rawRelation)) {
+      throw new Error(`relations[${index}] must be an object.`);
+    }
+    const relatedMemo = rawRelation.relatedMemo;
+    const relatedName = isJsonObject(relatedMemo)
+      ? requiredString(relatedMemo.name, `relations[${index}].relatedMemo.name`)
+      : requiredString(
+          firstDefined(rawRelation.related_memo, relatedMemo),
+          `relations[${index}].relatedMemo`,
+        );
+    const sourceMemo = rawRelation.memo;
+    if (isJsonObject(sourceMemo) && sourceMemo.name !== undefined) {
+      const sourceName = requiredString(
+        sourceMemo.name,
+        `relations[${index}].memo.name`,
+      );
+      if (parseMemosResourceName(sourceName) !== targetName) {
+        throw new Error(`relations[${index}].memo must match the target memo.`);
+      }
+    }
+    return {
+      related_memo: relatedName,
+      type: normalizeRelationType(rawRelation.type),
+    };
+  });
+  await replaceMemoRelations(context.db, context.user, targetName, {
+    relations,
+  });
+  return { ok: true };
+}
+
+async function streamableListAttachments(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const pageToken = optionalString(args, "pageToken");
+  if (pageToken) throw new Error("pageToken is not supported for attachments.");
+  const filter = optionalString(args, "filter");
+  if (filter) throw new Error("Attachment filter is not supported by FlareMo.");
+  const orderBy = optionalString(args, "orderBy");
+  if (orderBy)
+    throw new Error("Attachment orderBy is not supported by FlareMo.");
+  const memo = optionalString(args, "memo");
+  const rows = await listAttachments(context.db, context.user, {
+    memoId: memo,
+    pageSize: pageSize(args),
+  });
+  return { attachments: rows.map(attachmentToCurrentMemosDto) };
+}
+
+async function streamableGetAttachment(
+  context: ReturnTypeOfRequestContext,
+  args: JsonObject,
+) {
+  const name = resourceName(args, "attachment", "name");
+  const attachment = await getAttachmentById(context.db, context.user, name);
+  return attachmentToCurrentMemosDto(attachment);
+}
+
+async function streamableDeleteAttachment(
+  context: ReturnTypeOfRequestContext,
+  env: FlareMoEnv,
+  args: JsonObject,
+) {
+  const name = resourceName(args, "attachment", "name");
+  const attachment = await markAttachmentDeleting(
+    context.db,
+    context.user,
+    name,
+  );
+  await env.ATTACHMENTS.delete(attachment.r2Key);
+  await finalizeAttachmentDelete(context.db, context.user, attachment.id);
+  return { ok: true };
+}
+
+function mergedMemoInput(args: JsonObject): JsonObject {
+  const body = args.body;
+  const memoArgument = args.memo;
+  const memoObject = isJsonObject(memoArgument) ? memoArgument : {};
+  if (body !== undefined && !isJsonObject(body)) {
+    throw new Error("body must be an object.");
+  }
+  return {
+    ...args,
+    ...memoObject,
+    ...(isJsonObject(body) ? body : {}),
+  };
+}
+
+function assertUnsupportedMemoCollections(input: JsonObject) {
+  if (input.attachments !== undefined) {
+    throw new Error(
+      "Memo attachments must be changed with memo_set_memo_attachments.",
+    );
+  }
+  if (input.relations !== undefined) {
+    throw new Error(
+      "Memo relations must be changed with memo_set_memo_relations.",
+    );
+  }
+}
+
+function memoPayloadFromInput(input: JsonObject) {
+  const payloadValue = input.payload;
+  if (payloadValue !== undefined && !isJsonObject(payloadValue)) {
+    throw new Error("payload must be an object.");
+  }
+  const payload: JsonObject = isJsonObject(payloadValue)
+    ? { ...payloadValue }
+    : {};
+  if (input.tags !== undefined) {
+    if (
+      !Array.isArray(input.tags) ||
+      input.tags.some((tag) => typeof tag !== "string")
+    ) {
+      throw new Error("tags must be an array of strings.");
+    }
+    payload.tags = input.tags;
+  }
+  if (input.property !== undefined) {
+    if (!isJsonObject(input.property))
+      throw new Error("property must be an object.");
+    payload.property = input.property;
+  }
+  if (input.location !== undefined) payload.location = input.location;
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+function memoMutationFromInput(
+  input: JsonObject,
+  options: { allowEmpty: boolean; updateMask?: string },
+) {
+  const updateMask = options.updateMask
+    ? normalizeUpdateMask(options.updateMask)
+    : undefined;
+  const mutation: Record<string, unknown> = {};
+  const isFieldRequested = (field: string) => {
+    if (!updateMask) return true;
+    if (updateMask.has(field)) return true;
+    if (field === "status" && updateMask.has("state")) return true;
+    if (
+      field === "payload" &&
+      ["tags", "property", "location"].some((payloadField) =>
+        updateMask.has(payloadField),
+      )
+    ) {
+      return true;
+    }
+    return false;
+  };
+  const setIfRequested = (field: string, value: unknown) => {
+    if (value === undefined) return;
+    if (!isFieldRequested(field)) return;
+    mutation[field] = value;
+  };
+
+  setIfRequested(
+    "content",
+    input.content === undefined
+      ? undefined
+      : requiredString(input.content, "content"),
+  );
+  setIfRequested("visibility", normalizeVisibility(input.visibility, true));
+  const state = normalizeMemoState(
+    firstDefined(input.state, input.status) as string | undefined,
+  );
+  setIfRequested("status", state);
+  setIfRequested("pinned", optionalBoolean(input, "pinned"));
+
+  const hasPayloadInput =
+    input.payload !== undefined ||
+    input.tags !== undefined ||
+    input.property !== undefined ||
+    input.location !== undefined;
+  if (hasPayloadInput) {
+    setIfRequested("payload", memoPayloadFromInput(input));
+  }
+
+  if (updateMask) {
+    for (const field of updateMask) {
+      if (
+        ![
+          "content",
+          "visibility",
+          "status",
+          "state",
+          "pinned",
+          "payload",
+          "tags",
+          "property",
+          "location",
+        ].includes(field)
+      ) {
+        throw new Error(`Update field "${field}" is not supported by FlareMo.`);
+      }
+    }
+    if (updateMask.has("state")) {
+      if (mutation.status === undefined) {
+        throw new Error(
+          "updateMask includes state but no state value was provided.",
+        );
+      }
+    }
+    if (
+      updateMask.has("tags") ||
+      updateMask.has("property") ||
+      updateMask.has("location")
+    ) {
+      if (!hasPayloadInput) {
+        throw new Error(
+          "updateMask includes payload fields but no value was provided.",
+        );
+      }
+    }
+  }
+
+  if (!options.allowEmpty && Object.keys(mutation).length === 0) {
+    throw new Error("At least one supported memo field must be updated.");
+  }
+  return mutation as Parameters<typeof updateMemo>[3];
+}
+
+function normalizeUpdateMask(value: string) {
+  const fields = new Set<string>();
+  for (const rawField of value.split(",")) {
+    const field = rawField.trim().replace(/^memo\./, "");
+    if (field) fields.add(field);
+  }
+  if (fields.size === 0)
+    throw new Error("updateMask must name at least one field.");
+  return fields;
+}
+
+function normalizeOrderBy(value: string) {
+  const match =
+    /^(created_at|created_time|create_time|updated_at|updated_time|update_time)\s+(asc|desc)$/i.exec(
+      value.trim(),
+    );
+  if (!match) {
+    throw new Error(
+      "orderBy must be one supported single-field order such as create_time desc.",
+    );
+  }
+  const field = match[1]?.toLowerCase() ?? "";
+  const direction = match[2]?.toLowerCase() ?? "";
+  return `${field.startsWith("update") ? "updated_at" : "created_at"} ${direction}`;
+}
+
+function pageSize(args: JsonObject) {
+  const raw = firstDefined(args.pageSize, args.page_size);
+  if (raw === undefined) return 50;
+  if (typeof raw !== "number" || !Number.isInteger(raw)) {
+    throw new Error("pageSize must be an integer.");
+  }
+  if (raw < 1 || raw > 100) {
+    throw new Error("pageSize must be between 1 and 100.");
+  }
+  return raw;
+}
+
+function resourceName(
+  args: JsonObject,
+  primary: string,
+  secondary: string,
+  additional?: JsonObject,
+) {
+  const value = firstDefined(
+    args[primary],
+    args[secondary],
+    additional?.[primary],
+    additional?.[secondary],
+  );
+  return requiredString(value, primary);
+}
+
+function optionalString(args: JsonObject, ...names: string[]) {
+  for (const name of names) {
+    const value = args[name];
+    if (value === undefined || value === null) continue;
+    if (typeof value !== "string") throw new Error(`${name} must be a string.`);
+    return value;
+  }
+  return undefined;
+}
+
+function optionalBoolean(args: JsonObject, name: string) {
+  const value = args[name];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "boolean") throw new Error(`${name} must be a boolean.`);
+  return value;
+}
+
+function requiredString(value: unknown, name: string) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function firstDefined<T>(...values: Array<T | undefined>) {
+  return values.find((value) => value !== undefined);
+}
+
+function normalizeVisibility(value: unknown, optional = false) {
+  if (value === undefined || value === null) {
+    if (optional) return undefined;
+    return "private";
+  }
+  if (typeof value !== "string")
+    throw new Error("visibility must be a string.");
+  const normalized = value.toLowerCase();
+  if (normalized === "visibility_unspecified")
+    return optional ? undefined : "private";
+  if (["private", "protected", "public"].includes(normalized))
+    return normalized;
+  throw new Error(`Unsupported visibility "${value}".`);
+}
+
+function normalizeMemoState(value: string | undefined) {
+  if (value === undefined || value === "STATE_UNSPECIFIED") return undefined;
+  const normalized = value.toLowerCase();
+  if (["normal", "archived", "trashed", "deleted"].includes(normalized)) {
+    return normalized as "normal" | "archived" | "trashed" | "deleted";
+  }
+  throw new Error(`Unsupported memo state "${value}".`);
+}
+
+function normalizeRelationType(value: unknown): "reference" | "comment" {
+  if (value === undefined || value === null || value === "TYPE_UNSPECIFIED") {
+    return "reference" as const;
+  }
+  if (typeof value !== "string")
+    throw new Error("relation type must be a string.");
+  const normalized = value.toLowerCase();
+  if (normalized === "reference" || normalized === "comment") {
+    return normalized as "reference" | "comment";
+  }
+  throw new Error(`Unsupported relation type "${value}".`);
+}
+
+function memoToCurrentMemosDto(memo: MemoRow, user: UserRow) {
+  return currentMemoToDto(memo, user);
+}
+
+function attachmentToCurrentMemosDto(attachment: AttachmentRow) {
+  return currentAttachmentToDto(attachment);
+}
+
+function relationToCurrentMemosDto(
+  relation: Awaited<ReturnType<typeof listMemoRelations>>[number],
+) {
+  return {
+    memo: { name: relation.memoId },
+    relatedMemo: { name: relation.relatedMemoId },
+    type: relation.type.toUpperCase(),
+    createTime: relation.createdAt,
+  };
+}
+
+function currentUserToMemosDto(context: ReturnTypeOfRequestContext) {
+  return currentUserToDto(context.user);
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readableError(error: unknown) {
+  if (error instanceof z.ZodError) return formatZodError(error);
+  if (error instanceof Error && error.message) return error.message;
+  return "Tool call failed.";
+}
+
+function formatZodError(error: z.ZodError) {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "request";
+      return `${path}: ${issue.message}`;
+    })
+    .join("; ");
 }

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -1,0 +1,1255 @@
+import { createDb, type UserRow } from "@flaremo/db";
+import {
+  bindMemoAttachments,
+  createAttachmentMetadata,
+  createMemo,
+  createMemoShare,
+  type DomainError,
+  finalizeAttachmentDelete,
+  getAttachmentById,
+  getAuthUserById,
+  getFlaremoUserByAuthSessionToken,
+  getMemoById,
+  getMemosPersonalAccessToken,
+  getPublicShareByToken,
+  hardDeleteMemo,
+  listAttachments,
+  listAttachmentsForMemos,
+  listMemoAttachments,
+  listMemoRelations,
+  listMemoShares,
+  listMemos,
+  listMemosPersonalAccessTokens,
+  markAttachmentDeleting,
+  moveMemoToTrash,
+  replaceMemoRelations,
+  revokeAuthSessionByToken,
+  revokeMemoShare,
+  updateMemo,
+} from "@flaremo/domain";
+import {
+  currentAttachmentToDto,
+  currentMemoToDto,
+  currentRelationToDto,
+  currentShareToDto,
+  currentUserToDto,
+  legacyMemoState,
+} from "@flaremo/memos";
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  createAttachmentObjectKey,
+  MAX_ATTACHMENT_BYTES,
+} from "../attachment-http";
+import { createFlareMoAuth } from "../auth";
+import { getRequestContext, type HonoBindings } from "../context";
+
+export const memosCurrentApi = new Hono<HonoBindings>();
+
+const currentMemoBodySchema = z
+  .object({
+    memo: z.record(z.string(), z.unknown()).optional(),
+    memoId: z.string().optional(),
+    updateMask: z.string().optional(),
+    name: z.string().optional(),
+    state: z.string().optional(),
+    creator: z.string().optional(),
+    createTime: z.string().optional(),
+    updateTime: z.string().optional(),
+    content: z.string().optional(),
+    visibility: z.string().optional(),
+    pinned: z.boolean().optional(),
+    tags: z.array(z.string()).optional(),
+    property: z.record(z.string(), z.unknown()).optional(),
+    location: z.record(z.string(), z.unknown()).optional(),
+    payload: z.record(z.string(), z.unknown()).optional(),
+    attachments: z.array(z.record(z.string(), z.unknown())).optional(),
+    relations: z.array(z.record(z.string(), z.unknown())).optional(),
+  })
+  .passthrough();
+
+const currentSigninSchema = z.object({
+  passwordCredentials: z.object({
+    username: z.string().min(1),
+    password: z.string().min(1),
+  }),
+});
+
+const currentRelationBodySchema = z.object({
+  name: z.string().optional(),
+  relations: z.array(
+    z.object({
+      memo: z.record(z.string(), z.unknown()).optional(),
+      relatedMemo: z.record(z.string(), z.unknown()).optional(),
+      type: z.string().optional(),
+      related_memo: z.string().optional(),
+    }),
+  ),
+});
+
+const currentShareBodySchema = z
+  .object({
+    memoShare: z.record(z.string(), z.unknown()).optional(),
+    name: z.string().optional(),
+    createTime: z.string().optional(),
+    expireTime: z.string().datetime().nullable().optional(),
+    expiresAt: z.string().datetime().nullable().optional(),
+  })
+  .passthrough();
+
+const currentAttachmentBodySchema = z
+  .object({
+    attachment: z.record(z.string(), z.unknown()).optional(),
+    attachmentId: z.string().optional(),
+    name: z.string().optional(),
+    createTime: z.string().optional(),
+    filename: z.string().trim().min(1).max(512).optional(),
+    content: z.string().optional(),
+    externalLink: z.string().url().optional(),
+    type: z.string().trim().min(1).max(255).optional(),
+    memo: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const currentPatBodySchema = z.object({
+  description: z.string().trim().min(1).max(32).optional(),
+  expiresInDays: z.number().int().min(0).max(365).optional(),
+});
+
+const currentAttachmentPatchBodySchema = z
+  .object({
+    attachment: z.record(z.string(), z.unknown()).optional(),
+    updateMask: z.string().optional(),
+    name: z.string().optional(),
+    memo: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/**
+ * The default `/api/v1` representation is the current Memos protobuf-JSON
+ * shape. The previous FlareMo snake_case surface remains available by sending
+ * `X-FlareMo-Wire: legacy` (or the matching vendor Accept value); the route
+ * then falls through to the original handler mounted after this app.
+ */
+export function isLegacyWireRequest(c: {
+  req: { header(name: string): string | undefined };
+}) {
+  return (
+    c.req.header("x-flaremo-wire")?.toLowerCase() === "legacy" ||
+    c.req
+      .header("accept")
+      ?.toLowerCase()
+      .includes("application/vnd.flaremo.legacy+json") === true
+  );
+}
+
+memosCurrentApi.get("/auth/me", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    return c.json({ user: await currentUserForContext(context) });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.post("/auth/signin", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const credentials = currentSigninSchema.parse(
+      await c.req.json(),
+    ).passwordCredentials;
+    const dbContext = await createAuthContext(c);
+    const result = await dbContext.auth.api.signInUsername({
+      body: {
+        username: credentials.username,
+        password: credentials.password,
+        rememberMe: true,
+      },
+      headers: c.req.raw.headers,
+      asResponse: false,
+      returnHeaders: true,
+    });
+    const session = await getFlaremoUserByAuthSessionToken(
+      dbContext.db,
+      result.response.token,
+    );
+    if (!session) {
+      throw new Error(
+        "Better Auth returned a session that could not be resolved",
+      );
+    }
+    const response = c.json(
+      {
+        user: await currentUserForContext({
+          ...dbContext,
+          user: session.user,
+          authUserId: session.authUserId,
+        }),
+        accessToken: result.response.token,
+        accessTokenExpiresAt: session.session.expiresAt.toISOString(),
+      },
+      200,
+    );
+    copyHeaders(response.headers, result.headers);
+    return response;
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.post("/auth/refresh", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const authorization = c.req.header("authorization");
+    if (authorization) {
+      const token = parseBearerToken(authorization);
+      if (token.startsWith("memos_pat_")) {
+        throw new UnauthorizedCurrentError();
+      }
+      const authContext = await createAuthContext(c);
+      const session = await getFlaremoUserByAuthSessionToken(
+        authContext.db,
+        token,
+      );
+      if (!session) throw new UnauthorizedCurrentError();
+      return c.json({
+        accessToken: token,
+        expiresAt: session.session.expiresAt.toISOString(),
+      });
+    }
+
+    const authContext = await createAuthContext(c);
+    const result = await authContext.auth.api.getSession({
+      headers: c.req.raw.headers,
+      query: { disableCookieCache: true },
+    });
+    if (!result) throw new UnauthorizedCurrentError();
+    return c.json({
+      accessToken: result.session.token,
+      expiresAt: result.session.expiresAt.toISOString(),
+    });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.post("/auth/signout", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const authorization = c.req.header("authorization");
+    if (authorization) {
+      const token = parseBearerToken(authorization);
+      if (!token.startsWith("memos_pat_")) {
+        const context = await getRequestContext(c);
+        await revokeAuthSessionByToken(context.db, token);
+      }
+      return c.body(null, 200);
+    }
+
+    const context = await getRequestContext(c);
+    const request = new Request(new URL("/api/auth/sign-out", c.req.url), {
+      method: "POST",
+      headers: c.req.raw.headers,
+    });
+    return createFlareMoAuth(c.env, context.db).handler(request);
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/memos", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const result = await listMemos(
+      context.db,
+      context.user,
+      currentListQuery(c),
+    );
+    const attachments = await listAttachmentsForMemos(
+      context.db,
+      context.user,
+      result.memos.map((memo) => memo.id),
+    );
+    const byMemo = new Map<string, typeof attachments>();
+    for (const attachment of attachments) {
+      if (!attachment.memoId) continue;
+      const values = byMemo.get(attachment.memoId) ?? [];
+      values.push(attachment);
+      byMemo.set(attachment.memoId, values);
+    }
+    return c.json({
+      memos: result.memos.map((memo) =>
+        currentMemoToDto(memo, context.user, {
+          attachments: byMemo.get(memo.id) ?? [],
+        }),
+      ),
+      ...(result.nextPageToken ? { nextPageToken: result.nextPageToken } : {}),
+    });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.post("/memos", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const body = unwrapMemoBody(
+      currentMemoBodySchema.parse(await c.req.json()),
+    );
+    if (body.memoId) {
+      throw new ValidationCurrentError(
+        "memoId is not supported; FlareMo generates memo resource names",
+      );
+    }
+    if (typeof body.content !== "string" || !body.content.trim()) {
+      throw new ValidationCurrentError("Memo content is required");
+    }
+    const context = await getRequestContext(c);
+    const memo = await createMemo(context.db, context.user, {
+      content: body.content.trim(),
+      visibility: currentVisibilityToLegacy(body.visibility),
+      payload: currentPayload(body),
+      source: "memos-api",
+    });
+    return c.json(await currentMemoWithDetails(context, memo));
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/memos/:memo", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const memo = await getMemoById(
+      context.db,
+      context.user,
+      normalizeMemoName(c.req.param("memo")),
+    );
+    return c.json(await currentMemoWithDetails(context, memo));
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.patch("/memos/:memo", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const body = unwrapMemoBody(
+      currentMemoBodySchema.parse(await c.req.json()),
+    );
+    const updateMask = parseUpdateMask(
+      c.req.query("updateMask") ?? body.updateMask,
+    );
+    const input = currentUpdateInput(body, updateMask);
+    const context = await getRequestContext(c);
+    const memo = await updateMemo(
+      context.db,
+      context.user,
+      normalizeMemoName(c.req.param("memo")),
+      input,
+    );
+    return c.json(await currentMemoWithDetails(context, memo));
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.delete("/memos/:memo", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const name = normalizeMemoName(c.req.param("memo"));
+    if (c.req.query("force") === "true") {
+      await hardDeleteMemo(context.db, context.user, name);
+    } else {
+      await moveMemoToTrash(context.db, context.user, name);
+    }
+    return c.body(null, 200);
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/memos/:memo/attachments", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const attachments = await listMemoAttachments(
+      context.db,
+      context.user,
+      normalizeMemoName(c.req.param("memo")),
+    );
+    return c.json({ attachments: attachments.map(currentAttachmentToDto) });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.patch("/memos/:memo/attachments", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const body = unwrapMemoBody(
+      currentMemoBodySchema.parse(await c.req.json()),
+    );
+    const names = (body.attachments ?? []).flatMap((attachment) =>
+      typeof attachment.name === "string" ? [attachment.name] : [],
+    );
+    const context = await getRequestContext(c);
+    await bindMemoAttachments(
+      context.db,
+      context.user,
+      normalizeMemoName(c.req.param("memo")),
+      names,
+    );
+    return c.body(null, 200);
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/memos/:memo/relations", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const relations = await currentRelations(
+      context,
+      normalizeMemoName(c.req.param("memo")),
+    );
+    return c.json({ relations });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.patch("/memos/:memo/relations", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const body = currentRelationBodySchema.parse(await c.req.json());
+    const memoName = normalizeMemoName(c.req.param("memo"));
+    const relationInput = body.relations.flatMap((relation) => {
+      const relatedName =
+        relation.related_memo ??
+        (isRecord(relation.relatedMemo) &&
+        typeof relation.relatedMemo.name === "string"
+          ? relation.relatedMemo.name
+          : undefined);
+      if (!relatedName) return [];
+      return [
+        {
+          related_memo: relatedName,
+          type: currentRelationToLegacy(relation.type),
+        },
+      ];
+    });
+    const context = await getRequestContext(c);
+    await replaceMemoRelations(context.db, context.user, memoName, {
+      relations: relationInput,
+    });
+    return c.body(null, 200);
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/memos/:memo/shares", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const shares = await listMemoShares(
+      context.db,
+      context.user,
+      normalizeMemoName(c.req.param("memo")),
+    );
+    return c.json({ memoShares: shares.map(currentShareToDto) });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.post("/memos/:memo/shares", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const body = unwrapShareBody(
+      currentShareBodySchema.parse(await c.req.json()),
+    );
+    const context = await getRequestContext(c);
+    const share = await createMemoShare(
+      context.db,
+      context.user,
+      normalizeMemoName(c.req.param("memo")),
+      {
+        expires_at: body.expireTime ?? body.expiresAt ?? null,
+      },
+    );
+    return c.json(currentShareToDto(share));
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.delete("/memos/:memo/shares/:share", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    await revokeMemoShare(context.db, context.user, c.req.param("share"));
+    return c.body(null, 200);
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/shares/:shareToken", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const db = (await createAuthContext(c)).db;
+    const share = await getPublicShareByToken(db, c.req.param("shareToken"));
+    return c.json(
+      currentMemoToDto(share.memo, share.user, {
+        attachments: share.attachments,
+      }),
+    );
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/shares/:shareToken/memo", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const db = (await createAuthContext(c)).db;
+    const share = await getPublicShareByToken(db, c.req.param("shareToken"));
+    return c.json(
+      currentMemoToDto(share.memo, share.user, {
+        attachments: share.attachments,
+      }),
+    );
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/attachments", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const attachments = await listAttachments(context.db, context.user, {
+      memoId: c.req.query("memo"),
+      pageSize: parsePageSize(c.req.query("pageSize"), 50),
+    });
+    return c.json({ attachments: attachments.map(currentAttachmentToDto) });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.post("/attachments", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  if (
+    !c.req.header("content-type")?.toLowerCase().includes("application/json")
+  ) {
+    return next();
+  }
+  try {
+    const body = unwrapAttachmentBody(
+      currentAttachmentBodySchema.parse(await c.req.json()),
+    );
+    if (body.attachmentId) {
+      throw new ValidationCurrentError(
+        "attachmentId is not supported; FlareMo generates attachment resource names",
+      );
+    }
+    if (body.externalLink) {
+      throw new ValidationCurrentError(
+        "External attachments are not supported by FlareMo",
+      );
+    }
+    if (!body.content)
+      throw new ValidationCurrentError("Attachment content is required");
+    const filename = currentRequiredString(body.filename, "filename");
+    const type = currentRequiredString(body.type, "type");
+    const bytes = decodeBase64(body.content);
+    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+      throw new PayloadTooLargeCurrentError(
+        "Attachment exceeds the 25 MiB limit",
+      );
+    }
+    const context = await getRequestContext(c);
+    const objectKey = createAttachmentObjectKey(
+      context.user.id,
+      filename,
+      "memos",
+    );
+    const object = await c.env.ATTACHMENTS.put(objectKey, bytes, {
+      httpMetadata: { contentType: type },
+    });
+    try {
+      const attachment = await createAttachmentMetadata(
+        context.db,
+        context.user,
+        {
+          memoId: body.memo ?? null,
+          filename,
+          contentType: type,
+          size: bytes.byteLength,
+          r2Key: objectKey,
+          etag: object.httpEtag,
+        },
+      );
+      return c.json(currentAttachmentToDto(attachment));
+    } catch (error) {
+      await c.env.ATTACHMENTS.delete(objectKey);
+      throw error;
+    }
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/attachments/:attachment", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const attachment = await getAttachmentById(
+      context.db,
+      context.user,
+      normalizeAttachmentName(c.req.param("attachment")),
+    );
+    return c.json(currentAttachmentToDto(attachment));
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.patch("/attachments/:attachment", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const rawBody = currentAttachmentPatchBodySchema.parse(await c.req.json());
+    const body = unwrapAttachmentPatchBody(rawBody);
+    const updateMask = parseUpdateMask(
+      c.req.query("updateMask") ?? rawBody.updateMask,
+    );
+    if (!updateMask.every((field) => field === "memo")) {
+      throw new ValidationCurrentError(
+        "Only the attachment memo field is mutable",
+      );
+    }
+    if (!body.memo) throw new ValidationCurrentError("A memo is required");
+    const context = await getRequestContext(c);
+    const attachment = await getAttachmentById(
+      context.db,
+      context.user,
+      normalizeAttachmentName(c.req.param("attachment")),
+    );
+    await bindMemoAttachments(context.db, context.user, body.memo, [
+      attachment.id,
+    ]);
+    const updated = await getAttachmentById(
+      context.db,
+      context.user,
+      attachment.id,
+    );
+    return c.json(currentAttachmentToDto(updated));
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.delete("/attachments/:attachment", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    const attachment = await markAttachmentDeleting(
+      context.db,
+      context.user,
+      normalizeAttachmentName(c.req.param("attachment")),
+    );
+    await c.env.ATTACHMENTS.delete(attachment.r2Key);
+    await finalizeAttachmentDelete(context.db, context.user, attachment.id);
+    return c.body(null, 200);
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/users", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    return c.json({ users: [await currentUserForContext(context)] });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.get("/users/:user/personalAccessTokens", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    assertCurrentUserPath(c.req.param("user"), context.user.id);
+    const tokens = await listMemosPersonalAccessTokens(
+      context.db,
+      context.authUserId,
+    );
+    return c.json({
+      personalAccessTokens: tokens.map((token) =>
+        currentPatToDto(token, context.user.id),
+      ),
+    });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.post("/users/:user/personalAccessTokens", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    assertCurrentUserPath(c.req.param("user"), context.user.id);
+    const body = currentPatBodySchema.parse(await c.req.json());
+    const auth = createFlareMoAuth(c.env, context.db);
+    const created = await auth.api.createApiKey({
+      body: {
+        configId: "memos",
+        userId: context.authUserId,
+        name: body.description ?? "Memos API token",
+        expiresIn:
+          body.expiresInDays === 0 || body.expiresInDays === undefined
+            ? null
+            : body.expiresInDays * 24 * 60 * 60,
+      },
+    });
+    return c.json({
+      personalAccessToken: currentPatToDto(created, context.user.id),
+      token: created.key,
+    });
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+memosCurrentApi.delete(
+  "/users/:user/personalAccessTokens/:token",
+  async (c, next) => {
+    if (isLegacyWireRequest(c)) return next();
+    try {
+      const context = await getRequestContext(c);
+      assertCurrentUserPath(c.req.param("user"), context.user.id);
+      const tokenId = c.req.param("token").split("/").at(-1) ?? "";
+      const existing = await getMemosPersonalAccessToken(context.db, {
+        authUserId: context.authUserId,
+        keyId: tokenId,
+      });
+      if (!existing)
+        throw new NotFoundCurrentError("Personal access token not found");
+      await createFlareMoAuth(c.env, context.db).api.updateApiKey({
+        body: {
+          configId: "memos",
+          keyId: existing.id,
+          userId: context.authUserId,
+          enabled: false,
+        },
+      });
+      return c.body(null, 200);
+    } catch (error) {
+      return currentJsonError(c, error);
+    }
+  },
+);
+
+memosCurrentApi.get("/users/:user", async (c, next) => {
+  if (isLegacyWireRequest(c)) return next();
+  try {
+    const context = await getRequestContext(c);
+    assertCurrentUserPath(c.req.param("user"), context.user.id);
+    return c.json(await currentUserForContext(context));
+  } catch (error) {
+    return currentJsonError(c, error);
+  }
+});
+
+async function currentMemoWithDetails(
+  context: Awaited<ReturnType<typeof getRequestContext>>,
+  memo: Awaited<ReturnType<typeof getMemoById>>,
+) {
+  const [attachments, relations] = await Promise.all([
+    listMemoAttachments(context.db, context.user, memo.id),
+    currentRelations(context, memo.id),
+  ]);
+  return currentMemoToDto(memo, context.user, { attachments, relations });
+}
+
+async function currentRelations(
+  context: Awaited<ReturnType<typeof getRequestContext>>,
+  memoId: string,
+) {
+  const memo = await getMemoById(context.db, context.user, memoId, {
+    includeDeleted: true,
+  });
+  const rows = await listMemoRelations(context.db, context.user, memoId);
+  const related = await Promise.all(
+    rows.map(async (relation) => {
+      try {
+        const relatedMemo = await getMemoById(
+          context.db,
+          context.user,
+          relation.relatedMemoId,
+          { includeDeleted: true },
+        );
+        return currentRelationToDto(relation, memo, relatedMemo);
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return related.filter(
+    (value): value is NonNullable<typeof value> => value !== null,
+  );
+}
+
+async function currentUserForContext(context: {
+  db: ReturnType<typeof createDb>;
+  user: UserRow;
+  authUserId: string;
+}) {
+  return currentUserToDto(
+    context.user,
+    await getAuthUserById(context.db, context.authUserId),
+  );
+}
+
+async function createAuthContext(c: Parameters<typeof getRequestContext>[0]) {
+  const db = createDb(c.env.DB);
+  return { db, auth: createFlareMoAuth(c.env, db) };
+}
+
+function currentListQuery(c: Parameters<typeof getRequestContext>[0]) {
+  const rawOrderBy = c.req.query("orderBy") ?? "create_time desc";
+  const orderBy = normalizeCurrentOrderBy(rawOrderBy);
+  const rawState = c.req.query("state");
+  const state = legacyMemoState(rawState);
+  if (rawState && rawState !== "STATE_UNSPECIFIED" && !state) {
+    throw new ValidationCurrentError(`Unsupported memo state: ${rawState}`);
+  }
+  if (state === "trashed" || state === "deleted") {
+    throw new ValidationCurrentError(
+      "Current Memos only exposes NORMAL and ARCHIVED list states",
+    );
+  }
+  const filter = parseCurrentFilter(c.req.query("filter"));
+  return {
+    page_size: parsePageSize(c.req.query("pageSize"), 50),
+    page_token: c.req.query("pageToken"),
+    order_by: orderBy,
+    ...(state ? { state } : {}),
+    ...(filter.q ? { q: filter.q } : {}),
+    ...(filter.tag ? { tag: filter.tag } : {}),
+    ...(filter.visibility ? { visibility: filter.visibility } : {}),
+    include_deleted: c.req.query("showDeleted") === "true",
+  };
+}
+
+function parseCurrentFilter(filter: string | undefined) {
+  if (!filter?.trim()) return {};
+  const result: {
+    q?: string;
+    tag?: string;
+    visibility?: "private" | "protected" | "public";
+  } = {};
+  const terms: string[] = [];
+  for (const clause of filter.split(/\s*&&\s*/)) {
+    const content = clause.match(/^content\.contains\((['"])(.*?)\1\)$/);
+    if (content?.[2]) {
+      terms.push(content[2]);
+      continue;
+    }
+    const tag = clause.match(
+      /^tags\.exists\(\s*\w+\s*,\s*\w+\s*==\s*(['"])(.*?)\1\s*\)$/,
+    );
+    if (tag?.[2]) {
+      result.tag = tag[2];
+      continue;
+    }
+    const pinned = clause.match(/^pinned\s*==\s*(true|false)$/);
+    if (pinned?.[1] === "true") {
+      terms.push("is:pinned");
+      continue;
+    }
+    if (pinned?.[1] === "false") {
+      throw new ValidationCurrentError(
+        "The current filter subset only supports pinned == true",
+      );
+    }
+    const visibility = clause.match(
+      /^visibility\s*==\s*(['"])(PRIVATE|PROTECTED|PUBLIC)\1$/,
+    );
+    if (visibility?.[2]) {
+      result.visibility = visibility[2].toLowerCase() as
+        | "private"
+        | "protected"
+        | "public";
+      continue;
+    }
+    throw new ValidationCurrentError(`Unsupported Memos filter: ${clause}`);
+  }
+  if (terms.length > 0) result.q = terms.join(" ");
+  return result;
+}
+
+function currentPayload(body: z.infer<typeof currentMemoBodySchema>) {
+  const payload = { ...(body.payload ?? {}) };
+  if (body.tags) payload.tags = body.tags;
+  if (body.property) {
+    payload.property = {
+      ...(typeof body.property.title === "string"
+        ? { title: body.property.title }
+        : {}),
+      ...(typeof body.property.hasLink === "boolean"
+        ? { has_link: body.property.hasLink }
+        : {}),
+      ...(typeof body.property.hasTaskList === "boolean"
+        ? { has_task_list: body.property.hasTaskList }
+        : {}),
+      ...(typeof body.property.hasCode === "boolean"
+        ? { has_code: body.property.hasCode }
+        : {}),
+      ...(typeof body.property.hasIncompleteTasks === "boolean"
+        ? { has_incomplete_tasks: body.property.hasIncompleteTasks }
+        : {}),
+    };
+  }
+  if (body.location) payload.location = body.location;
+  return payload;
+}
+
+function unwrapMemoBody(body: z.infer<typeof currentMemoBodySchema>) {
+  const nested = isRecord(body.memo) ? body.memo : undefined;
+  return {
+    ...body,
+    ...(nested ?? {}),
+  };
+}
+
+function unwrapShareBody(body: z.infer<typeof currentShareBodySchema>) {
+  const nested = isRecord(body.memoShare) ? body.memoShare : undefined;
+  return {
+    ...body,
+    ...(nested ?? {}),
+  };
+}
+
+function unwrapAttachmentBody(
+  body: z.infer<typeof currentAttachmentBodySchema>,
+) {
+  const nested = isRecord(body.attachment) ? body.attachment : undefined;
+  return {
+    ...body,
+    ...(nested ?? {}),
+  };
+}
+
+function unwrapAttachmentPatchBody(
+  body: z.infer<typeof currentAttachmentPatchBodySchema>,
+) {
+  const nested = isRecord(body.attachment) ? body.attachment : undefined;
+  return {
+    ...body,
+    ...(nested ?? {}),
+  };
+}
+
+function currentUpdateInput(
+  body: z.infer<typeof currentMemoBodySchema>,
+  updateMask: string[],
+) {
+  const fields = updateMask.includes("*")
+    ? [
+        "content",
+        "visibility",
+        "state",
+        "pinned",
+        "property",
+        "location",
+        "tags",
+      ]
+    : updateMask;
+  const input: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (field === "content") {
+      if (body.content === undefined)
+        throw new ValidationCurrentError("content is required by updateMask");
+      input.content = body.content;
+    } else if (field === "visibility") {
+      if (body.visibility === undefined)
+        throw new ValidationCurrentError(
+          "visibility is required by updateMask",
+        );
+      input.visibility = currentVisibilityToLegacy(body.visibility);
+    } else if (field === "state") {
+      if (body.state === undefined)
+        throw new ValidationCurrentError("state is required by updateMask");
+      const state = legacyMemoState(body.state);
+      if (!state || state === "trashed" || state === "deleted") {
+        throw new ValidationCurrentError(
+          "Only NORMAL and ARCHIVED memo states are supported by current Memos",
+        );
+      }
+      input.status = state;
+    } else if (field === "pinned") {
+      if (body.pinned === undefined)
+        throw new ValidationCurrentError("pinned is required by updateMask");
+      input.pinned = body.pinned;
+    } else if (
+      field === "property" ||
+      field === "location" ||
+      field === "tags" ||
+      field === "payload"
+    ) {
+      input.payload = currentPayload(body);
+    } else {
+      throw new ValidationCurrentError(
+        `Unsupported updateMask field: ${field}`,
+      );
+    }
+  }
+  if (Object.keys(input).length === 0)
+    throw new ValidationCurrentError("updateMask is required");
+  return input as Parameters<typeof updateMemo>[3];
+}
+
+function currentVisibilityToLegacy(value: string | undefined) {
+  const normalized = (value ?? "PRIVATE").toLowerCase();
+  if (
+    normalized === "private" ||
+    normalized === "protected" ||
+    normalized === "public"
+  ) {
+    return normalized;
+  }
+  throw new ValidationCurrentError(`Unsupported memo visibility: ${value}`);
+}
+
+function currentRelationToLegacy(
+  value: string | undefined,
+): "reference" | "comment" {
+  const normalized = (value ?? "REFERENCE").toLowerCase();
+  if (normalized === "reference" || normalized === "comment") return normalized;
+  throw new ValidationCurrentError(`Unsupported memo relation type: ${value}`);
+}
+
+function parseUpdateMask(value: string | undefined) {
+  const fields = (value ?? "")
+    .split(",")
+    .map((field) => field.trim())
+    .filter(Boolean);
+  if (fields.length === 0)
+    throw new ValidationCurrentError("updateMask is required");
+  return fields;
+}
+
+function normalizeCurrentOrderBy(value: string) {
+  const match = /^(create_time|update_time)\s+(asc|desc)$/i.exec(value.trim());
+  if (!match) {
+    throw new ValidationCurrentError(
+      "Only a single create_time or update_time order is supported",
+    );
+  }
+  return `${match[1]?.toLowerCase().startsWith("update") ? "updated_at" : "created_at"} ${match[2]?.toLowerCase()}` as
+    | "created_at asc"
+    | "created_at desc"
+    | "updated_at asc"
+    | "updated_at desc";
+}
+
+function parsePageSize(value: string | undefined, fallback: number) {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1)
+    throw new ValidationCurrentError("pageSize must be a positive integer");
+  return Math.min(parsed, 100);
+}
+
+function parseBearerToken(value: string) {
+  const parts = value.trim().split(/\s+/);
+  if (parts.length !== 2 || parts[0]?.toLowerCase() !== "bearer" || !parts[1]) {
+    throw new UnauthorizedCurrentError();
+  }
+  return parts[1];
+}
+
+function normalizeMemoName(value: string) {
+  return value.startsWith("memos/") ? value : `memos/${value}`;
+}
+
+function normalizeAttachmentName(value: string) {
+  return value.startsWith("attachments/") ? value : `attachments/${value}`;
+}
+
+function assertCurrentUserPath(value: string, currentUserId: string) {
+  const expected = currentUserId.replace(/^users\//, "");
+  const normalized = value.startsWith("users/")
+    ? value.replace(/^users\//, "")
+    : value;
+  if (normalized !== expected)
+    throw new ForbiddenCurrentError("Only the current user is available");
+}
+
+function currentPatToDto(
+  token: {
+    id: string;
+    name: string | null;
+    createdAt: Date;
+    expiresAt: Date | null;
+    lastRequest: Date | null;
+  },
+  userId: string,
+) {
+  return {
+    name: `${userId}/personalAccessTokens/${token.id}`,
+    ...(token.name ? { description: token.name } : {}),
+    createdAt: token.createdAt.toISOString(),
+    ...(token.expiresAt ? { expiresAt: token.expiresAt.toISOString() } : {}),
+    ...(token.lastRequest
+      ? { lastUsedAt: token.lastRequest.toISOString() }
+      : {}),
+  };
+}
+
+function decodeBase64(value: string) {
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    throw new ValidationCurrentError("Attachment content must be valid base64");
+  }
+}
+
+function currentRequiredString(value: string | undefined, field: string) {
+  if (!value?.trim()) {
+    throw new ValidationCurrentError(`${field} is required`);
+  }
+  return value.trim();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function copyHeaders(target: Headers, source: Headers) {
+  source.forEach((value, key) => {
+    target.append(key, value);
+  });
+}
+
+function currentJsonError(
+  c: Parameters<typeof getRequestContext>[0],
+  error: unknown,
+) {
+  const status = currentErrorStatus(error);
+  const message = currentErrorMessage(error);
+  return c.json(
+    {
+      code: currentErrorCode(status),
+      message,
+      details: [],
+    },
+    status as 400 | 401 | 403 | 404 | 409 | 413 | 422 | 500,
+  );
+}
+
+function currentErrorStatus(error: unknown) {
+  if (error instanceof CurrentHttpError) return error.status;
+  if (isDomainError(error)) return error.status;
+  if (isRecord(error) && typeof error.statusCode === "number")
+    return error.statusCode;
+  if (isRecord(error) && typeof error.status === "number") return error.status;
+  if (isRecord(error) && Array.isArray(error.issues)) return 400;
+  console.error(
+    JSON.stringify({
+      level: "error",
+      message: "Unhandled current Memos compatibility request error",
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+  return 500;
+}
+
+function currentErrorMessage(error: unknown) {
+  if (error instanceof CurrentHttpError) return error.message;
+  if (isDomainError(error)) return error.message;
+  if (isRecord(error) && typeof error.message === "string")
+    return error.message;
+  if (isRecord(error) && Array.isArray(error.issues)) {
+    return error.issues
+      .map((issue) =>
+        isRecord(issue) && typeof issue.message === "string"
+          ? issue.message
+          : "Invalid request",
+      )
+      .join("; ");
+  }
+  return "Internal server error";
+}
+
+function currentErrorCode(status: number) {
+  if (status === 400 || status === 422) return 3;
+  if (status === 401) return 16;
+  if (status === 403) return 7;
+  if (status === 404) return 5;
+  if (status === 409) return 6;
+  if (status === 413) return 8;
+  return 13;
+}
+
+function isDomainError(error: unknown): error is DomainError {
+  return (
+    error instanceof Error &&
+    "status" in error &&
+    typeof error.status === "number"
+  );
+}
+
+class CurrentHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+class ValidationCurrentError extends CurrentHttpError {
+  constructor(message: string) {
+    super(message, 400);
+  }
+}
+
+class UnauthorizedCurrentError extends CurrentHttpError {
+  constructor(message = "Authentication required") {
+    super(message, 401);
+  }
+}
+
+class ForbiddenCurrentError extends CurrentHttpError {
+  constructor(message: string) {
+    super(message, 403);
+  }
+}
+
+class NotFoundCurrentError extends CurrentHttpError {
+  constructor(message: string) {
+    super(message, 404);
+  }
+}
+
+class PayloadTooLargeCurrentError extends CurrentHttpError {
+  constructor(message: string) {
+    super(message, 413);
+  }
+}

--- a/docs/agent-deploy.md
+++ b/docs/agent-deploy.md
@@ -99,7 +99,7 @@ curl "$FLAREMO_URL/api/v1/memos" \
 
 公开分享路径要单独验证 bypass policy，但分享内容仍必须由 FlareMo share token 控制。Access Service Token alone 不能访问私有 API。
 
-当前 `/api/v1/mcp` 是 FlareMo 现有 JSON-RPC 子集；Memos current `/mcp` Streamable HTTP 和 current camelCase wire adapter 由 Issue #40 追踪，Agent 不得在发布记录中宣称已经完整兼容。
+旧的 `/api/v1/mcp` 是 FlareMo 现有 JSON-RPC 子集；根 `/mcp` 现在提供 current Memos 风格的无状态 JSON Streamable HTTP MCP 子集。Agent 不得在发布记录中宣称已经完整兼容：完整 CEL、Connect/gRPC、SSE、comments/reactions/shortcuts，以及第三方客户端真实 smoke test 仍未完成。
 
 ## 常见失败
 
@@ -147,7 +147,7 @@ CF-Access-Client-Secret
 3. PAT 请求如果携带 Origin，也必须命中同一 allowlist；不匹配时预期返回 `403`。
 4. allowlist 不支持 wildcard；`Referer` 和 Cloudflare Access headers 都不能修复 Origin mismatch。修改公开 vars 后需要重新部署 Worker。
 
-这套规则与 Memos 0.30 的 browser-origin 模型方向一致，但不代表 `/mcp` Streamable HTTP 或 current camelCase wire adapter 已实现；两者仍属于 Issue #40。
+这套规则与 Memos 0.30 的 browser-origin 模型方向一致，但不代表 FlareMo 已完成完整 Memos Server parity。current wire 和根 `/mcp` 只承诺兼容矩阵中列出的子集。
 
 ### 前端资源旧版本
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -163,7 +163,7 @@ Cloudflare Access 可以在这三层之前作为外层 policy。它只负责入�
 
 `FLAREMO_PUBLIC_URL` 加上可选的 `FLAREMO_TRUSTED_ORIGINS` 形成精确 origin allowlist。cookie session 的状态变更请求（`POST`、`PATCH`、`DELETE` 等非安全方法）必须携带并命中该 allowlist；缺失或不匹配时返回 `403`。PAT/Bearer 请求允许无 Origin，以支持桌面脚本和 MCP；如果 PAT 请求带有 Origin，则同样必须命中 allowlist，否则返回 `403`。
 
-该校验只比较完整 origin，不接受 wildcard，也不把 `Referer` 或 Access headers 当作 Origin。它遵循 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 安全方向，但不扩大 FlareMo 当前兼容承诺：`/mcp` Streamable HTTP 与 current camelCase wire adapter 仍由 Issue [#40](https://github.com/realchendahuang/FlareMo/issues/40) 追踪。
+该校验只比较完整 origin，不接受 wildcard，也不把 `Referer` 或 Access headers 当作 Origin。它遵循 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 安全方向。当前 `/api/v1` 默认是 current camelCase wire，并提供根 `/mcp` 无状态 Streamable HTTP MCP 子集；这些是有限兼容面，不等于完整 Memos Server parity。
 
 ## Memos 兼容策略
 
@@ -200,10 +200,13 @@ FlareMo 对外暴露 Memos-compatible `/api/v1`。公共兼容面包括：
 - `POST /api/v1/import`
 - `GET /openapi.json`
 - `POST /api/v1/mcp`
+- `POST /mcp` stateless Streamable HTTP MCP subset
 
 同时支持：
 
 - 应用层由 Better Auth cookie session 或 `memos_pat_` PAT 负责认证。
+- 默认 `/api/v1` 使用 current camelCase/protobuf-JSON subset；旧 snake_case wire 通过 `X-FlareMo-Wire: legacy` 或 legacy vendor `Accept` 显式选择。
+- current auth facade 的 `accessToken` 是 opaque Better Auth session-backed token，不是 Memos 原生 JWT。
 - Cloudflare Access 是可选的外层 policy；启用时脚本和工具要同时携带 Access Service Token 与 FlareMo PAT。
 - 常见分页参数：`page_size`、`page_token`。
 - 常见排序参数：`order_by`。
@@ -232,11 +235,11 @@ Authorization: Bearer <memos_pat_...>
 - 基于 OpenAPI 暴露 MCP endpoint。
 - 响应字段在支持范围内保持 Memos-compatible。
 - Webhooks 作为自动化生态能力进入整体设计。
-- #39 只提供 PAT/Bearer auth 基础；Memos current camelCase wire adapter、auth facade、字段/错误翻译和 `/mcp` Streamable HTTP 由 Issue #40 追踪。
+- current camelCase wire、Better Auth-backed auth facade、字段/错误翻译、PAT 资源和根 `/mcp` 无状态 Streamable HTTP MCP 子集已实现并有仓库测试；`accessToken` 是 opaque session-backed token，不是 Memos 原生 JWT。
 
 ### 兼容边界
 
-FlareMo 兼容 Memos 生态，不复制 Memos 服务端历史包袱。Connect/gRPC、复杂 CEL filter、instance settings、SSO、notifications、comments、reactions、admin surfaces、SSE 等能力只有在它们确实服务 FlareMo 产品目标时才进入实现，不为了追求字面 parity 复制复杂度。
+FlareMo 兼容 Memos 生态，不复制 Memos 服务端历史包袱。完整 Connect/gRPC、复杂 CEL filter、instance settings、SSO、notifications、comments、reactions、shortcuts、admin surfaces、SSE、有状态 MCP session 和第三方客户端实测仍未完成；这些能力只有在它们确实服务 FlareMo 产品目标时才进入实现，不为了追求字面 parity 复制复杂度。
 
 ## API 分层
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -88,7 +88,7 @@ Cloudflare Access 可以作为额外的外层防线，但 Access 身份或 Acces
 | PAT/Bearer 携带 Origin | 必须精确匹配同一 allowlist | 不匹配返回 `403` |
 | Cloudflare Access headers | 只属于可选外层 policy | 不能替代 cookie session、PAT 或 Origin 校验 |
 
-这与 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 安全模型保持同一方向，但不表示 FlareMo 已实现 Memos 当前协议。`/mcp` Streamable HTTP 和 current camelCase wire adapter 仍由 Issue [#40](https://github.com/realchendahuang/FlareMo/issues/40) 追踪。
+这与 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 安全模型保持同一方向。当前 `/api/v1` 默认使用 current camelCase wire，并已提供 Better Auth-backed auth facade、PAT 资源和根 `/mcp` 无状态 Streamable HTTP MCP 子集；这些能力仍不是完整 Memos Server parity。`accessToken` 是 opaque session-backed token，不是 Memos 原生 JWT。
 
 ### 3. 配置 Worker secrets
 
@@ -143,7 +143,7 @@ curl "$FLAREMO_URL/api/v1/memos" \
 
 如果 Cloudflare Access 仍然启用，上面的请求还要附加 Access Service Token headers。Access Service Token 单独发送时，Worker 仍会返回应用层 `401`，这是预期行为。
 
-当前 `/api/v1/mcp` 是 FlareMo 既有 JSON-RPC MCP 子集，同样需要 cookie session 或 PAT。Memos current `/mcp` Streamable HTTP 和 current camelCase wire adapter 不属于本次认证任务，见 Issue #40。
+旧的 `/api/v1/mcp` 是 FlareMo 既有 JSON-RPC MCP 子集，同样需要 cookie session 或 PAT；它继续保留给旧客户端。current Memos 风格的无状态 JSON Streamable HTTP MCP 位于根 `/mcp`，支持 `initialize`、`notifications/initialized`、`tools/list` 和 `tools/call`，但不承诺 SSE、有状态 session 或完整 method surface。
 
 ## Cloudflare Access（可选外层防线）
 
@@ -228,6 +228,18 @@ curl "$FLAREMO_URL/api/v1/mcp" \
   -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
   -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
   --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+current Memos 风格 MCP 使用根 `/mcp`，同样需要 FlareMo PAT；它是无状态 JSON Streamable HTTP 子集：
+
+```bash
+curl "$FLAREMO_URL/mcp" \
+  -H "content-type: application/json" \
+  -H "accept: application/json, text/event-stream" \
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}'
 ```
 
 不要把 Access Service Token 改造成 FlareMo 应用内 token。两种凭据属于不同层：Access 只保护入口，FlareMo PAT 才映射到 D1 中的应用用户。

--- a/docs/en/agent-deploy.md
+++ b/docs/en/agent-deploy.md
@@ -8,14 +8,14 @@ This runbook is for Codex, Claude Code, Cursor Agent, and other command-capable 
 - `pnpm install` has completed, or the agent can run it.
 - Wrangler is logged in to the target Cloudflare account.
 - `wrangler.jsonc` points to the target D1 and R2 resources.
-- Production access is handled by Cloudflare Access, not FlareMo application code.
+- Application authentication is handled by Better Auth. Cloudflare Access is optional outer policy and does not replace a FlareMo cookie session or `memos_pat_` PAT.
 
 ## Do Not
 
 - Do not add GitHub Actions CI or deployment workflows. `flaremo-update.yml` is the only exception and only prepares upstream update pull requests in user deployment repositories.
 - Do not deploy before `pnpm verify`.
 - Do not commit `Temp/`, `node_modules/`, `dist/`, `.wrangler/`, `.dev.vars`, `backups/`, `test-results/`, or `playwright-report/`.
-- Do not add app-level Bearer token login.
+- Do not add a second authentication system, shared password, or standalone bearer-token table outside Better Auth. Machine access uses the revocable `memos_pat_` PAT boundary.
 - Do not move canonical note data from D1 to KV, R2, or Vectorize.
 
 ## Standard Flow
@@ -47,10 +47,13 @@ Scripts need an Access Service Token:
 ```bash
 curl "$FLAREMO_URL/api/v1/memos" \
   -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
-  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET"
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT"
 ```
 
 Public share routes need a separate Access bypass policy. The content must still be protected by FlareMo share tokens.
+
+The default `/api/v1` wire is the current camelCase/protobuf-JSON subset. `X-FlareMo-Wire: legacy` selects the older snake_case wire. The root `/mcp` endpoint is a stateless Streamable HTTP MCP subset; it is not a claim of complete Memos Server parity. The auth facade's `accessToken` is an opaque Better Auth session-backed token, not a native Memos JWT.
 
 ## Common Failures
 

--- a/docs/en/deploy.md
+++ b/docs/en/deploy.md
@@ -28,9 +28,11 @@ pnpm deploy:dry-run
 pnpm deploy
 ```
 
-## Cloudflare Access
+## Better Auth and optional Cloudflare Access
 
-FlareMo expects production instances to be protected by Cloudflare Access. Do not add an app-level Bearer token, login page, or custom session gateway to FlareMo.
+FlareMo's application authentication is provided by Better Auth. The first deployment uses the one-time `/setup` flow to create the single owner; browsers use an `HttpOnly` cookie session, while scripts, MCP, and Memos-compatible clients use a revocable `memos_pat_` PAT. Cloudflare Access is optional outer policy and never replaces the application session or PAT.
+
+The current `/api/v1` wire is the current Memos-style camelCase/protobuf-JSON subset. The legacy snake_case wire is selected explicitly with `X-FlareMo-Wire: legacy`. The current auth facade returns an opaque Better Auth session-backed `accessToken`, not a native Memos JWT. The root `/mcp` is a stateless Streamable HTTP MCP subset; complete Memos Server parity is not promised.
 
 Recommended boundary:
 
@@ -95,12 +97,13 @@ Return to the FlareMo Access application and add a policy:
 | Include | The Service Token you created |
 | Require | Optional; add IP/Country constraints if clients come from fixed networks |
 
-Machine clients authenticate with Cloudflare Access headers:
+Machine clients authenticate with Cloudflare Access headers plus the FlareMo application PAT:
 
 ```bash
 curl "$FLAREMO_URL/api/v1/memos" \
   -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
-  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET"
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT"
 ```
 
 MCP example:
@@ -110,7 +113,20 @@ curl "$FLAREMO_URL/api/v1/mcp" \
   -H "content-type: application/json" \
   -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
   -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
   --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+The current Memos-style stateless MCP surface is at `/mcp` and supports `initialize`, `notifications/initialized`, `tools/list`, and `tools/call`:
+
+```bash
+curl "$FLAREMO_URL/mcp" \
+  -H "content-type: application/json" \
+  -H "accept: application/json, text/event-stream" \
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}'
 ```
 
 Do not turn the Service Token into a FlareMo app token. FlareMo application code does not read, issue, or store these credentials.
@@ -166,7 +182,7 @@ curl -I "$FLAREMO_URL/api/public/shares/not-a-real-token"
 - The `Client Secret` is not committed to the repository, issues, PRs, or public logs.
 - `/share/*`, `/api/public/shares/*`, and `/assets/*` have explicit `Bypass` policies.
 - The root application, `/api/v1/*`, and `/openapi.json` are not bypassed.
-- FlareMo has no app-level Bearer token login.
+- Access is not treated as FlareMo application identity; private API requests still use a Better Auth cookie/session bearer or `memos_pat_` PAT.
 
 ## Local Development
 

--- a/docs/en/memos-compatibility.md
+++ b/docs/en/memos-compatibility.md
@@ -1,65 +1,103 @@
 # Memos Compatibility Matrix
 
-FlareMo is Memos-compatible, not a Memos server fork. The goal is to reuse common clients, scripts, import/export flows, OpenAPI, and MCP tools while keeping the implementation Cloudflare-native.
+FlareMo is a Cloudflare-native personal knowledge system with a Memos-compatible adapter, not a fork of the Memos Go server. The default `/api/v1` wire is a current Memos-style camelCase / protobuf-JSON subset. The previous FlareMo snake_case wire remains available through an explicit legacy header, and the root `/mcp` endpoint provides a stateless Streamable HTTP MCP subset.
 
-## Supported
+This is an interoperability boundary, not a claim of complete Memos Server parity. Repository contract tests prove FlareMo's own surface; they do not replace real smoke tests against Memos clients. See the [ecosystem matrix](../memos-ecosystem.md) for third-party verification status.
 
-| Capability | Status | Notes |
+## Wire negotiation
+
+| Wire | Selection | Meaning |
 | --- | --- | --- |
-| memo resource name | Supported | `memos/{id}`. |
-| attachment resource name | Supported | `attachments/{id}`. |
-| share resource name | Supported | `shares/{token}`. |
-| create memo | Supported | `POST /api/v1/memos`. |
-| list memos | Supported | `GET /api/v1/memos`. |
-| get memo | Supported | `GET /api/v1/{name=memos/*}`. |
-| update memo | Supported | `PATCH /api/v1/{memo.name=memos/*}`. |
-| delete memo | Supported | `DELETE /api/v1/{name=memos/*}` moves to trash by default. |
-| tag filter | Supported | `GET /api/v1/memos?tag=<tag>`. |
-| state filter | Supported | `normal`, `archived`, `trashed`. |
-| pagination | Supported | `page_size`, `page_token`. |
-| ordering | Supported | `order_by` subset. |
-| full-text search | Supported | `q` uses D1 FTS5 and safely falls back to substring matching when needed; it supports `has:attachment`, `is:pinned`, date, and `in:` filters. |
-| upload attachment | Supported | `POST /api/v1/attachments`; an optional `client_id` makes offline retries idempotent. |
-| bind memo attachments | Supported | `PATCH /api/v1/{name=memos/*}/attachments`. |
-| download attachment | Supported | `GET /api/v1/{name=attachments/*}/blob`. |
-| range / inline preview | Supported | Single byte ranges, ETag, and controlled inline disposition. |
-| memo relations | Supported | `GET/PATCH /api/v1/{name=memos/*}/relations`. |
-| relation context / backlinks | Supported | `GET /api/v1/memos/{id}/relation-context`. |
-| full memo context | Supported | `GET /api/v1/memos/{id}/context`. |
-| revisions | Supported | List and restore memo revisions. |
-| share | Supported | List/create memo shares and revoke them with `DELETE /api/v1/shares/{share_id}`. |
-| public share read | Supported | `GET /api/public/shares/{token}`. |
-| export | Supported | `GET /api/v1/export`. |
-| import | Supported | `POST /api/v1/import` with `duplicate`, `skip`, or `overwrite`. |
-| OpenAPI | Supported | `GET /openapi.json`. |
-| MCP | Supported | `POST /api/v1/mcp`. |
+| current (default) | No header, or `X-FlareMo-Wire: current` | camelCase fields, uppercase protobuf-style enums, and current standard errors. |
+| legacy | `X-FlareMo-Wire: legacy`, or `Accept: application/vnd.flaremo.legacy+json` | Existing FlareMo snake_case responses for older scripts and clients. |
 
-## Not Promised
+Resource names remain Memos-shaped, such as `memos/{id}`, `attachments/{id}`, and `users/{id}`. `GET /openapi.json` returns the current OpenAPI document by default; the explicit legacy wire returns the legacy document.
 
-These are not current compatibility goals unless they directly serve FlareMo:
+## Authentication boundary
 
-- Memos Go server internals.
-- Connect/gRPC.
-- Full CEL filter parity.
-- Instance admin surface.
-- Multi-user social features, comments, reactions, notifications.
-- SSE.
-- Memos-native auth, SSO, and login flows.
-- Original database abstraction and local filesystem behavior.
+Better Auth is the application authentication source of truth. Cloudflare Access is optional outer policy and does not map an Access identity to a FlareMo application user.
 
-## Compatibility Test Policy
+| Surface | Authentication | Compatibility note |
+| --- | --- | --- |
+| Web / Better Auth | Username/password followed by an `HttpOnly` cookie session | Single-user bootstrap is the current product mode; public signup is disabled while the data model leaves a future user-mapping boundary. |
+| Current auth facade | `POST /api/v1/auth/signin`, `refresh`, `signout`, and `GET /api/v1/auth/me` | Backed by Better Auth session/account data. `accessToken` is an opaque session-backed token, not a native Memos JWT. |
+| Private `/api/v1/*` | Cookie session or `Authorization: Bearer memos_pat_...` | PATs are created by an authenticated account, shown only at creation, revocable, and stored through the Better Auth API-key boundary. |
+| Current PAT resources | `/api/v1/users/{user}/personalAccessTokens` | Current user's list/create/revoke subset; not native Memos JWT/refresh-token parity. |
+| Root `/mcp` | Cookie session, Better Auth session bearer, or `memos_pat_` PAT | Stateless JSON response subset; it does not create an MCP session. |
+| Origin policy | Cookie-session mutations require an exact `FLAREMO_PUBLIC_URL` / `FLAREMO_TRUSTED_ORIGINS` Origin; PAT may omit Origin but a supplied Origin must match | Missing or untrusted Origin returns `403`; Access headers are not a substitute. |
+| Cloudflare Access | Optional outer policy / Service Auth | Access only gates the network edge; the application still needs the cookie, session bearer, or PAT above. |
+
+## Implemented current subset
+
+| Capability | Status | Current surface / note |
+| --- | --- | --- |
+| Current user | Implemented | `GET /api/v1/auth/me`, `GET /api/v1/users`, and `GET /api/v1/users/{user}`. |
+| Better Auth sign-in facade | Implemented subset | `POST /api/v1/auth/signin`, `POST /api/v1/auth/refresh`, and `POST /api/v1/auth/signout`; returns a Better Auth-backed opaque token. |
+| Create/list memos | Implemented subset | `POST /api/v1/memos` and `GET /api/v1/memos`; supports `pageSize`, `pageToken`, limited `orderBy`, and a limited filter subset. |
+| Get/update/delete memo | Implemented subset | `GET/PATCH/DELETE /api/v1/memos/{memo}`; supports the current `{ memo: {...} }` wrapper and `updateMask`; `memoId` is explicitly rejected. |
+| Memo state and visibility | Mapped subset | `NORMAL`, `ARCHIVED`, `PRIVATE`, `PROTECTED`, and `PUBLIC`; FlareMo trash/deleted semantics do not exactly match the current Memos state model. |
+| Memo fields | Implemented subset | `tags`, `property`, `location`, `snippet`, and core field mapping. |
+| Memo attachments | Implemented subset | `GET/PATCH /api/v1/memos/{memo}/attachments`; PATCH is primarily memo attachment-set replacement, not full Attachment update parity. |
+| Memo relations | Implemented subset | `GET/PATCH /api/v1/memos/{memo}/relations` with nested `memo` / `relatedMemo` DTOs and current relation enums. |
+| Memo shares | Implemented subset | `GET/POST /api/v1/memos/{memo}/shares` and `DELETE /api/v1/memos/{memo}/shares/{share}`; current share names use `memos/{id}/shares/{token}`. |
+| Anonymous share read | Implemented | `GET /api/v1/shares/{share_id}`, still guarded by share token, expiry, and memo state. |
+| Attachment resources | Implemented subset | `GET/POST /api/v1/attachments` and `GET/PATCH/DELETE /api/v1/attachments/{attachment}`; supports the current `{ attachment: {...} }` wrapper and explicitly rejects `attachmentId`. |
+| Attachment list | Implemented subset | Returns `attachments` and an optional `nextPageToken`; protobuf JSON `size` is emitted as a decimal string. |
+| PAT resources | Implemented foundation | `GET/POST /api/v1/users/{user}/personalAccessTokens` and `DELETE /api/v1/users/{user}/personalAccessTokens/{token}`. |
+| Standard errors | Implemented | Current errors use `{ code, message, details }` rather than exposing internal FlareMo exceptions. |
+| Current OpenAPI | Implemented | `GET /openapi.json`, and authenticated `GET /api/v1/openapi.json`, describe current/legacy negotiation, auth, and `/mcp`. |
+
+### Limited filter and ordering support
+
+The adapter does not interpret arbitrary CEL on Workers. The tested subset accepts expressions such as:
+
+```text
+content.contains("...")
+tags.exists(t, t == "...")
+pinned == true
+visibility == "PUBLIC"
+```
+
+`orderBy` currently accepts only a single `create_time` or `update_time` field with `asc` or `desc`. Unsupported filters and orderings return a current standard error instead of silently changing the query semantics.
+
+### Root `/mcp`
+
+`POST /mcp` is a stateless JSON Streamable HTTP MCP subset. It negotiates protocol versions `2025-03-26` and `2024-11-05` and supports:
+
+- `initialize`
+- `notifications/initialized`
+- `tools/list`
+- `tools/call`
+
+The current tool names use `memo_`, `attachment_`, and `auth_` prefixes and cover memo CRUD, memo attachments, memo relations, attachment list/get/delete, and the current user. Successful calls provide both text content and object-shaped `structuredContent`; tool failures remain in the MCP result with `isError: true`.
+
+The endpoint is currently stateless JSON. SSE, MCP session state, the complete method surface, and every third-party MCP client's behavior are not promised. The older `POST /api/v1/mcp` JSON-RPC tool names remain available for existing FlareMo clients.
+
+## Not complete or not verified
+
+Do not describe the following as complete compatibility:
+
+- Complete Memos Server parity or complete Connect/gRPC parity.
+- Full CEL, complex pagination/ordering, or complete attachment filter/order/page-token semantics.
+- Current attachment batch delete or Attachment updates beyond the memo-binding subset.
+- Memos comments, reactions, shortcuts, notifications, admin/instance surfaces.
+- SSE and stateful MCP sessions.
+- Native Memos JWT/refresh-token and byte-level auth parity; FlareMo `accessToken` is an opaque Better Auth session-backed token.
+- Real smoke tests for the official Memos client, MemoFlow, Dynos, Raycast, browser extensions, or other third-party clients.
+- Cloudflare Access policy correctness; Access is a deployment-layer policy, not the FlareMo application protocol.
+
+## Compatibility test policy
 
 Every expanded compatibility promise needs tests for:
 
-- DTO field mapping.
-- Resource name parser.
-- Pagination and ordering.
-- Import/export roundtrip.
-- Attachment upload and download.
-- Share token isolation.
-- OpenAPI schema.
-- MCP tool calls.
+- DTO mapping, uppercase current enums, and standard errors.
+- Resource-name parsing and nested relation/share DTOs.
+- Pagination, limited ordering, and rejection of unsupported filters.
+- Import/export roundtrips.
+- Attachment upload, listing, binding, and download.
+- Share-token isolation and anonymous reads.
+- Current/legacy OpenAPI negotiation.
+- Better Auth cookie, session bearer, PAT bearer, PAT revocation, and public-share boundaries.
+- `/mcp` initialize, tools/list, tools/call, and tool-error envelopes.
 
-For real clients, use [../memos-ecosystem.md](../memos-ecosystem.md). A client that cannot send Cloudflare Access Service Token headers may be API-compatible but still unusable against a protected production FlareMo instance.
-
-Third-party clients must only be marked as supported after a real FlareMo connection test. Untested clients stay in the candidate matrix as untested.
+These tests prove FlareMo's own contract, not third-party client compatibility. Untested clients stay untested until a real connection, version, date, and result are recorded in the [ecosystem matrix](../memos-ecosystem.md).

--- a/docs/memos-compatibility.md
+++ b/docs/memos-compatibility.md
@@ -1,85 +1,105 @@
 # Memos 兼容矩阵
 
-FlareMo 正在构建一个对外兼容 Memos 生态的兼容层，但当前仍处于实现和验证阶段，不宣称已经完成 Memos 生态兼容。当前只承诺本文列出的 FlareMo 自身 API 子集；第三方客户端必须实际连接并完成验证后才能标记为可用。我们不复制 Memos 服务端实现，目标是逐步让常用客户端、脚本、导入导出、OpenAPI 和 MCP 在已验证范围内接入 FlareMo。
+FlareMo 是一个运行在 Cloudflare Workers 上的 Memos-compatible 个人知识系统，不是 Memos Server 的 Go fork。当前默认公开的是 current Memos 风格的 camelCase / protobuf-JSON REST 子集，同时保留旧 FlareMo snake_case wire 作为显式兼容模式；根路径 `/mcp` 提供无状态 Streamable HTTP MCP 子集。
 
-第三方客户端和工具的实测情况见 [memos-ecosystem.md](./memos-ecosystem.md)。本文件只描述 FlareMo 自身承诺的 API 子集。
+这意味着当前可以把 FlareMo 当作“内核不同、对外协议尽量兼容”的实现，但不能宣称已经完成完整 Memos Server parity。第三方客户端、Memos 官方客户端和周边工具仍必须逐一真实连接验证；仓库自己的 contract tests 不能替代真实客户端 smoke test。实测记录见 [memos-ecosystem.md](./memos-ecosystem.md)。
+
+## Wire 模式
+
+| 模式 | 选择方式 | 说明 |
+| --- | --- | --- |
+| current（默认） | 不加 header；或 `X-FlareMo-Wire: current` | 使用 camelCase 字段、大写 protobuf 风格枚举和 current 标准错误。 |
+| legacy | `X-FlareMo-Wire: legacy`；或 `Accept: application/vnd.flaremo.legacy+json` | 保留既有 FlareMo snake_case API，供旧脚本和旧客户端迁移使用。 |
+
+current REST 的资源名仍使用 Memos 风格，例如 `memos/{id}`、`attachments/{id}`、`users/{id}`。`GET /openapi.json` 默认返回 current OpenAPI；显式 legacy wire 时返回旧文档。
 
 ## 认证边界
 
-当前 #39 提供的是 FlareMo 原生认证基础，不是完整的 Memos Server auth parity：
+Better Auth 是应用层认证事实源，Cloudflare Access 只能作为可选外层 policy，不能映射成 FlareMo 用户身份。
 
 | 入口 | 当前认证方式 | 兼容说明 |
 | --- | --- | --- |
-| Web / Better Auth | 用户名 + 密码，登录后使用 `HttpOnly` cookie session | 当前只支持一次性 owner bootstrap；正常公共 signup 已关闭。 |
-| `/api/v1/*` 私有 API | `Authorization: Bearer memos_pat_...` | PAT 由已登录账户创建、只在创建时显示一次、可撤销；PAT 是 FlareMo-native credential。 |
-| `/api/v1/mcp` | `Authorization: Bearer memos_pat_...` | 当前是 FlareMo 既有 JSON-RPC MCP 子集，不等于 Memos 当前 `/mcp` Streamable HTTP。 |
+| Web / Better Auth | 用户名 + 密码，登录后使用 `HttpOnly` cookie session | 当前是一套单用户 bootstrap；公共 signup 关闭，数据模型保留未来用户映射边界。 |
+| current auth facade | `POST /api/v1/auth/signin`、`refresh`、`signout`，以及 `GET /api/v1/auth/me` | 由 Better Auth session/account 数据驱动；`accessToken` 是 opaque session-backed token，不是 Memos 原生 JWT。 |
+| `/api/v1/*` 私有 API | cookie session，或 `Authorization: Bearer memos_pat_...` | PAT 由已登录账户创建、只在创建时显示一次、可撤销，并由 Better Auth API key/plugin 数据承载。 |
+| current PAT 资源 | `/api/v1/users/{user}/personalAccessTokens` | 提供当前用户的 list/create/revoke 基础；不是 Memos 原生 JWT/refresh-token parity。 |
+| root `/mcp` | cookie session、Better Auth session bearer，或 `memos_pat_` PAT | Streamable HTTP 是无状态 JSON 响应子集，不创建 MCP session。 |
 | Origin policy | cookie session 状态变更必须携带并精确匹配 `FLAREMO_PUBLIC_URL` / `FLAREMO_TRUSTED_ORIGINS`；PAT 可无 Origin，带 Origin 时同样必须匹配 | 缺失或不可信 Origin 返回 `403`；Access headers 不替代应用层 Origin。 |
-| Cloudflare Access | 可选外层 policy / Service Auth | Access 只解决外层网络门禁；启用时仍要提供上面的 cookie 或 PAT。 |
+| Cloudflare Access | 可选外层 policy / Service Auth | Access 只解决外层网络门禁；启用时仍要提供上面的 cookie、session bearer 或 PAT。 |
 
-Issue #40 才会处理真实 current camelCase wire adapter、Memos auth facade、字段和错误翻译，以及 `/mcp` Streamable HTTP。不要把当前 PAT/Bearer 基础宣传为完整 Memos server parity。
+## 已实现的 current 子集
 
-Origin 规则与 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 所描述的 browser-origin 模型保持同一安全方向，但当前 `/api/v1/mcp` 仍是 FlareMo 既有 JSON-RPC 子集；`/mcp` Streamable HTTP 和 current camelCase wire adapter 未实现。
+### REST 路由
 
-## 已支持
-
-| 能力 | 状态 | 说明 |
+| 能力 | 状态 | current 路径 / 说明 |
 | --- | --- | --- |
-| memo resource name | 支持 | `memos/{id}`。 |
-| attachment resource name | 支持 | `attachments/{id}`。 |
-| share resource name | 支持 | `shares/{token}`。 |
-| 创建 memo | 支持 | `POST /api/v1/memos`。 |
-| memo 列表 | 支持 | `GET /api/v1/memos`。 |
-| memo 详情 | 支持 | `GET /api/v1/{name=memos/*}`。 |
-| 更新 memo | 支持 | `PATCH /api/v1/{memo.name=memos/*}`。 |
-| 删除 memo | 支持 | `DELETE /api/v1/{name=memos/*}`，当前语义是进入回收站。 |
-| 标签过滤 | 支持 | `GET /api/v1/memos?tag=<tag>`。 |
-| 状态过滤 | 支持 | normal、archived、trashed。 |
-| 分页 | 支持 | `page_size`、`page_token`。 |
-| 排序 | 支持 | `order_by` 子集。 |
-| 全文搜索 | 支持 | `q` 使用 D1 FTS5，并在需要时回退到安全模糊匹配；支持 `has:attachment`、`is:pinned`、日期和 `in:` 筛选。 |
-| 附件上传 | 支持 | `POST /api/v1/attachments`；可选 `client_id` 让离线重试幂等。 |
-| memo 绑定附件 | 支持 | `PATCH /api/v1/{name=memos/*}/attachments`。 |
-| 附件下载 | 支持 | `GET /api/v1/{name=attachments/*}/blob`。 |
-| Range / 内联预览 | 支持 | 单段 byte range、ETag 和受控 inline disposition。 |
-| memo relations | 支持 | `GET/PATCH /api/v1/{name=memos/*}/relations`。 |
-| relation context / backlinks | 支持 | `GET /api/v1/memos/{id}/relation-context`。 |
-| memo 完整上下文 | 支持 | `GET /api/v1/memos/{id}/context`。 |
-| 历史版本 | 支持 | 列出并恢复 memo revisions。 |
-| 分享 | 支持 | 列出/创建 memo 分享，并通过 `DELETE /api/v1/shares/{share_id}` 撤销。 |
-| 公开分享读取 | 支持 | `GET /api/public/shares/{token}`。 |
-| 导出 | 支持 | `GET /api/v1/export`。 |
-| 导入 | 支持 | `POST /api/v1/import`，支持 `duplicate`、`skip`、`overwrite`。 |
-| OpenAPI | 支持 | `GET /openapi.json`。 |
-| MCP（FlareMo 现有 JSON-RPC 子集） | 支持 | `POST /api/v1/mcp`，需要 cookie session 或 `memos_pat_` PAT；不承诺 Memos 当前 `/mcp` Streamable HTTP 或 current camelCase wire adapter。 |
+| current 用户 | 已实现 | `GET /api/v1/auth/me`、`GET /api/v1/users`、`GET /api/v1/users/{user}`。 |
+| Better Auth 登录 facade | 已实现子集 | `POST /api/v1/auth/signin`、`POST /api/v1/auth/refresh`、`POST /api/v1/auth/signout`；返回 Better Auth-backed opaque token。 |
+| 创建/列表 memo | 已实现子集 | `POST /api/v1/memos`、`GET /api/v1/memos`；支持 `pageSize`、`pageToken`、有限 `orderBy` 和有限 filter。 |
+| memo 详情/更新/删除 | 已实现子集 | `GET/PATCH/DELETE /api/v1/memos/{memo}`；支持 current `{ memo: {...} }` body wrapper、`updateMask` 和 `memoId` 明确拒绝。 |
+| memo 状态与可见性 | 已实现映射 | `NORMAL`、`ARCHIVED`、`PRIVATE`、`PROTECTED`、`PUBLIC`；FlareMo 的 trash/deleted 与 current Memos 状态模型不完全相同。 |
+| memo 属性 | 已实现子集 | `tags`、`property`、`location`、`snippet` 以及基本字段映射。 |
+| memo 附件绑定 | 已实现子集 | `GET/PATCH /api/v1/memos/{memo}/attachments`；PATCH 主要是替换 memo 的附件集合，不是完整 Attachment update parity。 |
+| memo relations | 已实现子集 | `GET/PATCH /api/v1/memos/{memo}/relations`；返回 nested `memo` / `relatedMemo` DTO 和 current relation enum。 |
+| memo shares | 已实现子集 | `GET/POST /api/v1/memos/{memo}/shares`、`DELETE /api/v1/memos/{memo}/shares/{share}`；current share name 使用 `memos/{id}/shares/{token}` 兼容形态。 |
+| 匿名 share 读取 | 已实现 | `GET /api/v1/shares/{share_id}`；仍由 share token、过期时间和 memo 状态控制。 |
+| 附件资源 | 已实现子集 | `GET/POST /api/v1/attachments`、`GET/PATCH/DELETE /api/v1/attachments/{attachment}`；支持 current `{ attachment: {...} }` wrapper，`attachmentId` 明确拒绝。 |
+| 附件列表 | 已实现子集 | 返回 `attachments`、可选 `nextPageToken`；`size` 按 protobuf JSON 以十进制字符串输出。 |
+| PAT 资源 | 已实现基础 | `GET/POST /api/v1/users/{user}/personalAccessTokens`、`DELETE /api/v1/users/{user}/personalAccessTokens/{token}`。 |
+| 标准错误 | 已实现 | current 错误使用 `{ code, message, details }`，不把 FlareMo 内部异常直接暴露给客户端。 |
+| current OpenAPI | 已实现 | `GET /openapi.json`、认证后 `GET /api/v1/openapi.json`；文档显式描述 current/legacy wire、认证和 `/mcp`。 |
 
-## 当前不承诺
+### 有限 filter / order 支持
 
-这些能力不是当前兼容目标，只有在服务 FlareMo 产品目标时才进入实现：
+为了保持 Workers 上的安全和可预测性，current adapter 不解释任意 CEL。当前只接受已经实现并测试的有限表达式，例如：
 
-- Memos Go server 的内部 API parity。
-- Connect/gRPC。
-- 完整 CEL filter。
-- 实例管理后台。
-- 多用户社交、评论、反应、通知。
-- SSE。
-- Memos 原版认证、SSO 和登录流程。
-- Memos current camelCase wire adapter、auth facade 和 `/mcp` Streamable HTTP。
-- 原版数据库抽象和本地文件存储行为。
+```text
+content.contains("...")
+tags.exists(t, t == "...")
+pinned == true
+visibility == "PUBLIC"
+```
+
+`orderBy` 当前只支持单字段的 `create_time` / `update_time` asc/desc 子集。未支持的 filter 或排序会返回 current 标准错误，而不是静默改变语义。
+
+### 根 `/mcp`
+
+`POST /mcp` 是无状态 JSON Streamable HTTP MCP 子集，支持协议版本 `2025-03-26` 和 `2024-11-05`，核心方法为：
+
+- `initialize`
+- `notifications/initialized`
+- `tools/list`
+- `tools/call`
+
+current 工具名使用 `memo_`、`attachment_`、`auth_` 前缀，覆盖 memo CRUD、memo attachments、memo relations、附件 list/get/delete 和 current user。成功结果同时提供 text content 与 object-shaped `structuredContent`；工具执行失败保留在 MCP result 的 `isError: true` 中。
+
+`/mcp` 当前是无状态 JSON response，不承诺 SSE、MCP session、完整 method surface 或所有第三方 MCP client 的实测兼容。旧的 `POST /api/v1/mcp` JSON-RPC 工具名继续保留，供已有 FlareMo 客户端使用。
+
+## 仍未完成或未验证
+
+以下能力不能写成“完整兼容”：
+
+- 完整 Memos Server parity，以及完整 Connect/gRPC parity。
+- 完整 CEL filter、复杂分页/排序和附件 filter/order/page-token 语义。
+- current attachment batch delete，以及超出 memo binding subset 的 Attachment update。
+- Memos comments、reactions、shortcuts、notifications、admin/instance surfaces。
+- SSE 和有状态 MCP session 行为。
+- Memos 原生 JWT、refresh token 及其字节级认证 parity；FlareMo `accessToken` 是 opaque Better Auth session-backed token。
+- 官方 Memos 客户端、MemoFlow、Dynos、Raycast、浏览器插件等第三方客户端的真实 smoke test。
+- Cloudflare Access policy 本身的配置正确性；它是部署环境外层策略，不是 FlareMo 应用协议。
 
 ## 兼容测试目标
 
-后续每次扩大兼容面，都要补测试：
+每次扩大兼容面，都要补测试：
 
-- DTO 字段映射。
-- resource name parser。
-- 分页和排序。
+- DTO 字段映射、current 大写枚举和标准错误。
+- resource name parser、nested relation/share DTO。
+- 分页、有限排序和不支持 filter 的拒绝行为。
 - import/export roundtrip。
-- 附件上传和下载。
-- share token 隔离。
-- OpenAPI schema。
-- MCP tool 调用。
-- cookie session、PAT Bearer、PAT 撤销和公开分享匿名读取的边界。
+- 附件上传、列表、绑定和下载。
+- share token 隔离以及匿名读取。
+- OpenAPI current/legacy wire negotiation。
+- Better Auth cookie、session bearer、PAT Bearer、PAT 撤销和公开分享边界。
+- `/mcp` initialize、tools/list、tools/call 和工具错误 envelope。
 
-兼容不是口号。每个公开承诺的 endpoint 都需要测试覆盖。
-
-第三方客户端兼容记录必须回写到 [memos-ecosystem.md](./memos-ecosystem.md)。没有实际连接 FlareMo 的客户端只能标记为“未测”，不能写成“支持”。
+这些仓库测试证明的是 FlareMo 自己的协议契约，不等于第三方客户端已经可用。第三方连接结果必须回写到 [memos-ecosystem.md](./memos-ecosystem.md)，未真实连接的客户端只能标记为“未测”。

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -1,6 +1,6 @@
 # Memos 生态兼容记录
 
-FlareMo 的目标是复用 Memos 生态，但兼容必须被验证。这个文档记录第三方客户端、脚本和工具对 FlareMo 的真实可用性，不把“接口长得像”当成“已经兼容”。#39 只提供原生 cookie/PAT 认证基础；真实 current camelCase wire adapter 和 Streamable HTTP MCP 仍由 Issue #40 追踪。
+FlareMo 的目标是复用 Memos 生态，但兼容必须被验证。这个文档记录第三方客户端、脚本和工具对 FlareMo 的真实可用性，不把“接口长得像”当成“已经兼容”。当前工作树已经提供 current camelCase REST 子集、Better Auth-backed auth facade、PAT 资源基础和根 `/mcp` 无状态 Streamable HTTP MCP 子集；完整 Memos Server parity 和第三方客户端实测仍未完成。
 
 生产实例迁移期建议放在 Cloudflare Access 后面。第三方工具访问私有 FlareMo 时，必须满足应用层认证：
 
@@ -21,7 +21,7 @@ Access Service Token 只通过外层 Access policy，不会自动变成 FlareMo 
 
 浏览器 cookie session 的 `POST`、`PATCH`、`DELETE` 等状态变更必须携带 `Origin`，并精确命中 `FLAREMO_PUBLIC_URL` 或 `FLAREMO_TRUSTED_ORIGINS`；缺失或不匹配返回 `403`。桌面脚本、MCP 和其他非浏览器客户端使用 PAT 时可以不发送 Origin；若 PAT 请求主动携带 Origin，也必须命中同一 allowlist，否则返回 `403`。不使用 wildcard、`Referer` 或 Access headers 替代 Origin。
 
-这与 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 模型方向一致，只说明安全边界相似，不说明 FlareMo 已完成 Memos 协议兼容。`/mcp` Streamable HTTP 和 current camelCase wire adapter 仍属于 Issue [#40](https://github.com/realchendahuang/FlareMo/issues/40)。
+这与 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 模型方向一致，只说明安全边界相似。FlareMo 的 current wire 是当前已实现的兼容子集；它不等于完整 Memos 协议或完整服务端 parity。
 
 ## 状态定义
 
@@ -39,8 +39,10 @@ Access Service Token 只通过外层 Access policy，不会自动变成 FlareMo 
 | 工具 / 路径 | 类型 | 测试版本 | 请求路径 | 应用层认证 | 当前状态 | 证据 |
 | --- | --- | --- | --- | --- | --- | --- |
 | curl / HTTP script | 通用脚本 | 当前工作树 | `/api/v1/memos`、`/api/v1/attachments`、`/api/v1/export`、`/api/v1/import` | `memos_pat_`；Access 开启时再加 Access headers | 可用（Worker contract） | `apps/worker/src/auth.test.ts` 和 `apps/worker/src/api.test.ts` 覆盖 cookie、PAT、memo CRUD、分页、搜索、附件、分享、revisions、export/import。 |
-| OpenAPI consumers | API schema 工具 | 当前工作树 | `/openapi.json` | OpenAPI 描述可公开读取；私有 API 请求需 PAT | 可用（schema surface） | `apps/worker/src/memos-compatibility.test.ts` 断言公开路径写入 OpenAPI。 |
-| FlareMo MCP endpoint | MCP 客户端 | 当前工作树 | `/api/v1/mcp` | `memos_pat_`；Access 开启时再加 Access headers | 部分可用（旧式 JSON-RPC） | `apps/worker/src/auth.test.ts` 覆盖 PAT `tools/list`；current Memos `/mcp` Streamable HTTP 留在 #40。 |
+| current REST script | 通用脚本 | 当前工作树 | `/api/v1/auth/*`、`/api/v1/memos`、`/api/v1/attachments`、`/api/v1/users/*`、`/api/v1/shares/*` | Better Auth cookie/session bearer 或 `memos_pat_`；Access 开启时再加 Access headers | 可用（current contract） | `apps/worker/src/memos-compatibility.test.ts` 覆盖 camelCase DTO、current enum、updateMask、PAT、标准错误和匿名 share read；`accessToken` 是 opaque session-backed token。 |
+| OpenAPI consumers | API schema 工具 | 当前工作树 | `/openapi.json` | OpenAPI 描述可公开读取；私有 API 请求需 PAT | 可用（schema surface） | `apps/worker/src/memos-compatibility.test.ts` 断言默认 current OpenAPI 和显式 legacy OpenAPI。 |
+| FlareMo legacy MCP endpoint | MCP 客户端 | 当前工作树 | `/api/v1/mcp` | `memos_pat_`；Access 开启时再加 Access headers | 部分可用（旧式 JSON-RPC） | `apps/worker/src/auth.test.ts` 覆盖 PAT `tools/list`；保留给已有 FlareMo 客户端。 |
+| FlareMo current MCP endpoint | MCP 客户端 | 当前工作树 | `/mcp` | Better Auth cookie/session bearer 或 `memos_pat_`；Access 开启时再加 Access headers | 可用（stateless protocol subset） | `apps/worker/src/mcp-streamable.test.ts` 和 `apps/worker/src/memos-compatibility.test.ts` 覆盖 `initialize`、`notifications/initialized`、`tools/list`、`tools/call` 和工具错误 envelope；未验证所有第三方 MCP client。 |
 | FlareMo Telegram Worker example | Telegram Bot | 当前工作树 | Telegram webhook -> `/api/v1/memos` | 需要 PAT；现有示例的 Access-only 发送路径需单独更新 | 部分可用 / 待回归 | 现有示例测试覆盖 webhook 和 Access headers，但不证明新的应用层 PAT 已接通。 |
 | Public share reader | 浏览器 / curl | 当前工作树 | `/share/*`、`/api/public/shares/*` | 不需要 session/PAT；Access 开启时需 bypass | 可用（share contract） | Worker 测试覆盖 token 隔离、撤销和附件读取。 |
 
@@ -108,4 +110,4 @@ Access Service Token 只通过外层 Access policy，不会自动变成 FlareMo 
 - `apps/worker/src/memos-compatibility.test.ts`
 - `apps/worker/src/api.test.ts`
 
-这些测试证明 FlareMo 自己的公开子集和认证边界，但不能替代真实 Memos 客户端兼容测试，也不能证明 Memos current `/mcp` Streamable HTTP 已实现。真实客户端结果必须回写到本文。
+这些测试证明 FlareMo 自己的 current/legacy 公开子集、Better Auth 认证边界和无状态 `/mcp` 协议切片，但不能替代真实 Memos 客户端兼容测试，也不能证明完整 Memos Server parity。真实客户端结果必须回写到本文；在没有实际连接、版本和日期证据前，第三方客户端保持“未测”。

--- a/docs/release.md
+++ b/docs/release.md
@@ -53,7 +53,7 @@ pnpm deploy
 3. 应用认证 migration 后部署 Worker，由部署者在生产 HTTPS 的 `/setup` 页面手动完成一次性 owner 初始化，再检查 bootstrap status、用户名登录、密码修改、session 撤销、PAT 创建/撤销和公开分享。
 4. 验证 cookie session 状态变更必须使用 allowlist 内的 Origin；无 Origin 或不可信 Origin 返回 `403`。同时验证无 Origin 的 PAT 请求可用，以及带不可信 Origin 的 PAT 请求返回 `403`。
 5. 第一轮发布保留 Cloudflare Access。Access 是可选外层，不得把 Access Service Token 单独当成 FlareMo 应用身份。
-6. 如果 release 声称扩大 Memos 兼容面，必须同时提供真实客户端证据；#39 的 PAT/Bearer 基础不等于 current camelCase wire adapter 或 `/mcp` Streamable HTTP。
+6. 如果 release 声称扩大 Memos 兼容面，必须同时提供真实客户端证据；仓库 contract tests 证明的是 current camelCase REST、Better Auth-backed auth facade、PAT 资源和 `/mcp` 无状态 MCP 子集，不等于完整 Memos Server parity、原生 JWT parity 或第三方客户端已验证。
 
 ## 发版命令
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -231,6 +231,6 @@ docs/         # 结果型项目文档
 - KV 不是数据库替代品。
 - Memos 兼容 API 是 FlareMo 内部服务之上的 adapter。
 - Better Auth 是应用层认证边界；Cloudflare Access 只作为可选外层防线。
-- #39 的 PAT/Bearer 认证不等于 Memos Server 完整 auth parity；current camelCase wire adapter、auth facade 和 `/mcp` Streamable HTTP 由 Issue #40 追踪。Origin 安全方向参考 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp)，不等于已经完成协议兼容。
+- current camelCase/protobuf-JSON wire、Better Auth-backed auth facade、PAT 资源和根 `/mcp` 无状态 Streamable HTTP MCP 子集已实现；`accessToken` 是 opaque session-backed token，不是 Memos 原生 JWT。它们仍不等于完整 Memos Server parity、Connect/gRPC、完整 CEL、SSE 或第三方客户端已验证。Origin 安全方向参考 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp)。
 - 产品实现保持克制：围绕快速收集、时间线、搜索、标签、附件、导入导出、语义检索、AI 工作流和 Memos 兼容面展开，不做无关的社交和后台复杂度。
 - 不为了凑技术栈而添加 Cloudflare 产品。功能真的需要时再引入。

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./memos";
+export * from "./memos-current";
 export * from "./openapi";
+export * from "./openapi-current";
 export * from "./search-query";

--- a/packages/contracts/src/memos-current.test.ts
+++ b/packages/contracts/src/memos-current.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  currentListMemosResponseSchema,
+  currentStandardErrorSchema,
+} from "./memos-current";
+
+describe("current Memos contracts", () => {
+  it("requires camelCase fields and uppercase enums", () => {
+    const parsed = currentListMemosResponseSchema.parse({
+      memos: [
+        {
+          name: "memos/one",
+          state: "NORMAL",
+          creator: "users/owner",
+          createTime: "2026-08-03T00:00:00.000Z",
+          updateTime: "2026-08-03T00:00:00.000Z",
+          content: "hello",
+          visibility: "PUBLIC",
+          tags: [],
+          pinned: false,
+        },
+      ],
+      nextPageToken: "next",
+    });
+
+    expect(parsed.memos[0]).toMatchObject({
+      state: "NORMAL",
+      visibility: "PUBLIC",
+      createTime: expect.any(String),
+    });
+    expect(parsed).not.toHaveProperty("next_page_token");
+  });
+
+  it("keeps standard errors separate from the legacy error envelope", () => {
+    expect(
+      currentStandardErrorSchema.parse({
+        code: 3,
+        message: "Invalid argument",
+        details: [],
+      }),
+    ).toEqual({ code: 3, message: "Invalid argument", details: [] });
+  });
+});

--- a/packages/contracts/src/memos-current.ts
+++ b/packages/contracts/src/memos-current.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+/**
+ * Public wire contracts for the current Memos protobuf-JSON surface.
+ *
+ * The legacy FlareMo API intentionally keeps its snake_case schemas in
+ * memos.ts. Keeping these namespaced exports separate makes it difficult to
+ * accidentally change the legacy API while adding current compatibility.
+ */
+
+export const currentMemoStateSchema = z.enum([
+  "STATE_UNSPECIFIED",
+  "NORMAL",
+  "ARCHIVED",
+]);
+
+export const currentMemoVisibilitySchema = z.enum([
+  "VISIBILITY_UNSPECIFIED",
+  "PRIVATE",
+  "PROTECTED",
+  "PUBLIC",
+]);
+
+export const currentMemoRelationTypeSchema = z.enum([
+  "TYPE_UNSPECIFIED",
+  "REFERENCE",
+  "COMMENT",
+]);
+
+export const currentMemoPropertySchema = z
+  .object({
+    hasLink: z.boolean().optional(),
+    hasTaskList: z.boolean().optional(),
+    hasCode: z.boolean().optional(),
+    hasIncompleteTasks: z.boolean().optional(),
+    title: z.string().optional(),
+  })
+  .passthrough();
+
+export const currentLocationSchema = z
+  .object({
+    placeholder: z.string().optional(),
+    latitude: z.number().optional(),
+    longitude: z.number().optional(),
+  })
+  .passthrough();
+
+export const currentAttachmentSchema = z
+  .object({
+    name: z.string(),
+    createTime: z.string().datetime().optional(),
+    filename: z.string(),
+    type: z.string(),
+    size: z.string(),
+    memo: z.string().optional(),
+  })
+  .passthrough();
+
+export const currentMemoRelationSchema = z.object({
+  memo: z.object({ name: z.string(), snippet: z.string().optional() }),
+  relatedMemo: z.object({ name: z.string(), snippet: z.string().optional() }),
+  type: currentMemoRelationTypeSchema,
+});
+
+export const currentMemoSchema = z
+  .object({
+    name: z.string(),
+    state: currentMemoStateSchema,
+    creator: z.string(),
+    createTime: z.string().datetime(),
+    updateTime: z.string().datetime(),
+    content: z.string(),
+    visibility: currentMemoVisibilitySchema,
+    tags: z.array(z.string()),
+    pinned: z.boolean(),
+    attachments: z.array(currentAttachmentSchema).optional(),
+    relations: z.array(currentMemoRelationSchema).optional(),
+    reactions: z.array(z.record(z.string(), z.unknown())).optional(),
+    property: currentMemoPropertySchema.optional(),
+    snippet: z.string().optional(),
+    location: currentLocationSchema.optional(),
+  })
+  .passthrough();
+
+export const currentCreateMemoRequestSchema = z.object({
+  memo: currentMemoSchema.partial().extend({ content: z.string() }),
+  memoId: z.string().optional(),
+});
+
+export const currentUpdateMemoRequestSchema = z.object({
+  memo: currentMemoSchema.partial().extend({ name: z.string() }),
+  updateMask: z.string(),
+});
+
+export const currentListMemosResponseSchema = z.object({
+  memos: z.array(currentMemoSchema),
+  nextPageToken: z.string().optional(),
+});
+
+export const currentListAttachmentsResponseSchema = z.object({
+  attachments: z.array(currentAttachmentSchema),
+  nextPageToken: z.string().optional(),
+  totalSize: z.number().int().nonnegative().optional(),
+});
+
+export const currentMemoShareSchema = z
+  .object({
+    name: z.string(),
+    createTime: z.string().datetime(),
+    expireTime: z.string().datetime().nullable().optional(),
+  })
+  .passthrough();
+
+export const currentUserSchema = z
+  .object({
+    name: z.string(),
+    role: z.enum(["ROLE_UNSPECIFIED", "USER", "ADMIN"]),
+    username: z.string(),
+    email: z.string(),
+    displayName: z.string(),
+    avatarUrl: z.string().optional(),
+    state: z.enum(["STATE_UNSPECIFIED", "NORMAL"]),
+    createTime: z.string().datetime(),
+    updateTime: z.string().datetime(),
+  })
+  .passthrough();
+
+export const currentPersonalAccessTokenSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    createdAt: z.string().datetime(),
+    expiresAt: z.string().datetime().optional(),
+    lastUsedAt: z.string().datetime().optional(),
+  })
+  .passthrough();
+
+export const currentStandardErrorSchema = z.object({
+  code: z.number().int(),
+  message: z.string(),
+  details: z.array(z.record(z.string(), z.unknown())),
+});
+
+export type CurrentMemo = z.infer<typeof currentMemoSchema>;
+export type CurrentAttachment = z.infer<typeof currentAttachmentSchema>;
+export type CurrentMemoRelation = z.infer<typeof currentMemoRelationSchema>;
+export type CurrentMemoShare = z.infer<typeof currentMemoShareSchema>;
+export type CurrentUser = z.infer<typeof currentUserSchema>;
+export type CurrentPersonalAccessToken = z.infer<
+  typeof currentPersonalAccessTokenSchema
+>;
+export type CurrentStandardError = z.infer<typeof currentStandardErrorSchema>;

--- a/packages/contracts/src/memos.ts
+++ b/packages/contracts/src/memos.ts
@@ -65,6 +65,7 @@ export const listMemosQuerySchema = z.object({
   page_token: z.string().optional(),
   order_by: memoOrderBySchema.default("created_at desc"),
   state: memoStatusSchema.optional(),
+  visibility: memoVisibilitySchema.optional(),
   q: z
     .string()
     .optional()

--- a/packages/contracts/src/openapi-current.ts
+++ b/packages/contracts/src/openapi-current.ts
@@ -1,0 +1,815 @@
+import { FLAREMO_API_VERSION } from "./openapi";
+
+type JsonSchema = Record<string, unknown>;
+
+const json = (schema: JsonSchema) => ({
+  "application/json": { schema },
+});
+
+const response = (description: string, schema: JsonSchema) => ({
+  description,
+  content: json(schema),
+});
+
+const emptyResponse = (description: string) => ({ description });
+
+const bearerSecurity = [{ bearerAuth: [] }, { cookieAuth: [] }];
+
+const memoName = {
+  name: "memo",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+  description: "A memo resource name or memo id.",
+};
+
+const attachmentName = {
+  name: "attachment",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+  description: "An attachment resource name or attachment id.",
+};
+
+const userName = {
+  name: "user",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+  description: "The current user resource name, for example users/owner.",
+};
+
+const currentMemo = {
+  type: "object",
+  required: ["content"],
+  properties: {
+    name: { type: "string" },
+    state: {
+      type: "string",
+      enum: ["STATE_UNSPECIFIED", "NORMAL", "ARCHIVED"],
+    },
+    creator: { type: "string" },
+    createTime: { type: "string", format: "date-time" },
+    updateTime: { type: "string", format: "date-time" },
+    content: { type: "string" },
+    visibility: {
+      type: "string",
+      enum: ["VISIBILITY_UNSPECIFIED", "PRIVATE", "PROTECTED", "PUBLIC"],
+    },
+    tags: { type: "array", items: { type: "string" } },
+    pinned: { type: "boolean" },
+    attachments: {
+      type: "array",
+      items: { $ref: "#/components/schemas/Attachment" },
+    },
+    relations: {
+      type: "array",
+      items: { $ref: "#/components/schemas/MemoRelation" },
+    },
+    reactions: { type: "array", items: { type: "object" } },
+    property: { $ref: "#/components/schemas/MemoProperty" },
+    snippet: { type: "string" },
+    location: { $ref: "#/components/schemas/Location" },
+  },
+};
+
+const memoRequest = {
+  type: "object",
+  required: ["memo"],
+  properties: {
+    memo: currentMemo,
+    memoId: {
+      type: "string",
+      description: "Not supported; FlareMo generates ids.",
+    },
+  },
+};
+
+const attachment = {
+  type: "object",
+  required: ["filename", "type"],
+  properties: {
+    name: { type: "string" },
+    createTime: { type: "string", format: "date-time" },
+    filename: { type: "string" },
+    content: {
+      type: "string",
+      format: "byte",
+      description: "Base64-encoded input bytes.",
+    },
+    externalLink: { type: "string", format: "uri" },
+    type: { type: "string" },
+    size: {
+      type: "string",
+      description: "Protobuf JSON int64 represented as a decimal string.",
+    },
+    memo: { type: "string" },
+  },
+};
+
+const attachmentRequest = {
+  type: "object",
+  required: ["attachment"],
+  properties: {
+    attachment,
+    attachmentId: {
+      type: "string",
+      description: "Not supported; FlareMo generates ids.",
+    },
+  },
+};
+
+const currentUser = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    role: { type: "string", enum: ["ROLE_UNSPECIFIED", "USER", "ADMIN"] },
+    username: { type: "string" },
+    email: { type: "string", format: "email" },
+    displayName: { type: "string" },
+    avatarUrl: { type: "string", format: "uri" },
+    state: { type: "string", enum: ["STATE_UNSPECIFIED", "NORMAL"] },
+    createTime: { type: "string", format: "date-time" },
+    updateTime: { type: "string", format: "date-time" },
+  },
+};
+
+const error = {
+  type: "object",
+  required: ["code", "message", "details"],
+  properties: {
+    code: { type: "integer" },
+    message: { type: "string" },
+    details: { type: "array", items: { type: "object" } },
+  },
+};
+
+const secured = (input: Record<string, unknown>) => ({
+  ...input,
+  security: bearerSecurity,
+});
+
+export function createCurrentOpenApiDocument() {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "FlareMo current Memos-compatible API",
+      version: FLAREMO_API_VERSION,
+      description:
+        "The default /api/v1 wire format is the current Memos camelCase/protobuf-JSON subset. FlareMo uses Better Auth cookie sessions and opaque session-backed access tokens or memos_pat_ PATs. The legacy FlareMo snake_case wire is available only with X-FlareMo-Wire: legacy or application/vnd.flaremo.legacy+json.",
+    },
+    servers: [{ url: "/" }],
+    tags: [
+      { name: "Auth" },
+      { name: "Memos" },
+      { name: "Attachments" },
+      { name: "Relations" },
+      { name: "Shares" },
+      { name: "Users" },
+      { name: "MCP" },
+    ],
+    paths: {
+      "/api/v1/auth/me": {
+        get: secured({
+          operationId: "getCurrentUser",
+          summary: "Get the current user",
+          tags: ["Auth"],
+          responses: {
+            "200": response("Current user.", {
+              type: "object",
+              properties: { user: { $ref: "#/components/schemas/User" } },
+            }),
+            "401": response("Unauthenticated.", error),
+          },
+        }),
+      },
+      "/api/v1/auth/signin": {
+        post: {
+          operationId: "signIn",
+          summary: "Sign in with Better Auth-backed credentials",
+          tags: ["Auth"],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              required: ["passwordCredentials"],
+              properties: {
+                passwordCredentials: {
+                  type: "object",
+                  required: ["username", "password"],
+                  properties: {
+                    username: { type: "string" },
+                    password: { type: "string", format: "password" },
+                  },
+                },
+              },
+            }),
+          },
+          responses: {
+            "200": response("Signed-in user and opaque access token.", {
+              type: "object",
+              properties: {
+                user: { $ref: "#/components/schemas/User" },
+                accessToken: { type: "string" },
+                accessTokenExpiresAt: { type: "string", format: "date-time" },
+              },
+            }),
+            "401": response("Invalid credentials.", error),
+          },
+        },
+      },
+      "/api/v1/auth/refresh": {
+        post: secured({
+          operationId: "refreshToken",
+          summary: "Refresh the Better Auth-backed session facade",
+          tags: ["Auth"],
+          responses: {
+            "200": response("Access token.", {
+              type: "object",
+              properties: {
+                accessToken: { type: "string" },
+                expiresAt: { type: "string", format: "date-time" },
+              },
+            }),
+            "401": response("Unauthenticated.", error),
+          },
+        }),
+      },
+      "/api/v1/auth/signout": {
+        post: secured({
+          operationId: "signOut",
+          summary: "Sign out and revoke the current session",
+          tags: ["Auth"],
+          responses: {
+            "200": emptyResponse("Signed out."),
+            "401": response("Unauthenticated.", error),
+          },
+        }),
+      },
+      "/api/v1/memos": {
+        get: secured({
+          operationId: "listMemosCurrent",
+          summary: "List memos",
+          tags: ["Memos"],
+          parameters: [
+            {
+              name: "pageSize",
+              in: "query",
+              schema: { type: "integer", minimum: 1, maximum: 100 },
+            },
+            { name: "pageToken", in: "query", schema: { type: "string" } },
+            {
+              name: "state",
+              in: "query",
+              schema: {
+                type: "string",
+                enum: ["STATE_UNSPECIFIED", "NORMAL", "ARCHIVED"],
+              },
+            },
+            {
+              name: "orderBy",
+              in: "query",
+              schema: { type: "string", example: "create_time desc" },
+            },
+            {
+              name: "filter",
+              in: "query",
+              schema: { type: "string" },
+              description:
+                "Supported subset: content.contains, tags.exists, pinned == true, visibility == enum.",
+            },
+            { name: "showDeleted", in: "query", schema: { type: "boolean" } },
+          ],
+          responses: {
+            "200": response("Memos.", {
+              type: "object",
+              properties: {
+                memos: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Memo" },
+                },
+                nextPageToken: { type: "string" },
+              },
+            }),
+            "400": response("Invalid argument.", error),
+          },
+        }),
+        post: secured({
+          operationId: "createMemoCurrent",
+          summary: "Create a memo",
+          tags: ["Memos"],
+          requestBody: { required: true, content: json(memoRequest) },
+          responses: {
+            "200": response("Created memo.", {
+              $ref: "#/components/schemas/Memo",
+            }),
+            "400": response("Invalid argument.", error),
+          },
+        }),
+      },
+      "/api/v1/memos/{memo}": {
+        get: secured({
+          operationId: "getMemoCurrent",
+          summary: "Get a memo",
+          tags: ["Memos"],
+          parameters: [memoName],
+          responses: {
+            "200": response("Memo.", { $ref: "#/components/schemas/Memo" }),
+            "404": response("Not found.", error),
+          },
+        }),
+        patch: secured({
+          operationId: "updateMemoCurrent",
+          summary: "Update a memo",
+          tags: ["Memos"],
+          parameters: [
+            memoName,
+            {
+              name: "updateMask",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "Comma-separated allowlisted fields.",
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              required: ["memo"],
+              properties: { memo: currentMemo },
+            }),
+          },
+          responses: {
+            "200": response("Updated memo.", {
+              $ref: "#/components/schemas/Memo",
+            }),
+            "400": response("Invalid argument.", error),
+          },
+        }),
+        delete: secured({
+          operationId: "deleteMemoCurrent",
+          summary: "Delete a memo",
+          tags: ["Memos"],
+          parameters: [
+            memoName,
+            { name: "force", in: "query", schema: { type: "boolean" } },
+          ],
+          responses: {
+            "200": emptyResponse("Deleted."),
+            "404": response("Not found.", error),
+          },
+        }),
+      },
+      "/api/v1/memos/{memo}/attachments": {
+        get: secured({
+          operationId: "listMemoAttachmentsCurrent",
+          summary: "List memo attachments",
+          tags: ["Attachments"],
+          parameters: [memoName],
+          responses: {
+            "200": response("Attachments.", {
+              type: "object",
+              properties: {
+                attachments: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Attachment" },
+                },
+              },
+            }),
+          },
+        }),
+        patch: secured({
+          operationId: "setMemoAttachmentsCurrent",
+          summary: "Replace memo attachments",
+          tags: ["Attachments"],
+          parameters: [memoName],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              required: ["attachments"],
+              properties: {
+                name: { type: "string" },
+                attachments: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Attachment" },
+                },
+              },
+            }),
+          },
+          responses: { "200": emptyResponse("Attachments replaced.") },
+        }),
+      },
+      "/api/v1/memos/{memo}/relations": {
+        get: secured({
+          operationId: "listMemoRelationsCurrent",
+          summary: "List memo relations",
+          tags: ["Relations"],
+          parameters: [memoName],
+          responses: {
+            "200": response("Relations.", {
+              type: "object",
+              properties: {
+                relations: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/MemoRelation" },
+                },
+              },
+            }),
+          },
+        }),
+        patch: secured({
+          operationId: "setMemoRelationsCurrent",
+          summary: "Replace memo relations",
+          tags: ["Relations"],
+          parameters: [memoName],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              required: ["relations"],
+              properties: {
+                name: { type: "string" },
+                relations: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/MemoRelation" },
+                },
+              },
+            }),
+          },
+          responses: { "200": emptyResponse("Relations replaced.") },
+        }),
+      },
+      "/api/v1/memos/{memo}/shares": {
+        get: secured({
+          operationId: "listMemoSharesCurrent",
+          summary: "List memo shares",
+          tags: ["Shares"],
+          parameters: [memoName],
+          responses: {
+            "200": response("Shares.", {
+              type: "object",
+              properties: {
+                memoShares: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/MemoShare" },
+                },
+              },
+            }),
+          },
+        }),
+        post: secured({
+          operationId: "createMemoShareCurrent",
+          summary: "Create a memo share",
+          tags: ["Shares"],
+          parameters: [memoName],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              properties: {
+                parent: { type: "string" },
+                memoShare: { $ref: "#/components/schemas/MemoShare" },
+              },
+            }),
+          },
+          responses: {
+            "200": response("Share.", {
+              $ref: "#/components/schemas/MemoShare",
+            }),
+          },
+        }),
+      },
+      "/api/v1/memos/{memo}/shares/{share}": {
+        delete: secured({
+          operationId: "deleteMemoShareCurrent",
+          summary: "Delete a memo share",
+          tags: ["Shares"],
+          parameters: [
+            memoName,
+            {
+              name: "share",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: { "200": emptyResponse("Share deleted.") },
+        }),
+      },
+      "/api/v1/shares/{share_id}": {
+        get: {
+          operationId: "getMemoByShareCurrent",
+          summary: "Get a memo by public share token",
+          tags: ["Shares"],
+          parameters: [
+            {
+              name: "share_id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": response("Shared memo.", {
+              $ref: "#/components/schemas/Memo",
+            }),
+            "404": response("Not found.", error),
+          },
+        },
+      },
+      "/api/v1/attachments": {
+        get: secured({
+          operationId: "listAttachmentsCurrent",
+          summary: "List attachments",
+          tags: ["Attachments"],
+          parameters: [
+            {
+              name: "pageSize",
+              in: "query",
+              schema: { type: "integer", minimum: 1, maximum: 100 },
+            },
+            { name: "memo", in: "query", schema: { type: "string" } },
+          ],
+          responses: {
+            "200": response("Attachments.", {
+              type: "object",
+              properties: {
+                attachments: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Attachment" },
+                },
+              },
+            }),
+          },
+        }),
+        post: secured({
+          operationId: "createAttachmentCurrent",
+          summary: "Create an attachment from base64 JSON",
+          tags: ["Attachments"],
+          requestBody: { required: true, content: json(attachmentRequest) },
+          responses: {
+            "200": response("Attachment.", {
+              $ref: "#/components/schemas/Attachment",
+            }),
+          },
+        }),
+      },
+      "/api/v1/attachments/{attachment}": {
+        get: secured({
+          operationId: "getAttachmentCurrent",
+          summary: "Get attachment metadata",
+          tags: ["Attachments"],
+          parameters: [attachmentName],
+          responses: {
+            "200": response("Attachment.", {
+              $ref: "#/components/schemas/Attachment",
+            }),
+          },
+        }),
+        patch: secured({
+          operationId: "updateAttachmentCurrent",
+          summary: "Bind an attachment to a memo",
+          tags: ["Attachments"],
+          parameters: [
+            attachmentName,
+            {
+              name: "updateMask",
+              in: "query",
+              required: true,
+              schema: { type: "string", enum: ["memo"] },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              properties: {
+                attachment: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    memo: { type: "string" },
+                  },
+                },
+              },
+            }),
+          },
+          responses: {
+            "200": response("Attachment.", {
+              $ref: "#/components/schemas/Attachment",
+            }),
+          },
+        }),
+        delete: secured({
+          operationId: "deleteAttachmentCurrent",
+          summary: "Delete an attachment",
+          tags: ["Attachments"],
+          parameters: [attachmentName],
+          responses: { "200": emptyResponse("Deleted.") },
+        }),
+      },
+      "/api/v1/users": {
+        get: secured({
+          operationId: "listUsersCurrent",
+          summary: "List the current user",
+          tags: ["Users"],
+          responses: {
+            "200": response("Users.", {
+              type: "object",
+              properties: {
+                users: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/User" },
+                },
+              },
+            }),
+          },
+        }),
+      },
+      "/api/v1/users/{user}": {
+        get: secured({
+          operationId: "getUserCurrent",
+          summary: "Get the current user",
+          tags: ["Users"],
+          parameters: [userName],
+          responses: {
+            "200": response("User.", { $ref: "#/components/schemas/User" }),
+          },
+        }),
+      },
+      "/api/v1/users/{user}/personalAccessTokens": {
+        get: secured({
+          operationId: "listPersonalAccessTokensCurrent",
+          summary: "List personal access tokens",
+          tags: ["Users"],
+          parameters: [userName],
+          responses: {
+            "200": response("Personal access tokens.", {
+              type: "object",
+              properties: {
+                personalAccessTokens: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/PersonalAccessToken" },
+                },
+                totalSize: { type: "integer" },
+              },
+            }),
+          },
+        }),
+        post: secured({
+          operationId: "createPersonalAccessTokenCurrent",
+          summary: "Create a personal access token",
+          tags: ["Users"],
+          parameters: [userName],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              properties: {
+                description: { type: "string" },
+                expiresInDays: { type: "integer", minimum: 0, maximum: 365 },
+              },
+            }),
+          },
+          responses: {
+            "200": response("Token metadata and one-time token value.", {
+              type: "object",
+              properties: {
+                personalAccessToken: {
+                  $ref: "#/components/schemas/PersonalAccessToken",
+                },
+                token: { type: "string" },
+              },
+            }),
+          },
+        }),
+      },
+      "/api/v1/users/{user}/personalAccessTokens/{token}": {
+        delete: secured({
+          operationId: "deletePersonalAccessTokenCurrent",
+          summary: "Revoke a personal access token",
+          tags: ["Users"],
+          parameters: [
+            userName,
+            {
+              name: "token",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: { "200": emptyResponse("Token revoked.") },
+        }),
+      },
+      "/mcp": {
+        post: secured({
+          operationId: "mcpStreamableHttp",
+          summary: "Stateless current Memos MCP Streamable HTTP endpoint",
+          tags: ["MCP"],
+          requestBody: {
+            required: true,
+            content: json({
+              type: "object",
+              properties: {
+                jsonrpc: { type: "string", enum: ["2.0"] },
+                id: {},
+                method: { type: "string" },
+                params: { type: "object" },
+              },
+            }),
+          },
+          responses: {
+            "200": response("JSON-RPC response.", { type: "object" }),
+            "202": emptyResponse("Notification accepted."),
+          },
+        }),
+      },
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "memos_pat_ or Better Auth session token",
+        },
+        cookieAuth: {
+          type: "apiKey",
+          in: "cookie",
+          name: "flaremo.session_token",
+        },
+      },
+      schemas: {
+        Memo: currentMemo,
+        MemoProperty: {
+          type: "object",
+          properties: {
+            hasLink: { type: "boolean" },
+            hasTaskList: { type: "boolean" },
+            hasCode: { type: "boolean" },
+            hasIncompleteTasks: { type: "boolean" },
+            title: { type: "string" },
+          },
+        },
+        Location: {
+          type: "object",
+          properties: {
+            placeholder: { type: "string" },
+            latitude: { type: "number" },
+            longitude: { type: "number" },
+          },
+        },
+        Attachment: attachment,
+        MemoRelation: {
+          type: "object",
+          properties: {
+            memo: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                snippet: { type: "string" },
+              },
+            },
+            relatedMemo: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                snippet: { type: "string" },
+              },
+            },
+            type: {
+              type: "string",
+              enum: ["TYPE_UNSPECIFIED", "REFERENCE", "COMMENT"],
+            },
+          },
+        },
+        MemoShare: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            createTime: { type: "string", format: "date-time" },
+            expireTime: { type: "string", format: "date-time", nullable: true },
+          },
+        },
+        User: currentUser,
+        PersonalAccessToken: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            description: { type: "string" },
+            createdAt: { type: "string", format: "date-time" },
+            expiresAt: { type: "string", format: "date-time", nullable: true },
+            lastUsedAt: { type: "string", format: "date-time", nullable: true },
+          },
+        },
+        Error: error,
+      },
+    },
+    "x-flaremo-legacy-wire": {
+      header: "X-FlareMo-Wire: legacy",
+      accept: "application/vnd.flaremo.legacy+json",
+      document: "/openapi.json",
+    },
+  };
+}

--- a/packages/domain/src/auth.ts
+++ b/packages/domain/src/auth.ts
@@ -1,12 +1,14 @@
 import {
   authApiKeys,
   authBootstrap,
+  authSessions,
   authUserLinks,
+  authUsers,
   type FlareMoDb,
   type UserRow,
   users,
 } from "@flaremo/db";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, gt } from "drizzle-orm";
 import { ConflictError } from "./errors";
 import { ensureSingleUser, type SingleUserConfig } from "./users";
 
@@ -113,6 +115,55 @@ export async function getFlaremoUserByAuthUserId(
       where: eq(users.id, link.flaremoUserId),
     })) ?? null
   );
+}
+
+export async function getAuthUserById(db: FlareMoDb, authUserId: string) {
+  return (
+    (await db.query.authUsers.findFirst({
+      where: eq(authUsers.id, authUserId),
+    })) ?? null
+  );
+}
+
+/**
+ * Resolve a Better Auth session token for the current-Memos auth facade.
+ *
+ * Better Auth's browser session remains the source of truth. This helper only
+ * lets a Memos-compatible client carry the opaque session token returned by
+ * `/api/v1/auth/signin` in an Authorization header; it does not introduce a
+ * second token store or a shared-password fallback.
+ */
+export async function getFlaremoUserByAuthSessionToken(
+  db: FlareMoDb,
+  token: string,
+) {
+  const session = await db.query.authSessions.findFirst({
+    where: and(
+      eq(authSessions.token, token),
+      gt(authSessions.expiresAt, new Date()),
+    ),
+  });
+  if (!session) return null;
+
+  const user = await getFlaremoUserByAuthUserId(db, session.userId);
+  if (!user) return null;
+
+  return {
+    authUserId: session.userId,
+    session,
+    user,
+  };
+}
+
+export async function revokeAuthSessionByToken(
+  db: FlareMoDb,
+  token: string,
+): Promise<boolean> {
+  const deleted = await db
+    .delete(authSessions)
+    .where(eq(authSessions.token, token))
+    .returning({ id: authSessions.id });
+  return deleted.length > 0;
 }
 
 export async function listMemosPersonalAccessTokens(

--- a/packages/domain/src/memos.ts
+++ b/packages/domain/src/memos.ts
@@ -112,6 +112,10 @@ export async function listMemos(
     filters.push(eq(memos.status, "normal"));
   }
 
+  if (query.visibility) {
+    filters.push(eq(memos.visibility, query.visibility));
+  }
+
   if (search.text) {
     const ftsQuery = buildFtsQuery(search.text);
     filters.push(

--- a/packages/memos/src/current-adapter.test.ts
+++ b/packages/memos/src/current-adapter.test.ts
@@ -1,0 +1,116 @@
+import type { AttachmentRow, MemoRow, UserRow } from "@flaremo/db";
+import { describe, expect, it } from "vitest";
+import {
+  currentAttachmentToDto,
+  currentMemosToListResponse,
+  currentMemoToDto,
+  currentRelationToDto,
+  currentShareToDto,
+} from "./current-adapter";
+
+const user = {
+  id: "users/owner",
+  role: "owner",
+  email: "owner@example.com",
+  name: "Owner",
+  avatarUrl: null,
+  createdAt: "2026-08-03T00:00:00.000Z",
+  updatedAt: "2026-08-03T00:00:00.000Z",
+} as unknown as UserRow;
+
+const memo = {
+  id: "memos/one",
+  userId: user.id,
+  content: "# Heading\nA memo with [a link](https://example.com).",
+  visibility: "protected",
+  status: "normal",
+  pinned: true,
+  payload: {
+    tags: ["one", "#two"],
+    property: { has_link: true, has_code: false, title: "Heading" },
+    location: { placeholder: "Shanghai", latitude: 31.2 },
+  },
+  createdAt: "2026-08-03T00:00:00.000Z",
+  updatedAt: "2026-08-03T00:01:00.000Z",
+} as unknown as MemoRow;
+
+const attachment = {
+  id: "attachments/file",
+  userId: user.id,
+  memoId: memo.id,
+  filename: "note.txt",
+  contentType: "text/plain",
+  size: 5,
+  createdAt: "2026-08-03T00:00:00.000Z",
+  updatedAt: "2026-08-03T00:00:00.000Z",
+} as unknown as AttachmentRow;
+
+describe("current Memos wire adapter", () => {
+  it("maps memo fields to camelCase and uppercase enums", () => {
+    expect(currentMemoToDto(memo, user)).toMatchObject({
+      name: "memos/one",
+      state: "NORMAL",
+      visibility: "PROTECTED",
+      createTime: memo.createdAt,
+      updateTime: memo.updatedAt,
+      tags: ["one", "#two"],
+      pinned: true,
+      property: { hasLink: true, hasCode: false, title: "Heading" },
+      location: { placeholder: "Shanghai", latitude: 31.2 },
+      snippet: "Heading A memo with a link.",
+    });
+  });
+
+  it("uses protobuf JSON int64 strings for attachment size", () => {
+    expect(currentAttachmentToDto(attachment)).toEqual({
+      name: "attachments/file",
+      createTime: attachment.createdAt,
+      filename: "note.txt",
+      type: "text/plain",
+      size: "5",
+      memo: "memos/one",
+    });
+  });
+
+  it("maps nested relations, shares, and page tokens", () => {
+    const relatedMemo = {
+      ...memo,
+      id: "memos/two",
+      content: "related",
+    } as MemoRow;
+    const relation = {
+      memoId: memo.id,
+      relatedMemoId: relatedMemo.id,
+      type: "comment",
+      createdAt: "2026-08-03T00:02:00.000Z",
+    } as const;
+    expect(currentRelationToDto(relation, memo, relatedMemo)).toMatchObject({
+      memo: { name: "memos/one" },
+      relatedMemo: { name: "memos/two" },
+      type: "COMMENT",
+    });
+
+    const share = {
+      memoId: memo.id,
+      token: "opaque-share",
+      createdAt: "2026-08-03T00:00:00.000Z",
+      expiresAt: null,
+    } as never;
+    expect(currentShareToDto(share)).toEqual({
+      name: "memos/one/shares/opaque-share",
+      createTime: "2026-08-03T00:00:00.000Z",
+    });
+
+    expect(
+      currentMemosToListResponse({
+        memos: [memo],
+        user,
+        attachmentsByMemo: new Map([[memo.id, [attachment]]]),
+        nextPageToken: "next",
+      }),
+    ).toMatchObject({
+      nextPageToken: "next",
+      memos: [{ attachments: [{ size: "5" }] }],
+    });
+  });
+});

--- a/packages/memos/src/current-adapter.ts
+++ b/packages/memos/src/current-adapter.ts
@@ -1,0 +1,222 @@
+import type {
+  AttachmentRow,
+  AuthUserRow,
+  MemoRow,
+  ShareRow,
+  UserRow,
+} from "@flaremo/db";
+
+type CurrentMemoRelationRow = {
+  memoId: string;
+  relatedMemoId: string;
+  type: "reference" | "comment";
+  createdAt: string;
+};
+
+export type CurrentMemoRelation = {
+  memo: { name: string; snippet?: string };
+  relatedMemo: { name: string; snippet?: string };
+  type: "TYPE_UNSPECIFIED" | "REFERENCE" | "COMMENT";
+};
+
+export function currentMemoToDto(
+  memo: MemoRow,
+  user: UserRow,
+  options: {
+    attachments?: AttachmentRow[];
+    relations?: CurrentMemoRelation[];
+  } = {},
+) {
+  const payload = isRecord(memo.payload) ? memo.payload : {};
+  const property = currentProperty(payload.property);
+  const location = currentLocation(payload.location);
+
+  return {
+    name: memo.id,
+    state: currentMemoState(memo.status),
+    creator: user.id,
+    createTime: memo.createdAt,
+    updateTime: memo.updatedAt,
+    content: memo.content,
+    visibility: currentVisibility(memo.visibility),
+    tags: Array.isArray(payload.tags)
+      ? payload.tags.filter((tag): tag is string => typeof tag === "string")
+      : [],
+    pinned: memo.pinned,
+    ...(options.attachments
+      ? { attachments: options.attachments.map(currentAttachmentToDto) }
+      : {}),
+    ...(options.relations ? { relations: options.relations } : {}),
+    reactions: [],
+    ...(property ? { property } : {}),
+    snippet: memoSnippet(memo.content),
+    ...(location ? { location } : {}),
+  };
+}
+
+export function currentMemosToListResponse(input: {
+  memos: MemoRow[];
+  user: UserRow;
+  attachmentsByMemo?: ReadonlyMap<string, AttachmentRow[]>;
+  nextPageToken?: string;
+}) {
+  return {
+    memos: input.memos.map((memo) =>
+      currentMemoToDto(memo, input.user, {
+        ...(input.attachmentsByMemo
+          ? { attachments: input.attachmentsByMemo.get(memo.id) ?? [] }
+          : {}),
+      }),
+    ),
+    ...(input.nextPageToken ? { nextPageToken: input.nextPageToken } : {}),
+  };
+}
+
+export function currentAttachmentToDto(attachment: AttachmentRow) {
+  return {
+    name: attachment.id,
+    createTime: attachment.createdAt,
+    filename: attachment.filename,
+    type: attachment.contentType ?? "application/octet-stream",
+    // Protobuf JSON encodes int64 as a decimal string.
+    size: String(attachment.size),
+    ...(attachment.memoId ? { memo: attachment.memoId } : {}),
+  };
+}
+
+export function currentAttachmentsToListResponse(
+  attachments: AttachmentRow[],
+  options: { nextPageToken?: string; totalSize?: number } = {},
+) {
+  return {
+    attachments: attachments.map(currentAttachmentToDto),
+    ...(options.nextPageToken ? { nextPageToken: options.nextPageToken } : {}),
+    ...(options.totalSize === undefined
+      ? {}
+      : { totalSize: options.totalSize }),
+  };
+}
+
+export function currentShareToDto(share: ShareRow) {
+  return {
+    name: `${share.memoId}/shares/${share.token}`,
+    createTime: share.createdAt,
+    ...(share.expiresAt ? { expireTime: share.expiresAt } : {}),
+  };
+}
+
+export function currentRelationToDto(
+  relation: CurrentMemoRelationRow,
+  memo: MemoRow,
+  relatedMemo: MemoRow,
+): CurrentMemoRelation {
+  return {
+    memo: {
+      name: memo.id,
+      snippet: memoSnippet(memo.content),
+    },
+    relatedMemo: {
+      name: relatedMemo.id,
+      snippet: memoSnippet(relatedMemo.content),
+    },
+    type: currentRelationType(relation.type),
+  };
+}
+
+export function currentUserToDto(user: UserRow, authUser?: AuthUserRow | null) {
+  return {
+    name: user.id,
+    role: user.role === "owner" ? "ADMIN" : "USER",
+    username: authUser?.username ?? user.id.replace(/^users\//, ""),
+    email: authUser?.email ?? user.email,
+    displayName: user.name,
+    ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
+    state: "NORMAL",
+    createTime: user.createdAt,
+    updateTime: user.updatedAt,
+  };
+}
+
+export function currentMemoState(
+  value: MemoRow["status"],
+): "STATE_UNSPECIFIED" | "NORMAL" | "ARCHIVED" {
+  // FlareMo keeps a separate trash state. Current Memos has only NORMAL and
+  // ARCHIVED in its public proto, so deleted rows are surfaced as ARCHIVED
+  // only when a caller explicitly asks for deleted rows.
+  return value === "normal" ? "NORMAL" : "ARCHIVED";
+}
+
+export function currentVisibility(
+  value: MemoRow["visibility"],
+): "VISIBILITY_UNSPECIFIED" | "PRIVATE" | "PROTECTED" | "PUBLIC" {
+  if (value === "private") return "PRIVATE";
+  if (value === "protected") return "PROTECTED";
+  return "PUBLIC";
+}
+
+export function currentRelationType(
+  value: "reference" | "comment",
+): "REFERENCE" | "COMMENT" {
+  return value === "comment" ? "COMMENT" : "REFERENCE";
+}
+
+export function legacyMemoState(
+  value: unknown,
+): "normal" | "archived" | "trashed" | "deleted" | undefined {
+  if (value === "NORMAL") return "normal";
+  if (value === "ARCHIVED") return "archived";
+  if (
+    value === "normal" ||
+    value === "archived" ||
+    value === "trashed" ||
+    value === "deleted"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+function currentProperty(value: unknown) {
+  if (!isRecord(value)) return undefined;
+  const property = {
+    ...(typeof value.title === "string" ? { title: value.title } : {}),
+    ...(typeof value.has_link === "boolean" ? { hasLink: value.has_link } : {}),
+    ...(typeof value.has_task_list === "boolean"
+      ? { hasTaskList: value.has_task_list }
+      : {}),
+    ...(typeof value.has_code === "boolean" ? { hasCode: value.has_code } : {}),
+    ...(typeof value.has_incomplete_tasks === "boolean"
+      ? { hasIncompleteTasks: value.has_incomplete_tasks }
+      : {}),
+  };
+  return Object.keys(property).length > 0 ? property : undefined;
+}
+
+function currentLocation(value: unknown) {
+  if (!isRecord(value)) return undefined;
+  const location = {
+    ...(typeof value.placeholder === "string"
+      ? { placeholder: value.placeholder }
+      : {}),
+    ...(typeof value.latitude === "number" ? { latitude: value.latitude } : {}),
+    ...(typeof value.longitude === "number"
+      ? { longitude: value.longitude }
+      : {}),
+  };
+  return Object.keys(location).length > 0 ? location : undefined;
+}
+
+function memoSnippet(content: string) {
+  const plain = content
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/[*`_>#~-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return plain.slice(0, 200);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/memos/src/index.ts
+++ b/packages/memos/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./adapter";
+export * from "./current-adapter";

--- a/tests/e2e/auth-flow.spec.ts
+++ b/tests/e2e/auth-flow.spec.ts
@@ -191,7 +191,10 @@ test("creates, uses, and revokes a Memos PAT while shares stay public", async ()
     expect(listedTokens).not.toContain(createdToken.token);
 
     const patMemoResponse = await patClient.post("/api/v1/memos", {
-      headers: { authorization: `Bearer ${createdToken.token}` },
+      headers: {
+        authorization: `Bearer ${createdToken.token}`,
+        "x-flaremo-wire": "legacy",
+      },
       data: { content: "E2E PAT memo" },
     });
     expect(patMemoResponse.status()).toBe(201);
@@ -203,13 +206,13 @@ test("creates, uses, and revokes a Memos PAT while shares stay public", async ()
     expect(patManagementResponse.status()).toBe(401);
 
     const memoResponse = await session.post("/api/v1/memos", {
-      headers: { origin: E2E_BASE_URL },
+      headers: { origin: E2E_BASE_URL, "x-flaremo-wire": "legacy" },
       data: { content: "E2E public share memo" },
     });
     expect(memoResponse.status()).toBe(201);
     const memo = (await memoResponse.json()) as { name: string };
     const shareResponse = await session.post(`/api/v1/${memo.name}/shares`, {
-      headers: { origin: E2E_BASE_URL },
+      headers: { origin: E2E_BASE_URL, "x-flaremo-wire": "legacy" },
       data: {},
     });
     expect(shareResponse.status()).toBe(201);
@@ -219,7 +222,9 @@ test("creates, uses, and revokes a Memos PAT while shares stay public", async ()
       `/api/public/shares/${share.token}`,
     );
     expect(anonymousShare.status()).toBe(200);
-    const anonymousPrivate = await anonymous.get("/api/v1/memos");
+    const anonymousPrivate = await anonymous.get("/api/v1/memos", {
+      headers: { "x-flaremo-wire": "legacy" },
+    });
     expect(anonymousPrivate.status()).toBe(401);
 
     const revokeResponse = await session.post(
@@ -229,7 +234,10 @@ test("creates, uses, and revokes a Memos PAT while shares stay public", async ()
     expect(revokeResponse.status()).toBe(200);
 
     const revokedPatResponse = await patClient.post("/api/v1/memos", {
-      headers: { authorization: `Bearer ${createdToken.token}` },
+      headers: {
+        authorization: `Bearer ${createdToken.token}`,
+        "x-flaremo-wire": "legacy",
+      },
       data: { content: "should be rejected" },
     });
     expect(revokedPatResponse.status()).toBe(401);

--- a/tests/e2e/memo-flow.spec.ts
+++ b/tests/e2e/memo-flow.spec.ts
@@ -5,6 +5,10 @@ const E2E_COOKIE_MUTATION_OPTIONS = {
   headers: { origin: E2E_BASE_URL },
 };
 
+const E2E_LEGACY_API_MUTATION_OPTIONS = {
+  headers: { origin: E2E_BASE_URL, "x-flaremo-wire": "legacy" },
+};
+
 test("creates a memo and filters it by tag", async ({ page }) => {
   const tag = `e2e${Date.now()}`;
   const content = `Playwright memo #${tag}`;
@@ -112,7 +116,7 @@ test("shows a memo submitted by an external agent in the timeline", async ({
 }) => {
   const marker = `Agent ingestion ${Date.now()}`;
   const response = await page.request.post("/api/v1/memos", {
-    ...E2E_COOKIE_MUTATION_OPTIONS,
+    ...E2E_LEGACY_API_MUTATION_OPTIONS,
     data: {
       content: `${marker} #telegram`,
       source: "telegram",
@@ -424,6 +428,7 @@ test("creates, follows, reads, and removes memo relations", async ({
 
   const contextResponse = await page.request.get(
     `/api/v1/${source.name}/relation-context`,
+    { headers: { "x-flaremo-wire": "legacy" } },
   );
   expect(contextResponse.ok()).toBe(true);
   expect(await contextResponse.json()).toMatchObject({ relations: [] });


### PR DESCRIPTION
Closes #40

## Summary
- add the current Memos-style camelCase/protobuf-JSON REST subset with Better Auth-backed auth facade and PAT resource paths
- keep the existing FlareMo snake_case wire behind explicit legacy negotiation
- add current adapters/contracts, standard errors, pagination/order/filter subset, nested relations/shares, attachments, and current OpenAPI
- add the stateless root `/mcp` Streamable HTTP MCP subset while preserving `/api/v1/mcp`
- keep the web app explicit on legacy wire until its internal DTOs are migrated, and document the compatibility boundary and unverified third-party clients

## Verification
- `pnpm format:check`
- `pnpm check`
- `pnpm test`
- `pnpm verify` (21 E2E tests passed)
- `pnpm deploy:dry-run`

## Compatibility boundary
This does not claim complete Memos Server parity. Full CEL, Connect/gRPC, SSE, native Memos JWT byte-level parity, comments/reactions/shortcuts, and real third-party client smoke tests remain future work.