### PR TITLE
fix(auth): harden native recovery and origin boundaries

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,6 +1,7 @@
 # 本地开发变量示例。
 # 复制为 .dev.vars 后只填入本机值；不要提交 .dev.vars，也不要把生产凭据写进仓库。
-# BETTER_AUTH_SECRET 和 FLAREMO_BOOTSTRAP_SECRET 必须使用你自己生成的本地值。
+# BETTER_AUTH_SECRET、FLAREMO_BOOTSTRAP_SECRET 必须使用你自己生成的本地值。
+# FLAREMO_RECOVERY_SECRET 只在本地演练 break-glass recovery 时临时设置。
 
 FLAREMO_SINGLE_USER_EMAIL=owner@example.com
 FLAREMO_SINGLE_USER_NAME=FlareMo Owner
@@ -8,3 +9,4 @@ FLAREMO_PUBLIC_URL=http://localhost:8787
 FLAREMO_TRUSTED_ORIGINS=
 BETTER_AUTH_SECRET=<local-secret-at-least-32-characters>
 FLAREMO_BOOTSTRAP_SECRET=<local-one-time-bootstrap-secret>
+FLAREMO_RECOVERY_SECRET=<local-break-glass-recovery-secret>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ FlareMo 使用 SemVer。每个 release 都要写清楚升级影响、Cloudflare 
 
 ## Unreleased
 
-后续变更将在下一次 release 汇总。
+### 鉴权安全收口
+
+- Better Auth 的危险 cookie 请求（包括直接 Better Auth endpoint、bootstrap/recovery 和 current Memos signin/refresh）统一要求携带并精确匹配 trusted Origin；缺失或不可信 Origin 返回 `403`。
+- 增加独立、默认关闭的 `FLAREMO_RECOVERY_SECRET` operator recovery：只重置已完成 bootstrap 的既有 owner，复用 Better Auth 的一次性 reset/password hashing/session 撤销流程，并撤销所有 `memos_pat_`；不创建第二个 owner。
+- current Memos facade 的 PAT signout 现在会验证 PAT，随机/无效 PAT 不再得到假成功响应；Access headers 仍不能单独成为应用身份。
+- 明确记录当前没有 email provider，Better Auth 忘记密码邮件流程保持关闭；恢复能力与普通“知道当前密码时修改密码”不再混淆。
 
 ## v0.4.0
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ FlareMo 的应用层认证由 Better Auth 提供。第一次部署时由部署�
 - PAT 只在创建响应中显示一次，可以列出元数据并撤销；PAT 不能进入账户管理接口。
 - cookie session 的 `POST`、`PATCH`、`DELETE` 等状态变更必须带 `Origin`，并精确匹配 `FLAREMO_PUBLIC_URL` 或 `FLAREMO_TRUSTED_ORIGINS`，否则返回 `403`；PAT 请求可以无 Origin，但如果携带 Origin 也必须匹配同一 allowlist，否则返回 `403`。不使用 wildcard、`Referer` 或 Access headers 替代 Origin。
 - Cloudflare Access 是可选外层。启用时，Access Service Token 只通过外层 policy，仍必须同时提供 Better Auth cookie 或 PAT。
+- 当前没有邮件 provider，因此 Better Auth 的忘记密码邮件流程默认关闭；已知当前密码时可在账户页修改。已完成 bootstrap 的实例只在显式配置独立 recovery secret 时提供 operator break-glass recovery，成功后会撤销现有 session/PAT，不能把它当作普通用户自助找回。
 - 公开分享仍使用 FlareMo share token、过期时间和 memo 状态校验，不把公开分享混入私有登录。
 
 生产部署前在 `wrangler.jsonc` 填入不带 path/query/hash 的 `FLAREMO_PUBLIC_URL`，并交互式配置 secrets：

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,10 +24,11 @@
 - FlareMo 应用层使用 Better Auth。浏览器会话使用 `HttpOnly`、`SameSite=Lax` 的 cookie；认证身份与既有 FlareMo `users/owner` 通过专用映射表关联。
 - 当前只开放一次性 owner bootstrap，不开放公共 signup。bootstrap 需要部署者配置的 `FLAREMO_BOOTSTRAP_SECRET`，成功后会被 D1 状态锁定；失败状态必须显式恢复，不能自动创建第二个 owner。
 - 密码由 Better Auth 处理，当前要求长度为 12–128 个字符。初始密码只通过 bootstrap 请求提交，不写入代码、文档、migration、日志或聊天。
+- 当前默认没有 email provider，因此“忘记密码”邮件流程保持关闭；已知当前密码时可通过 Better Auth 修改。已完成 bootstrap 的单用户实例可以在明确配置独立 `FLAREMO_RECOVERY_SECRET` 的短窗口内执行 break-glass recovery：它保留原 owner mapping、复用 Better Auth reset-password 流程、撤销所有 session 和 `memos_pat_`，成功后必须立即轮换或删除该 secret。
 - 脚本、MCP 和 Memos-compatible 客户端使用由已登录浏览器账户创建的 `memos_pat_` Personal Access Token。PAT 只在创建响应中返回一次，D1 只保存不可逆校验值；账户页可以列出和撤销 PAT。
 - Cloudflare Access 是可选的外层防线，生产迁移期建议保留。启用 Access 时，客户端必须同时通过 Access policy 和 FlareMo 应用层认证；Access Service Token 本身不等于 FlareMo 用户 session，也不能单独访问私有 API。
 - 公开分享路径可以 bypass Access，但分享内容仍由 FlareMo 的 share token、过期时间和 memo 状态校验。公开分享不接受浏览器 session 或 PAT 作为分享授权的替代物。
