### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,37 @@ FlareMo 使用 SemVer。每个 release 都要写清楚升级影响、Cloudflare 
 
 ## Unreleased
 
-Better Auth 原生认证基础版本。这个变更把 FlareMo 从“只依赖 Cloudflare Access”推进到应用层可独立认证，同时保留 Access 作为可选的迁移期和纵深防御边界。
+后续变更将在下一次 release 汇总。
+
+## v0.4.0
+
+Memos current 兼容与原生认证生态版本。这个版本把 FlareMo 从“有 Better Auth/PAT 基础的 Memos-compatible API”推进到默认 current camelCase REST、Better Auth-backed auth facade 和根 `/mcp` 无状态 Streamable HTTP MCP 子集，同时保留旧 wire 供已有客户端迁移。
 
 ### 已包含
 
 - 接入 Better Auth + D1/Drizzle adapter：用户名/密码、HttpOnly cookie session、一次性 owner bootstrap，并关闭正常公共 signup。
 - 保留既有 `users/owner`、memo、attachment、R2 object key 和 share token，通过 `auth_user_links` 做认证身份到业务用户的桥接。
-- 增加 `memos_pat_` Personal Access Token 基础：由 cookie session 创建，明文只在创建时返回一次，可以列出元数据和撤销；PAT 可用于当前受保护的 `/api/v1/*` 和旧式 `/api/v1/mcp` 子集。
+- 增加 `memos_pat_` Personal Access Token 基础：由 cookie session 创建，明文只在创建时返回一次，可以列出元数据和撤销；PAT 可用于 current `/api/v1/*`、旧式 `/api/v1/mcp` 和根 `/mcp` 子集。
 - 新增 `FLAREMO_PUBLIC_URL`、可选 `FLAREMO_TRUSTED_ORIGINS` 两个公开 Worker vars；`BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 必须通过 Wrangler secret 或 Cloudflare 控制台配置。
 - 增加按凭据区分的 Origin 安全契约：cookie session 的 `POST`、`PATCH`、`DELETE` 等状态变更必须携带并精确命中 allowlist；PAT 可以无 Origin，但携带 Origin 时也必须命中，否则返回 `403`。Access headers 不替代应用层 Origin 校验。
+- 默认 `/api/v1` 增加 current Memos camelCase / protobuf-JSON wire adapter，包括 current memo、attachment、relation、share、user、PAT DTO、current 大写枚举、有限 filter/order、分页、`updateMask`、nested relation/share 和标准错误。
+- 增加 Better Auth-backed current auth facade：`/api/v1/auth/me`、`signin`、`refresh`、`signout`。`accessToken` 是 opaque session-backed token，不是 Memos 原生 JWT。
+- 增加根 `/mcp` 无状态 JSON Streamable HTTP MCP 子集，支持 `initialize`、`notifications/initialized`、`tools/list` 和 `tools/call`；保留 `/api/v1/mcp` 旧式 JSON-RPC 工具名。
+- 增加 current OpenAPI 文档和显式 legacy wire negotiation；FlareMo Web 内部客户端明确选择 legacy wire，外部 `/api/v1` 调用默认选择 current wire。
+- 增加 current contracts、adapter、OpenAPI、MCP 和 Worker/E2E 测试，并记录第三方客户端仍需真实 smoke test 的兼容边界。
 
 ### Cloudflare、数据库与兼容影响
 
-- 新增 Better Auth 认证表 migration；发布前必须确认 D1 备份、恢复和演练覆盖 `auth_users`、`auth_sessions`、`auth_accounts`、`auth_verifications`、`auth_apikeys`、`auth_user_links` 和 `auth_bootstrap`。
+- 本版本不新增 D1 migration；已有 Better Auth 认证表仍必须包含在 D1 备份、恢复和演练范围内，包括 `auth_users`、`auth_sessions`、`auth_accounts`、`auth_verifications`、`auth_apikeys`、`auth_user_links` 和 `auth_bootstrap`。
 - 第一轮生产部署建议保留 Cloudflare Access。Access Service Token 只通过外层 policy，不自动成为 FlareMo 应用用户身份；启用 Access 时，机器请求仍需 FlareMo PAT。
-- 本变更只提供 PAT/Bearer authentication foundation，不承诺 Memos Server 完整 auth parity。真实 current camelCase wire adapter、auth facade、字段/错误翻译和 `/mcp` Streamable HTTP 由 Issue #40 追踪。
+- 本版本不承诺完整 Memos Server parity、完整 CEL、Connect/gRPC、SSE、Memos 原生 JWT 字节级 parity、comments/reactions/shortcuts 或第三方客户端已验证。完整兼容矩阵见 `docs/memos-compatibility.md`。
 
 ### 升级说明
 
 - 设置 `wrangler.jsonc` 中的 `FLAREMO_PUBLIC_URL`，并通过 `wrangler secret put` 配置两个 Better Auth secrets；不要把真实值写进仓库、release notes、issue、日志或聊天。
-- 应用 D1 migration 后，由部署者在生产 HTTPS 的 `/setup` 页面手动完成一次 owner bootstrap；bootstrap secret、用户名、邮箱和初始密码不进入 shell、Agent 输出、release notes、Git 或日志。
+- 本版本不需要新的 D1 migration；尚未 bootstrap 的实例仍需由部署者在生产 HTTPS 的 `/setup` 页面手动完成一次 owner bootstrap。bootstrap secret、用户名、邮箱和初始密码不进入 shell、Agent 输出、release notes、Git 或日志。
 - 验证 cookie session、密码修改后的其他 session 撤销、PAT 创建/访问/撤销、公开分享匿名访问和无凭据 `401`；同时验证 cookie mutation 的 trusted Origin、无 Origin 的 PAT，以及不可信 Origin 的 `403`。
-- 在认证与备份脚本完成远端演练前，不要关闭 Access，也不要把本次变更宣称为完整生产认证/恢复验收。
+- 在认证与备份脚本完成远端演练前，不要关闭 Access，也不要把本次变更宣称为完整生产认证/恢复验收。生产入口仍可保留 Access 作为外层防线；Better Auth 是应用层身份来源。
 
 ## v0.3.0
 

--- a/apps/telegram-bot/package.json
+++ b/apps/telegram-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/telegram-bot-example",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flaremo/web",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/worker",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -373,7 +373,7 @@ describe("FlareMo Worker API", () => {
     expect(health).toMatchObject({
       ok: true,
       product: "FlareMo",
-      version: "0.3.0",
+      version: "0.4.0",
       update_repository: "example/flaremo",
       update_workflow_url:
         "https://github.com/example/flaremo/actions/workflows/flaremo-update.yml",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaremo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.7.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/contracts",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/src/openapi.ts
+++ b/packages/contracts/src/openapi.ts
@@ -21,7 +21,7 @@ import {
   updateMemoSchema,
 } from "./memos";
 
-export const FLAREMO_API_VERSION = "0.3.0";
+export const FLAREMO_API_VERSION = "0.4.0";
 
 type JsonSchema = Record<string, unknown>;
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/db",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/domain",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/memos/package.json
+++ b/packages/memos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaremo/memos",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/tests/e2e/memo-flow.spec.ts
+++ b/tests/e2e/memo-flow.spec.ts
@@ -367,12 +367,12 @@ test("shows the installed version and safe update fallback", async ({
     name: /system update|系统更新/i,
   });
   await expect(updateButton).toBeVisible();
-  await expect(updateButton).toContainText("v0.3.0");
+  await expect(updateButton).toContainText("v0.4.0");
   await updateButton.click();
 
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
-  await expect(dialog).toContainText("v0.3.0");
+  await expect(dialog).toContainText("v0.4.0");
   await expect(
     dialog.getByRole("link", { name: /update guide|升级指南/i }),
   ).toHaveAttribute("href", /docs\/update\.md$/);


### PR DESCRIPTION
## Summary
- promote the current Memos compatibility and Better Auth facade work to the v0.4.0 release line
- synchronize root, app, package, and API versions to 0.4.0
- replace the stale Unreleased compatibility notes with an accurate v0.4.0 changelog entry
- update health and E2E version contracts

## Verification
- `pnpm verify` (21 E2E tests passed)
- `pnpm deploy:dry-run`

## Release
After squash merge, run `pnpm release v0.4.0` to rerun the release gate, create the tag, and publish the GitHub Release.