-- `BETTER_AUTH_SECRET`、`FLAREMO_BOOTSTRAP_SECRET` 不得放入 `wrangler.jsonc`、`.dev.vars.example` 的真实值、Git、issue、PR、日志或聊天；生产环境应使用 `wrangler secret put` 或 Cloudflare 控制台配置。
+- `BETTER_AUTH_SECRET`、`FLAREMO_BOOTSTRAP_SECRET` 和可选的 `FLAREMO_RECOVERY_SECRET` 不得放入 `wrangler.jsonc`、`.dev.vars.example` 的真实值、Git、issue、PR、日志或聊天；生产环境应使用 `wrangler secret put` 或 Cloudflare 控制台配置。
 
 ### Origin 与凭据类型
 

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -794,6 +794,7 @@ async function bootstrapAndSignIn() {
       headers: {
         "content-type": "application/json",
         "x-flaremo-bootstrap-secret": TEST_BOOTSTRAP_SECRET,
+        origin: "http://flaremo.test",
       },
       body: JSON.stringify({
         username: "owner",
@@ -809,7 +810,10 @@ async function bootstrapAndSignIn() {
   const signIn = await app.fetch(
     new Request("http://flaremo.test/api/auth/sign-in/username", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+      },
       body: JSON.stringify({
         username: "owner",
         password: TEST_PASSWORD,

--- a/apps/worker/src/auth.test.ts
+++ b/apps/worker/src/auth.test.ts
@@ -12,6 +12,8 @@ const TEST_AUTH_SECRET =
   "test-better-auth-secret-that-is-never-used-in-production";
 const TEST_BOOTSTRAP_SECRET =
   "test-bootstrap-secret-that-is-never-used-in-production";
+const TEST_RECOVERY_SECRET =
+  "test-recovery-secret-that-is-never-used-in-production";
 const INITIAL_PASSWORD = "test-password-not-for-production-123";
 const UPDATED_PASSWORD = "updated-password-not-for-production-456";
 
@@ -40,7 +42,10 @@ describe("FlareMo native authentication", () => {
 
     const missingSecret = await fetchRaw("/api/auth/flaremo/bootstrap", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+      },
       body: JSON.stringify(bootstrapInput()),
     });
     expect(missingSecret.status).toBe(403);
@@ -50,6 +55,7 @@ describe("FlareMo native authentication", () => {
       headers: {
         "content-type": "application/json",
         "x-flaremo-bootstrap-secret": "wrong-bootstrap-secret",
+        origin: "http://flaremo.test",
       },
       body: JSON.stringify(bootstrapInput()),
     });
@@ -60,6 +66,7 @@ describe("FlareMo native authentication", () => {
       headers: {
         "content-type": "application/json",
         "x-flaremo-bootstrap-secret": TEST_BOOTSTRAP_SECRET,
+        origin: "http://flaremo.test",
       },
       body: JSON.stringify(bootstrapInput()),
     });
@@ -92,6 +99,7 @@ describe("FlareMo native authentication", () => {
       headers: {
         "content-type": "application/json",
         "x-flaremo-bootstrap-secret": TEST_BOOTSTRAP_SECRET,
+        origin: "http://flaremo.test",
       },
       body: JSON.stringify({
         ...bootstrapInput(),
@@ -109,6 +117,7 @@ describe("FlareMo native authentication", () => {
         headers: {
           "content-type": "application/json",
           "x-flaremo-bootstrap-secret": TEST_BOOTSTRAP_SECRET,
+          origin: "http://flaremo.test",
         },
         body: JSON.stringify(bootstrapInput()),
       });
@@ -129,6 +138,117 @@ describe("FlareMo native authentication", () => {
       .first<{ count: number }>();
     expect(authOwners?.count).toBe(1);
     expect(ownerLinks?.count).toBe(1);
+  });
+
+  it("requires an exact Origin for cookie auth mutations and keeps Access outside app identity", async () => {
+    await bootstrapOwner();
+
+    const missingOrigin = await fetchRaw("/api/auth/sign-in/username", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ username: "owner", password: INITIAL_PASSWORD }),
+    });
+    expect(missingOrigin.status).toBe(403);
+
+    const untrustedOrigin = await fetchRaw("/api/auth/sign-in/username", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://untrusted.example",
+      },
+      body: JSON.stringify({ username: "owner", password: INITIAL_PASSWORD }),
+    });
+    expect(untrustedOrigin.status).toBe(403);
+
+    const trustedOrigin = await signIn("owner", INITIAL_PASSWORD);
+    expect(trustedOrigin.response.status).toBe(200);
+
+    const activeSession = await db
+      .prepare(
+        "SELECT token FROM auth_sessions ORDER BY created_at DESC LIMIT 1",
+      )
+      .first<{ token: string }>();
+    expect(activeSession?.token).toBeTruthy();
+    await db
+      .prepare("UPDATE auth_sessions SET expires_at = ? WHERE token = ?")
+      .bind(Date.now() - 1_000, activeSession?.token)
+      .run();
+    const expiredSession = await fetchRaw("/api/v1/memos", {
+      headers: { authorization: `Bearer ${activeSession?.token}` },
+    });
+    expect(expiredSession.status).toBe(401);
+
+    const signupAfterBootstrap = await fetchRaw("/api/auth/sign-up/email", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+      },
+      body: JSON.stringify({
+        email: "second@example.com",
+        name: "Second",
+        password: INITIAL_PASSWORD,
+        username: "second",
+        displayUsername: "second",
+      }),
+    });
+    expect(signupAfterBootstrap.status).toBeGreaterThanOrEqual(400);
+
+    const accessOnly = await fetchRaw("/api/app/memos", {
+      headers: {
+        "cf-access-client-id": "access-only-id",
+        "cf-access-client-secret": "access-only-secret",
+      },
+    });
+    expect(accessOnly.status).toBe(401);
+  });
+
+  it("recovers the existing owner through Better Auth and revokes sessions and PATs", async () => {
+    await bootstrapOwner();
+    const firstSession = await signIn("owner", INITIAL_PASSWORD);
+    const secondSession = await signIn("owner", INITIAL_PASSWORD);
+    expect(firstSession.response.status).toBe(200);
+    expect(secondSession.response.status).toBe(200);
+
+    const createdPat = await fetchRaw(
+      "/api/app/account/personal-access-tokens",
+      {
+        method: "POST",
+        headers: authenticatedJsonHeaders(firstSession.cookie),
+        body: JSON.stringify({ name: "recovery test", expires_in_days: 30 }),
+      },
+    );
+    expect(createdPat.status).toBe(201);
+    const pat = await json<{ token: string }>(createdPat);
+
+    const recovery = await fetchRaw("/api/auth/flaremo/recover", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-flaremo-recovery-secret": TEST_RECOVERY_SECRET,
+        origin: "http://flaremo.test",
+      },
+      body: JSON.stringify({ new_password: UPDATED_PASSWORD }),
+    });
+    expect(recovery.status).toBe(200);
+    expect(await json(recovery)).toEqual({ ok: true });
+
+    for (const cookie of [firstSession.cookie, secondSession.cookie]) {
+      const staleSession = await fetchRaw("/api/app/memos", {
+        headers: { cookie },
+      });
+      expect(staleSession.status).toBe(401);
+    }
+
+    const stalePat = await fetchRaw("/api/v1/memos", {
+      headers: { authorization: `Bearer ${pat.token}` },
+    });
+    expect(stalePat.status).toBe(401);
+
+    const oldPassword = await signIn("owner", INITIAL_PASSWORD);
+    expect(oldPassword.response.ok).toBe(false);
+    const recoveredPassword = await signIn("owner", UPDATED_PASSWORD);
+    expect(recoveredPassword.response.status).toBe(200);
   });
 
   it("uses HttpOnly cookie sessions, supports account changes, and accepts revocable Memos PATs", async () => {
@@ -331,6 +451,7 @@ async function bootstrapOwner() {
     headers: {
       "content-type": "application/json",
       "x-flaremo-bootstrap-secret": TEST_BOOTSTRAP_SECRET,
+      origin: "http://flaremo.test",
     },
     body: JSON.stringify(bootstrapInput()),
   });
@@ -349,7 +470,10 @@ function bootstrapInput() {
 async function signIn(username: string, password: string) {
   const response = await fetchRaw("/api/auth/sign-in/username", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      origin: "http://flaremo.test",
+    },
     body: JSON.stringify({ username, password }),
   });
   return {
@@ -443,6 +567,7 @@ async function createTestRuntime() {
       FLAREMO_PUBLIC_URL: "http://flaremo.test",
       BETTER_AUTH_SECRET: TEST_AUTH_SECRET,
       FLAREMO_BOOTSTRAP_SECRET: TEST_BOOTSTRAP_SECRET,
+      FLAREMO_RECOVERY_SECRET: TEST_RECOVERY_SECRET,
     } as Env,
   };
 }

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -55,6 +55,14 @@ export type MemosApiKey = {
 
 export type FlareMoAuth = {
   handler: (request: Request) => Response | Promise<Response>;
+  /**
+   * Reset a password through Better Auth's own reset-password endpoint. This
+   * is only used by the explicitly configured operator recovery route.
+   */
+  operatorResetPassword: (input: {
+    authUserId: string;
+    newPassword: string;
+  }) => Promise<void>;
   api: {
     createApiKey: (input: {
       body: {
@@ -125,7 +133,7 @@ export function createFlareMoAuth(
   const publicUrl = getPublicUrl(env);
   const isSecureDeployment = new URL(publicUrl).protocol === "https:";
 
-  return betterAuth({
+  const auth = betterAuth({
     appName: "FlareMo",
     baseURL: publicUrl,
     basePath: "/api/auth",
@@ -141,6 +149,9 @@ export function createFlareMoAuth(
       minPasswordLength: 12,
       maxPasswordLength: 128,
       autoSignIn: false,
+      // Password resets must invalidate every session, including sessions
+      // the operator cannot inspect in a browser.
+      revokeSessionsOnPasswordReset: true,
     },
     rateLimit: {
       // Local D1/Miniflare does not provide Cloudflare's trusted client-IP
@@ -190,6 +201,39 @@ export function createFlareMoAuth(
       }),
     ],
   });
+
+  return {
+    ...auth,
+    operatorResetPassword: async ({ authUserId, newPassword }) => {
+      // Better Auth's resetPassword API owns password validation, hashing,
+      // verification consumption, reset callbacks, and session revocation.
+      // Create only a short-lived, in-memory-referenced verification record so
+      // the operator path enters that same official flow without touching
+      // auth_accounts.password or exposing a reusable reset token.
+      const authContext = await auth.$context;
+      const token = crypto.randomUUID();
+      const identifier = `reset-password:${token}`;
+      await authContext.internalAdapter.createVerificationValue({
+        identifier,
+        value: authUserId,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+      try {
+        const result = await auth.api.resetPassword({
+          body: { newPassword, token },
+        });
+        if (!result.status) {
+          throw new Error("Better Auth rejected the password reset.");
+        }
+      } catch (error) {
+        await authContext.internalAdapter
+          .deleteVerificationByIdentifier(identifier)
+          .catch(() => undefined);
+        throw error;
+      }
+    },
+  };
 }
 
 export function getPublicUrl(env: FlareMoEnv): string {
@@ -261,6 +305,17 @@ export function getTrustedOrigins(
 export function getBootstrapSecret(env: FlareMoEnv): string | null {
   const value = env.FLAREMO_BOOTSTRAP_SECRET?.trim();
   return value || null;
+}
+
+/**
+ * Break-glass recovery is intentionally separate from the one-time bootstrap
+ * secret. It should normally be absent and be configured only for an
+ * operator-approved recovery, then rotated or removed immediately afterward.
+ */
+export function getRecoverySecret(env: FlareMoEnv): string | null {
+  const value = env.FLAREMO_RECOVERY_SECRET?.trim();
+  if (!value || value.length < 32) return null;
+  return value;
 }
 
 function getRequiredBetterAuthSecret(env: FlareMoEnv): string {

--- a/apps/worker/src/context.ts
+++ b/apps/worker/src/context.ts
@@ -101,7 +101,7 @@ export async function getBrowserRequestContext(
   };
 }
 
-function assertTrustedCookieMutation(c: Context<HonoBindings>) {
+export function assertTrustedCookieMutation(c: Context<HonoBindings>) {
   if (!isUnsafeMethod(c.req.method)) return;
 
   const origin = c.req.header("origin");

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -1,6 +1,7 @@
 export type FlareMoEnv = Env & {
   BETTER_AUTH_SECRET?: string;
   FLAREMO_BOOTSTRAP_SECRET?: string;
+  FLAREMO_RECOVERY_SECRET?: string;
   FLAREMO_PUBLIC_URL?: string;
   FLAREMO_TRUSTED_ORIGINS?: string;
 };

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -10,8 +10,13 @@ import {
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createFlareMoAuth, getTrustedOrigins } from "./auth";
-import { getRequestContext, type HonoBindings } from "./context";
+import {
+  assertTrustedCookieMutation,
+  getRequestContext,
+  type HonoBindings,
+} from "./context";
 import type { FlareMoEnv } from "./env";
+import { jsonError } from "./http";
 import { accountApi } from "./routes/account-api";
 import { appApi } from "./routes/app-api";
 import { authApi } from "./routes/auth-api";
@@ -65,6 +70,19 @@ app.use(
     allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
   }),
 );
+
+// Better Auth's own handler also mutates the browser session. Keep its
+// endpoints under the same exact-origin contract as the application routes;
+// the handler's trustedOrigins setting is not a substitute for requiring an
+// Origin header on unsafe cookie requests.
+app.use("/api/auth/*", async (c, next) => {
+  try {
+    assertTrustedCookieMutation(c);
+    return await next();
+  } catch (error) {
+    return jsonError(c, error);
+  }
+});
 
 app.route("/api/auth/flaremo", authApi);
 app.all("/api/auth/*", (c) => createFlareMoAuth(c.env).handler(c.req.raw));

--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -503,11 +503,30 @@ describe("Memos-compatible API contract", () => {
       info: { title: "FlareMo Memos-compatible API" },
     });
 
-    const signInResponse = await fetchCurrent(
+    const missingOriginSignIn = await fetchCurrent(
       "http://flaremo.test/api/v1/auth/signin",
       {
         method: "POST",
         headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          passwordCredentials: {
+            username: "owner",
+            password: TEST_PASSWORD,
+          },
+        }),
+      },
+      { authenticated: false },
+    );
+    expect(missingOriginSignIn.status).toBe(403);
+
+    const signInResponse = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/signin",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
         body: JSON.stringify({
           passwordCredentials: {
             username: "owner",
@@ -738,9 +757,29 @@ describe("Memos-compatible API contract", () => {
     );
     expect(pat.token).toMatch(/^memos_pat_/);
 
+    const invalidPatSignout = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/signout",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer memos_pat_not-a-real-key" },
+      },
+      { authenticated: false },
+    );
+    expect(invalidPatSignout.status).toBe(401);
+
+    const validPatSignout = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/signout",
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${pat.token}` },
+      },
+      { authenticated: false },
+    );
+    expect(validPatSignout.status).toBe(200);
+
     const patList = await fetchCurrent(
       "http://flaremo.test/api/v1/users/owner/personalAccessTokens",
-      { headers: { authorization: `Bearer ${pat.token}` } },
+      { headers: bearer },
     );
     expect(patList.status).toBe(200);
     expect(await patList.json()).toMatchObject({
@@ -750,6 +789,13 @@ describe("Memos-compatible API contract", () => {
         }),
       ],
     });
+
+    const patManagementWithPat = await fetchCurrent(
+      "http://flaremo.test/api/v1/users/owner/personalAccessTokens",
+      { headers: { authorization: `Bearer ${pat.token}` } },
+      { authenticated: false },
+    );
+    expect(patManagementWithPat.status).toBe(401);
 
     const mcpHeaders = {
       authorization: `Bearer ${pat.token}`,
@@ -883,6 +929,7 @@ async function bootstrapAndSignIn() {
       headers: {
         "content-type": "application/json",
         "x-flaremo-bootstrap-secret": TEST_BOOTSTRAP_SECRET,
+        origin: "http://flaremo.test",
       },
       body: JSON.stringify({
         username: "owner",
@@ -898,7 +945,10 @@ async function bootstrapAndSignIn() {
   const signIn = await app.fetch(
     new Request("http://flaremo.test/api/auth/sign-in/username", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+      },
       body: JSON.stringify({
         username: "owner",
         password: TEST_PASSWORD,

--- a/apps/worker/src/routes/auth-api.ts
+++ b/apps/worker/src/routes/auth-api.ts
@@ -3,12 +3,18 @@ import {
   claimOwnerBootstrap,
   completeOwnerBootstrap,
   getAuthBootstrapStatus,
+  getOwnerAuthUserId,
+  listMemosPersonalAccessTokens,
   markOwnerBootstrapRecoveryRequired,
 } from "@flaremo/domain";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-import { createFlareMoAuth, getBootstrapSecret } from "../auth";
+import {
+  createFlareMoAuth,
+  getBootstrapSecret,
+  getRecoverySecret,
+} from "../auth";
 import type { HonoBindings } from "../context";
 import { jsonError } from "../http";
 
@@ -27,6 +33,10 @@ const bootstrapSchema = z.object({
   name: z.string().trim().min(1).max(80),
   email: z.string().trim().email().max(320),
   password: z.string().min(12).max(128),
+});
+
+const operatorRecoverySchema = z.object({
+  new_password: z.string().min(12).max(128),
 });
 
 authApi.get("/bootstrap/status", async (c) => {
@@ -137,6 +147,92 @@ authApi.post("/bootstrap", zValidator("json", bootstrapSchema), async (c) => {
     );
   }
 });
+
+/**
+ * Break-glass recovery for an already completed single-user instance.
+ *
+ * This is deliberately not a public "forgot password" flow: no email
+ * provider is configured yet, and the endpoint is disabled unless a separate
+ * recovery secret is explicitly present. It preserves the existing owner
+ * mapping and enters Better Auth's own one-time reset/password hashing flow.
+ * Rotate or remove FLAREMO_RECOVERY_SECRET immediately after use.
+ */
+authApi.post(
+  "/recover",
+  zValidator("json", operatorRecoverySchema),
+  async (c) => {
+    const recoverySecret = getRecoverySecret(c.env);
+    if (!recoverySecret) {
+      return c.json(
+        { error: { message: "Operator recovery is not configured." } },
+        503,
+      );
+    }
+
+    const suppliedSecret = c.req.header("x-flaremo-recovery-secret");
+    if (!(await secretsMatch(suppliedSecret, recoverySecret))) {
+      return c.json(
+        { error: { message: "Operator recovery is not authorized." } },
+        403,
+      );
+    }
+
+    const db = createDb(c.env.DB);
+    const authUserId = await getOwnerAuthUserId(db);
+    if (!authUserId) {
+      return c.json(
+        {
+          error: {
+            message:
+              "Operator recovery requires a completed single-user bootstrap.",
+          },
+        },
+        409,
+      );
+    }
+
+    const input = c.req.valid("json");
+    try {
+      const auth = createFlareMoAuth(c.env, db);
+      // Password reset invalidates browser sessions through Better Auth. PATs
+      // are a separate credential class, so revoke every existing Memos PAT
+      // before changing the password as well.
+      for (const token of await listMemosPersonalAccessTokens(db, authUserId)) {
+        if (!token.enabled) continue;
+        await auth.api.updateApiKey({
+          body: {
+            configId: "memos",
+            keyId: token.id,
+            userId: authUserId,
+            enabled: false,
+          },
+        });
+      }
+      await auth.operatorResetPassword({
+        authUserId,
+        newPassword: input.new_password,
+      });
+      console.log(
+        JSON.stringify({
+          level: "info",
+          message: "FlareMo operator password recovery completed",
+        }),
+      );
+      return c.json({ ok: true });
+    } catch {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          message: "FlareMo operator password recovery failed",
+        }),
+      );
+      return c.json(
+        { error: { message: "Operator recovery could not complete." } },
+        500,
+      );
+    }
+  },
+);
 
 async function secretsMatch(
   supplied: string | undefined,

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -42,7 +42,11 @@ import {
   MAX_ATTACHMENT_BYTES,
 } from "../attachment-http";
 import { createFlareMoAuth } from "../auth";
-import { getRequestContext, type HonoBindings } from "../context";
+import {
+  assertTrustedCookieMutation,
+  getRequestContext,
+  type HonoBindings,
+} from "../context";
 
 export const memosCurrentApi = new Hono<HonoBindings>();
 
@@ -156,6 +160,10 @@ memosCurrentApi.get("/auth/me", async (c, next) => {
 memosCurrentApi.post("/auth/signin", async (c, next) => {
   if (isLegacyWireRequest(c)) return next();
   try {
+    // This endpoint creates a browser cookie as well as returning the opaque
+    // session-backed access token. Treat it as a cookie mutation even when a
+    // Memos-compatible client chooses to use the bearer token afterward.
+    assertTrustedCookieMutation(c);
     const credentials = currentSigninSchema.parse(
       await c.req.json(),
     ).passwordCredentials;
@@ -219,6 +227,7 @@ memosCurrentApi.post("/auth/refresh", async (c, next) => {
       });
     }
 
+    if (!authorization) assertTrustedCookieMutation(c);
     const authContext = await createAuthContext(c);
     const result = await authContext.auth.api.getSession({
       headers: c.req.raw.headers,
@@ -240,10 +249,14 @@ memosCurrentApi.post("/auth/signout", async (c, next) => {
     const authorization = c.req.header("authorization");
     if (authorization) {
       const token = parseBearerToken(authorization);
-      if (!token.startsWith("memos_pat_")) {
-        const context = await getRequestContext(c);
-        await revokeAuthSessionByToken(context.db, token);
+      if (token.startsWith("memos_pat_")) {
+        // A PAT does not have a browser session to clear, but it still must be
+        // valid. Do not return success for arbitrary bearer strings.
+        await getRequestContext(c);
+        return c.body(null, 200);
       }
+      const context = await getRequestContext(c);
+      await revokeAuthSessionByToken(context.db, token);
       return c.body(null, 200);
     }
 
@@ -688,6 +701,7 @@ memosCurrentApi.get("/users/:user/personalAccessTokens", async (c, next) => {
   if (isLegacyWireRequest(c)) return next();
   try {
     const context = await getRequestContext(c);
+    assertSessionCredential(context);
     assertCurrentUserPath(c.req.param("user"), context.user.id);
     const tokens = await listMemosPersonalAccessTokens(
       context.db,
@@ -707,6 +721,7 @@ memosCurrentApi.post("/users/:user/personalAccessTokens", async (c, next) => {
   if (isLegacyWireRequest(c)) return next();
   try {
     const context = await getRequestContext(c);
+    assertSessionCredential(context);
     assertCurrentUserPath(c.req.param("user"), context.user.id);
     const body = currentPatBodySchema.parse(await c.req.json());
     const auth = createFlareMoAuth(c.env, context.db);
@@ -736,6 +751,7 @@ memosCurrentApi.delete(
     if (isLegacyWireRequest(c)) return next();
     try {
       const context = await getRequestContext(c);
+      assertSessionCredential(context);
       assertCurrentUserPath(c.req.param("user"), context.user.id);
       const tokenId = c.req.param("token").split("/").at(-1) ?? "";
       const existing = await getMemosPersonalAccessToken(context.db, {
@@ -823,6 +839,15 @@ async function currentUserForContext(context: {
 async function createAuthContext(c: Parameters<typeof getRequestContext>[0]) {
   const db = createDb(c.env.DB);
   return { db, auth: createFlareMoAuth(c.env, db) };
+}
+
+function assertSessionCredential(
+  context: Awaited<ReturnType<typeof getRequestContext>>,
+) {
+  // PATs authorize memo data, but a credential-management endpoint must not
+  // let a leaked PAT mint or revoke additional PATs. Cookie sessions and the
+  // opaque Better Auth session bearer returned by the auth facade are allowed.
+  if (context.credential === "pat") throw new UnauthorizedCurrentError();
 }
 
 function currentListQuery(c: Parameters<typeof getRequestContext>[0]) {

--- a/docs/agent-deploy.md
+++ b/docs/agent-deploy.md
@@ -9,7 +9,7 @@
 - Wrangler 已登录目标 Cloudflare 账号。
 - `wrangler.jsonc` 里的 D1、R2 binding 指向目标资源。
 - `wrangler.jsonc` 的 `FLAREMO_PUBLIC_URL` 已设置为生产 canonical origin；需要时设置 `FLAREMO_TRUSTED_ORIGINS`。
-- `BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 已通过 Wrangler secret 或 Cloudflare 控制台配置。Agent 不得要求用户把 secret、密码、cookie 或 PAT 粘贴到聊天中。
+- `BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 已通过 Wrangler secret 或 Cloudflare 控制台配置。`FLAREMO_RECOVERY_SECRET` 只在明确批准的 break-glass recovery 窗口临时配置。Agent 不得要求用户把 secret、密码、cookie 或 PAT 粘贴到聊天中。
 - `FLAREMO_SINGLE_USER_EMAIL` 和 `FLAREMO_SINGLE_USER_NAME` 只是既有 `users/owner` domain metadata 的 legacy 公开变量；它们不是 Better Auth 登录身份、用户名、密码或 bootstrap 输入。初始认证身份以部署者在生产 `/setup` 页面提交的值为准。
 - Cloudflare Access 可以作为可选外层防线，但不替代 FlareMo 应用层认证。
 
@@ -52,6 +52,8 @@ pnpm deploy:dry-run
 ```bash
 pnpm exec wrangler secret put BETTER_AUTH_SECRET --config ./wrangler.jsonc
 pnpm exec wrangler secret put FLAREMO_BOOTSTRAP_SECRET --config ./wrangler.jsonc
+# 仅在批准的 operator recovery 窗口临时执行；成功后立即 rotate/delete。
+pnpm exec wrangler secret put FLAREMO_RECOVERY_SECRET --config ./wrangler.jsonc
 ```
 
 Wrangler secret 不提供安全的值回读路径。Agent 只检查配置后的 bootstrap status，不得要求用户把 secret 重新粘贴、打印或通过命令行转交。
@@ -78,7 +80,7 @@ curl "$FLAREMO_URL/api/auth/flaremo/bootstrap/status"
 
 首次安装必须由部署者在浏览器打开 `https://<your-flaremo-origin>/setup`，并在生产 HTTPS 页面手动输入 `FLAREMO_BOOTSTRAP_SECRET`、初始用户名、显示名、邮箱和 12–128 个字符的初始密码。如果启用了 Cloudflare Access，先通过外层 policy 再打开 `/setup`。Agent 不得要求用户把这些值粘贴到聊天、命令行、shell history、issue、日志或 Agent 输出，也不得代用户调用 bootstrap endpoint；部署者完成页面提交后，Agent 只能检查 bootstrap status 和登录结果。
 
-bootstrap endpoint 只保留给明确批准的受控恢复/自动化流程；本 runbook 不提供把 secret 或密码放进环境变量、命令行参数或非交互 `curl` 的示例。
+bootstrap endpoint 只保留给明确批准的受控初始化流程；本 runbook 不提供把 secret 或密码放进环境变量、命令行参数或非交互 `curl` 的示例。已完成 bootstrap 后的密码破窗恢复使用单独的 `FLAREMO_RECOVERY_SECRET`，重置现有 owner、撤销全部 session/PAT，不创建第二个 owner；恢复成功后立即轮换或删除该 secret。
 
 然后验证 cookie session，登录后创建并安全保存 `memos_pat_` PAT，再用 PAT 访问私有 API。PAT 明文只在创建时显示一次。
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -155,7 +155,9 @@ Better Auth 是 FlareMo 的应用层认证事实源，按请求使用当前 Work
 
 首次安装只允许通过 `FLAREMO_BOOTSTRAP_SECRET` 保护的一次性 owner bootstrap 创建账号；正常 Better Auth signup 被关闭。bootstrap 成功后，Better Auth 用户通过 `auth_user_links` 映射到既有的 `users/owner`，不重写 memo、attachment、R2 object key 或 share token。未来多用户可以增加更多映射对，但不需要改变现有资源 ID。
 
-PAT 由 cookie session 下的账户接口创建、列出和撤销，明文只在创建响应返回一次；PAT 不模拟浏览器 session，也不能调用账户 PAT 管理接口。`memos_pat_` 是 FlareMo-native credential，用于保护当前兼容 API 子集，不代表 Memos Server 的完整 auth parity。
+PAT 由 cookie session 或 Better Auth session bearer 下的账户接口创建、列出和撤销，明文只在创建响应返回一次；`memos_pat_` 本身只能访问私有业务数据，不能调用账户 PAT 管理接口。`memos_pat_` 是 FlareMo-native credential，用于保护当前兼容 API 子集，不代表 Memos Server 的完整 auth parity。
+
+当前没有 email provider，因此 Better Auth 的自助忘记密码流程保持关闭。已完成 bootstrap 的单用户实例可以临时配置独立 `FLAREMO_RECOVERY_SECRET`，只针对已存在的 owner 进入 Better Auth reset-password 流程；成功时撤销全部 session 和 PAT，不创建第二个用户。该 secret 不是登录凭据，恢复结束后必须立即轮换或删除。
 
 Cloudflare Access 可以在这三层之前作为外层 policy。它只负责入口门禁，Access identity 或 Service Token 不会自动提供 FlareMo 应用用户身份；启用时请求仍需 cookie session 或 PAT。公开分享可在 Access 上对最窄路径做 bypass，但不跳过 FlareMo share token 校验。
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -99,7 +99,7 @@ pnpm exec wrangler secret put BETTER_AUTH_SECRET --config ./wrangler.jsonc
 pnpm exec wrangler secret put FLAREMO_BOOTSTRAP_SECRET --config ./wrangler.jsonc
 ```
 
-`BETTER_AUTH_SECRET` 至少需要 32 个字符。两个 secret 都应由部署者在密码管理器或安全随机数工具中生成，不能写入 `wrangler.jsonc`、`.dev.vars.example`、Git、issue、PR、日志或聊天记录。
+`BETTER_AUTH_SECRET` 至少需要 32 个字符。`BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 应由部署者在密码管理器或安全随机数工具中生成，不能写入 `wrangler.jsonc`、`.dev.vars.example`、Git、issue、PR、日志或聊天记录。`FLAREMO_RECOVERY_SECRET` 是可选的独立 break-glass secret，也至少需要 32 个字符；正常运行时可以不配置，只在明确批准的 operator recovery 窗口临时配置，成功后立即轮换或删除。
 
 Wrangler secret 是写入式配置，部署者应把值保存在自己的密码管理器中；不要尝试通过命令回读、打印或把它传给 Agent。后续只验证 secret 已使 bootstrap status 显示 `setup_available: true`，不验证或输出 secret 本身。
 
@@ -112,7 +112,7 @@ pnpm migrate:remote
 curl "$FLAREMO_URL/api/auth/flaremo/bootstrap/status"
 ```
 
-首次安装应看到 `state: "ready"` 和 `setup_available: true`。如果返回 `recovery_required`，不要重复提交 bootstrap 或手工创建第二个账户；应先按维护流程做有意的 operator recovery。
+首次安装应看到 `state: "ready"` 和 `setup_available: true`。如果返回 `recovery_required`，不要重复提交 bootstrap 或手工创建第二个账户；这表示身份创建和 domain owner 映射之间发生了部分失败，需要先按维护流程处理 bootstrap recovery。
 
 ### 5. 一次性创建 owner（生产主路径：`/setup` 页面）
 
@@ -133,6 +133,31 @@ curl "$FLAREMO_URL/api/auth/flaremo/bootstrap/status"
 - `/api/auth/update-user`：修改用户名等 Better Auth 用户资料。
 - `/api/auth/change-password`：修改密码；密码修改时可以撤销其他 session。
 - `/api/app/account/personal-access-tokens`：在 cookie session 下创建、列出和撤销 `memos_pat_` PAT。
+
+当前没有配置邮件 provider，因此 Better Auth 的普通 `request-password-reset` 邮件流程保持关闭；账户页提供的是“知道当前密码时修改密码”。如需忘记密码自助找回，应先接入真实 transactional email provider，再配置 Better Auth 的 `sendResetPassword` 和 reset 页面，不要把一个假的成功提示当作恢复能力。
+
+### Break-glass operator recovery
+
+没有邮件 provider 时，已完成 bootstrap 的单用户实例可以使用单独的 `FLAREMO_RECOVERY_SECRET` 做受限恢复。这个入口只重置现有 owner，不创建用户、不重建 `auth_user_links`，并通过 Better Auth 的 reset-password 流程完成密码校验、哈希、一次性 verification 消费和 session 撤销；现有 `memos_pat_` 也会全部撤销。它是运维破窗能力，不是普通用户的忘记密码功能。
+
+安全边界：
+
+- secret 只通过 Wrangler secret 或 Cloudflare 控制台输入，不能进入 URL、请求体、代码、Git、日志或聊天；
+- 请求必须是 HTTPS `POST`，并带 canonical `Origin`；
+- 新密码只通过 HTTPS 请求体传输，不能放进 shell history、命令参数或日志；
+- recovery 成功后立即删除或轮换 `FLAREMO_RECOVERY_SECRET`，并让客户端重新创建 PAT；
+- Access headers 只可作为外层门禁，不能单独调用该入口，也不能替代 Better Auth 身份。
+
+恢复入口是：
+
+```text
+POST /api/auth/flaremo/recover
+X-FlareMo-Recovery-Secret: <operator secret>
+Origin: https://<your-flaremo-origin>
+{"new_password":"<new password>"}
+```
+
+不要把上面的占位符替换后写进公开文档、issue、日志或聊天。完成恢复后检查 `bootstrap/status` 仍为 `complete`，用新密码登录，再重新创建 PAT；旧 session 和旧 PAT 预期全部失效。
 
 PAT 明文只在创建响应中返回一次；list 和 revoke 响应不会返回明文或 hash。把 PAT 放入密码管理器，之后只通过环境变量或安全的客户端配置使用：
 

--- a/docs/en/agent-deploy.md
+++ b/docs/en/agent-deploy.md
@@ -9,6 +9,7 @@ This runbook is for Codex, Claude Code, Cursor Agent, and other command-capable 
 - Wrangler is logged in to the target Cloudflare account.
 - `wrangler.jsonc` points to the target D1 and R2 resources.
 - Application authentication is handled by Better Auth. Cloudflare Access is optional outer policy and does not replace a FlareMo cookie session or `memos_pat_` PAT.
+- `BETTER_AUTH_SECRET` and `FLAREMO_BOOTSTRAP_SECRET` are configured as Wrangler secrets. `FLAREMO_RECOVERY_SECRET` is optional and must only be configured for an approved break-glass recovery window, then rotated or removed.
 
 ## Do Not
 

--- a/docs/en/deploy.md
+++ b/docs/en/deploy.md
@@ -32,6 +32,8 @@ pnpm deploy
 
 FlareMo's application authentication is provided by Better Auth. The first deployment uses the one-time `/setup` flow to create the single owner; browsers use an `HttpOnly` cookie session, while scripts, MCP, and Memos-compatible clients use a revocable `memos_pat_` PAT. Cloudflare Access is optional outer policy and never replaces the application session or PAT.
 
+The current release supports username/password login and authenticated password changes. No email provider is configured, so Better Auth's self-service forgot-password email flow remains disabled rather than pretending to work. A completed single-user instance has a separately configured break-glass operator recovery route; it targets the existing owner, revokes sessions and PATs, and must be rotated or removed immediately after use.
+
 The current `/api/v1` wire is the current Memos-style camelCase/protobuf-JSON subset. The legacy snake_case wire is selected explicitly with `X-FlareMo-Wire: legacy`. The current auth facade returns an opaque Better Auth session-backed `accessToken`, not a native Memos JWT. The root `/mcp` is a stateless Streamable HTTP MCP subset; complete Memos Server parity is not promised.
 
 Recommended boundary:

--- a/docs/memos-compatibility.md
+++ b/docs/memos-compatibility.md
@@ -22,7 +22,7 @@ Better Auth 是应用层认证事实源，Cloudflare Access 只能作为可选�
 | Web / Better Auth | 用户名 + 密码，登录后使用 `HttpOnly` cookie session | 当前是一套单用户 bootstrap；公共 signup 关闭，数据模型保留未来用户映射边界。 |
 | current auth facade | `POST /api/v1/auth/signin`、`refresh`、`signout`，以及 `GET /api/v1/auth/me` | 由 Better Auth session/account 数据驱动；`accessToken` 是 opaque session-backed token，不是 Memos 原生 JWT。 |
 | `/api/v1/*` 私有 API | cookie session，或 `Authorization: Bearer memos_pat_...` | PAT 由已登录账户创建、只在创建时显示一次、可撤销，并由 Better Auth API key/plugin 数据承载。 |
-| current PAT 资源 | `/api/v1/users/{user}/personalAccessTokens` | 提供当前用户的 list/create/revoke 基础；不是 Memos 原生 JWT/refresh-token parity。 |
+| current PAT 资源 | `/api/v1/users/{user}/personalAccessTokens` | 提供当前用户的 list/create/revoke 基础；要求 cookie session 或 Better Auth session bearer，`memos_pat_` 本身不能管理 PAT；不是 Memos 原生 JWT/refresh-token parity。 |
 | root `/mcp` | cookie session、Better Auth session bearer，或 `memos_pat_` PAT | Streamable HTTP 是无状态 JSON 响应子集，不创建 MCP session。 |
 | Origin policy | cookie session 状态变更必须携带并精确匹配 `FLAREMO_PUBLIC_URL` / `FLAREMO_TRUSTED_ORIGINS`；PAT 可无 Origin，带 Origin 时同样必须匹配 | 缺失或不可信 Origin 返回 `403`；Access headers 不替代应用层 Origin。 |
 | Cloudflare Access | 可选外层 policy / Service Auth | Access 只解决外层网络门禁；启用时仍要提供上面的 cookie、session bearer 或 PAT。 |

--- a/packages/domain/src/auth.ts
+++ b/packages/domain/src/auth.ts
@@ -101,6 +101,33 @@ export async function markOwnerBootstrapRecoveryRequired(
     .where(eq(authBootstrap.id, OWNER_BOOTSTRAP_ID));
 }
 
+/**
+ * Return the already-linked owner identity for a completed single-user
+ * bootstrap. Recovery must target this identity in place; it must never create
+ * another Better Auth user or another domain owner.
+ */
+export async function getOwnerAuthUserId(
+  db: FlareMoDb,
+): Promise<string | null> {
+  const bootstrap = await db.query.authBootstrap.findFirst({
+    where: eq(authBootstrap.id, OWNER_BOOTSTRAP_ID),
+  });
+  if (
+    bootstrap?.state !== "complete" ||
+    !bootstrap.authUserId ||
+    !bootstrap.flaremoUserId
+  ) {
+    return null;
+  }
+
+  const link = await db.query.authUserLinks.findFirst({
+    where: eq(authUserLinks.authUserId, bootstrap.authUserId),
+  });
+  if (!link || link.flaremoUserId !== bootstrap.flaremoUserId) return null;
+
+  return bootstrap.authUserId;
+}
+
 export async function getFlaremoUserByAuthUserId(
   db: FlareMoDb,
   authUserId: string,

--- a/tests/e2e/auth-fixture.ts
+++ b/tests/e2e/auth-fixture.ts
@@ -56,7 +56,10 @@ export async function createInitialAuthState(): Promise<void> {
     const bootstrapResponse = await context.post(
       "/api/auth/flaremo/bootstrap",
       {
-        headers: { "x-flaremo-bootstrap-secret": E2E_BOOTSTRAP_SECRET },
+        headers: {
+          "x-flaremo-bootstrap-secret": E2E_BOOTSTRAP_SECRET,
+          origin: E2E_BASE_URL,
+        },
         data: E2E_BOOTSTRAP_INPUT,
       },
     );

--- a/tests/e2e/auth-flow.spec.ts
+++ b/tests/e2e/auth-flow.spec.ts
@@ -34,7 +34,10 @@ test("bootstraps one owner and signs in with username/password", async () => {
     const secondBootstrap = await anonymous.post(
       "/api/auth/flaremo/bootstrap",
       {
-        headers: { "x-flaremo-bootstrap-secret": E2E_BOOTSTRAP_SECRET },
+        headers: {
+          "x-flaremo-bootstrap-secret": E2E_BOOTSTRAP_SECRET,
+          origin: E2E_BASE_URL,
+        },
         data: {
           ...E2E_BOOTSTRAP_INPUT,
           username: "another_e2e_owner",


### PR DESCRIPTION
## Summary

- enforce exact trusted Origin on Better Auth and cookie-backed auth mutations
- add disabled-by-default operator break-glass recovery that resets the existing owner through Better Auth and revokes sessions/PATs
- tighten current Memos auth facade and PAT-management credential boundaries
- update security/deploy/Memos compatibility documentation and contract/E2E coverage

## Compatibility and deployment

- No new D1 migration.
- Cloudflare Access remains optional outer policy; Access headers never become FlareMo application identity.
- This preserves the documented Memos-compatible subset and does not claim complete Memos Server parity, native JWT parity, or third-party-client verification.
- Email forgot-password remains disabled because no mail provider is configured.

## Verification

- `pnpm test:e2e` (21 passed)
- `pnpm verify` (format, checks, tests, builds, E2E; passed)
- `pnpm deploy:dry-run` (passed)
- `pnpm backup:drill` (passed; remote D1 reported no pending migrations)
- `git diff --check` (passed)

No issue is linked because the repository currently has no open issue for this change; this PR is the implementation of the requested auth hardening and recovery boundary.