### PR TITLE
fix: close native auth and Memos integration boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ FlareMo 使用 SemVer。每个 release 都要写清楚升级影响、Cloudflare 
 
 后续变更将在下一次 release 汇总。
 
+## v0.4.2
+
+Better Auth 与 Memos-compatible 集成收口版本。这个版本不新增 D1 migration，重点修复 partial bootstrap、current auth facade 和渠道 Worker 的应用层认证边界。
+
+### 已修复
+
+- bootstrap status 只有在 `auth_bootstrap` 的完成状态、owner IDs 和精确 `auth_user_links` 映射全部一致时才报告 `complete`；未来用户 link 或 partial write 不会误开放 setup。
+- 增加默认关闭的 `POST /api/auth/flaremo/recover-bootstrap` operator recovery，只协调唯一既有 Better Auth 身份与 `users/owner`，不接受用户名/密码、不创建第二个认证用户；多身份或歧义映射 fail closed 返回 `409`。
+- current Memos `auth/refresh` 的 session bearer 统一经过共享认证 context，补齐过期、PAT 拒绝和 trusted Origin 校验；无 Origin 的机器 session bearer 仍可用。
+- credential-bearing current signin/refresh 与 PAT 创建响应设置 `Cache-Control: no-store`；current signout 在同时收到 bearer 和 cookie 时会同时撤销 session 并清理 cookie。
+- Telegram Worker 改为必须使用 Better Auth `memos_pat_` PAT；Cloudflare Access headers 仅在成对配置时追加，缺失/半配置 fail closed，FlareMo 目标 URL 强制为 HTTPS origin。
+- bootstrap secret 最少 32 个字符；生产 `FLAREMO_PUBLIC_URL` 强制 HTTPS，本地 `.test`/localhost HTTP 仅用于开发测试。
+
+### Cloudflare、数据库与兼容影响
+
+- 本版本不新增 D1 migration；现有认证表和 PAT 仍必须纳入备份、恢复和演练范围。
+- Cloudflare Access 仍是可选外层 policy，不能替代 Better Auth cookie/session bearer 或 PAT。公开分享是否能穿过 Access 仍取决于 Cloudflare 控制面的精确 bypass policy。
+- 登录、bootstrap 和 operator recovery 的跨 edge 失败/请求限流需要在 Cloudflare WAF/Rate Limiting 配置；Worker 内置限流只是单 isolate 补充。
+- 继续提供已记录的 Memos-compatible 子集，不宣称完整 Memos Server parity、原生 JWT parity 或所有第三方客户端已验证。
+
+### 升级说明
+
+- 保持现有 `FLAREMO_PUBLIC_URL`、`FLAREMO_TRUSTED_ORIGINS`、Better Auth secrets 和已创建的 PAT 配置；不要把任何 secret、密码、cookie 或 PAT 写入 Git、release notes、日志或聊天。
+- 尚未 bootstrap 的实例需要使用不少于 32 个字符的 bootstrap secret；生产 canonical URL 必须是 HTTPS。
+- 若 bootstrap status 为 `recovery_required`，仅在批准的 operator recovery 窗口临时配置 recovery secret，调用 `recover-bootstrap` 后立即轮换或删除该 secret。
+- Telegram Worker 新增必需的 `FLAREMO_MEMOS_PAT` secret；生产仍启用 Access 时，再配置成对的 Access client ID/secret。
+
 ## v0.4.1
 
 鉴权安全收口补丁。这个版本把 Better Auth、operator recovery 和 Memos-compatible auth facade 的安全边界收紧，同时不改变 D1 schema。

--- a/apps/telegram-bot/src/index.test.ts
+++ b/apps/telegram-bot/src/index.test.ts
@@ -4,6 +4,7 @@ import { handleTelegramWebhook, type TelegramBotEnv } from "./index";
 const env: TelegramBotEnv = {
   FLAREMO_ACCESS_CLIENT_ID: "access-id",
   FLAREMO_ACCESS_CLIENT_SECRET: "access-secret",
+  FLAREMO_MEMOS_PAT: "memos_pat_test-only-telegram-credential",
   FLAREMO_URL: "https://flaremo.example.workers.dev/",
   TELEGRAM_ALLOWED_CHAT_IDS: "42, 84",
   TELEGRAM_WEBHOOK_SECRET: "telegram-secret",
@@ -37,6 +38,9 @@ describe("Telegram ingestion example", () => {
     const headers = new Headers(init?.headers);
     expect(headers.get("CF-Access-Client-Id")).toBe("access-id");
     expect(headers.get("CF-Access-Client-Secret")).toBe("access-secret");
+    expect(headers.get("Authorization")).toBe(
+      "Bearer memos_pat_test-only-telegram-credential",
+    );
     expect(JSON.parse(String(init?.body))).toMatchObject({
       content: "A useful link https://example.com/article",
       source: "telegram",
@@ -67,6 +71,69 @@ describe("Telegram ingestion example", () => {
     );
     expect(deniedChat.status).toBe(403);
     expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("supports native FlareMo auth without Cloudflare Access headers", async () => {
+    const fetcher = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ name: "memos/native" }, { status: 201 }),
+    );
+    const nativeEnv: TelegramBotEnv = {
+      ...env,
+      FLAREMO_ACCESS_CLIENT_ID: undefined,
+      FLAREMO_ACCESS_CLIENT_SECRET: undefined,
+    };
+    const response = await handleTelegramWebhook(
+      telegramRequest({
+        update_id: 1002,
+        message: { chat: { id: 42 }, message_id: 8, text: "native auth" },
+      }),
+      nativeEnv,
+      fetcher,
+    );
+
+    expect(response.status).toBe(200);
+    const [, init] = fetcher.mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe(
+      "Bearer memos_pat_test-only-telegram-credential",
+    );
+    expect(headers.get("CF-Access-Client-Id")).toBeNull();
+    expect(headers.get("CF-Access-Client-Secret")).toBeNull();
+  });
+
+  it("fails closed when the application PAT or Access pair is misconfigured", async () => {
+    const fetcher = vi.fn();
+    const missingPat = await handleTelegramWebhook(
+      telegramRequest({
+        update_id: 1003,
+        message: { chat: { id: 42 }, message_id: 9, text: "missing pat" },
+      }),
+      { ...env, FLAREMO_MEMOS_PAT: undefined },
+      fetcher,
+    );
+    expect(missingPat.status).toBe(503);
+
+    const partialAccess = await handleTelegramWebhook(
+      telegramRequest({
+        update_id: 1004,
+        message: { chat: { id: 42 }, message_id: 10, text: "partial access" },
+      }),
+      { ...env, FLAREMO_ACCESS_CLIENT_SECRET: undefined },
+      fetcher,
+    );
+    expect(partialAccess.status).toBe(503);
+    expect(fetcher).not.toHaveBeenCalled();
+
+    const insecureUrl = await handleTelegramWebhook(
+      telegramRequest({
+        update_id: 1005,
+        message: { chat: { id: 42 }, message_id: 11, text: "insecure url" },
+      }),
+      { ...env, FLAREMO_URL: "http://flaremo.example.workers.dev" },
+      fetcher,
+    );
+    expect(insecureUrl.status).toBe(503);
   });
 });
 

--- a/apps/telegram-bot/src/index.ts
+++ b/apps/telegram-bot/src/index.ts
@@ -1,6 +1,7 @@
 export type TelegramBotEnv = {
-  FLAREMO_ACCESS_CLIENT_ID: string;
-  FLAREMO_ACCESS_CLIENT_SECRET: string;
+  FLAREMO_ACCESS_CLIENT_ID?: string;
+  FLAREMO_ACCESS_CLIENT_SECRET?: string;
+  FLAREMO_MEMOS_PAT?: string;
   FLAREMO_URL: string;
   TELEGRAM_ALLOWED_CHAT_IDS: string;
   TELEGRAM_WEBHOOK_SECRET: string;
@@ -43,6 +44,23 @@ export async function handleTelegramWebhook(
     return json({ error: "Invalid Telegram webhook secret" }, 401);
   }
 
+  const memosPat = env.FLAREMO_MEMOS_PAT?.trim();
+  if (!memosPat?.startsWith("memos_pat_")) {
+    return json(
+      { error: "FlareMo application credential is not configured" },
+      503,
+    );
+  }
+  const accessClientId = env.FLAREMO_ACCESS_CLIENT_ID?.trim();
+  const accessClientSecret = env.FLAREMO_ACCESS_CLIENT_SECRET?.trim();
+  if (Boolean(accessClientId) !== Boolean(accessClientSecret)) {
+    return json({ error: "Cloudflare Access credentials are incomplete" }, 503);
+  }
+  const flaremoUrl = getFlaremoUrl(env.FLAREMO_URL);
+  if (!flaremoUrl) {
+    return json({ error: "FlareMo URL must be an HTTPS origin" }, 503);
+  }
+
   const update = (await request.json()) as TelegramUpdate;
   const message =
     update.message ??
@@ -67,31 +85,28 @@ export async function handleTelegramWebhook(
     return json({ ok: true, skipped: "empty_message" });
   }
 
-  const response = await fetcher(
-    `${env.FLAREMO_URL.replace(/\/$/, "")}/api/v1/memos`,
-    {
-      method: "POST",
-      headers: {
-        "CF-Access-Client-Id": env.FLAREMO_ACCESS_CLIENT_ID,
-        "CF-Access-Client-Secret": env.FLAREMO_ACCESS_CLIENT_SECRET,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        content,
-        visibility: "private",
-        source: "telegram",
-        payload: {
-          tags: ["telegram"],
-          client_id: `telegram:${update.update_id ?? message.message_id ?? "unknown"}`,
-          telegram: {
-            chat_id: String(chatId),
-            message_id: message.message_id,
-            forwarded: message.forward_origin !== undefined,
-          },
+  const response = await fetcher(`${flaremoUrl}/api/v1/memos`, {
+    method: "POST",
+    headers: flaremoHeaders({
+      memosPat,
+      accessClientId,
+      accessClientSecret,
+    }),
+    body: JSON.stringify({
+      content,
+      visibility: "private",
+      source: "telegram",
+      payload: {
+        tags: ["telegram"],
+        client_id: `telegram:${update.update_id ?? message.message_id ?? "unknown"}`,
+        telegram: {
+          chat_id: String(chatId),
+          message_id: message.message_id,
+          forwarded: message.forward_origin !== undefined,
         },
-      }),
-    },
-  );
+      },
+    }),
+  });
   if (!response.ok) {
     return json(
       {
@@ -107,4 +122,39 @@ export async function handleTelegramWebhook(
 
 function json(body: unknown, status = 200) {
   return Response.json(body, { status });
+}
+
+function flaremoHeaders(input: {
+  memosPat: string;
+  accessClientId?: string;
+  accessClientSecret?: string;
+}) {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${input.memosPat}`,
+    "content-type": "application/json",
+  };
+  if (input.accessClientId && input.accessClientSecret) {
+    headers["CF-Access-Client-Id"] = input.accessClientId;
+    headers["CF-Access-Client-Secret"] = input.accessClientSecret;
+  }
+  return headers;
+}
+
+function getFlaremoUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      (url.pathname !== "/" && url.pathname !== "") ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
 }

--- a/apps/worker/src/auth.test.ts
+++ b/apps/worker/src/auth.test.ts
@@ -1,7 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { createDb } from "@flaremo/db";
 import { Miniflare } from "miniflare";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createFlareMoAuth } from "./auth";
+import type { FlareMoEnv } from "./env";
 import app from "./index";
 
 let runtime: Miniflare;
@@ -140,6 +143,106 @@ describe("FlareMo native authentication", () => {
     expect(ownerLinks?.count).toBe(1);
   });
 
+  it("does not mistake a partial link for complete and reconciles it in place", async () => {
+    await bootstrapOwner();
+    await db
+      .prepare(
+        "UPDATE auth_bootstrap SET state = ?, auth_user_id = NULL, flaremo_user_id = NULL, completed_at = NULL WHERE id = ?",
+      )
+      .bind("recovery_required", "bootstrap/owner")
+      .run();
+
+    const partialStatus = await json<{
+      initialized: boolean;
+      state: string;
+      setup_available: boolean;
+    }>(await fetchRaw("/api/auth/flaremo/bootstrap/status"));
+    expect(partialStatus).toEqual({
+      initialized: false,
+      state: "recovery_required",
+      setup_available: false,
+    });
+
+    const recovery = await fetchRaw("/api/auth/flaremo/recover-bootstrap", {
+      method: "POST",
+      headers: {
+        "x-flaremo-recovery-secret": TEST_RECOVERY_SECRET,
+        origin: "http://flaremo.test",
+      },
+    });
+    expect(recovery.status).toBe(200);
+    expect(await json(recovery)).toEqual({ ok: true });
+
+    const completedStatus = await json<{
+      initialized: boolean;
+      state: string;
+      setup_available: boolean;
+    }>(await fetchRaw("/api/auth/flaremo/bootstrap/status"));
+    expect(completedStatus).toEqual({
+      initialized: true,
+      state: "complete",
+      setup_available: false,
+    });
+
+    const counts = await Promise.all([
+      db
+        .prepare("SELECT COUNT(*) AS count FROM auth_users")
+        .first<{ count: number }>(),
+      db
+        .prepare("SELECT COUNT(*) AS count FROM auth_user_links")
+        .first<{ count: number }>(),
+      db
+        .prepare("SELECT COUNT(*) AS count FROM users WHERE id = ?")
+        .bind("users/owner")
+        .first<{ count: number }>(),
+    ]);
+    expect(counts[0]?.count).toBe(1);
+    expect(counts[1]?.count).toBe(1);
+    expect(counts[2]?.count).toBe(1);
+  });
+
+  it("fails closed when bootstrap recovery finds multiple identities", async () => {
+    await bootstrapOwner();
+    const auth = createFlareMoAuth(env as FlareMoEnv, createDb(db), {
+      allowBootstrapSignUp: true,
+    });
+    await auth.api.signUpEmail({
+      body: {
+        email: "second@example.com",
+        name: "Second",
+        password: INITIAL_PASSWORD,
+        username: "second",
+        displayUsername: "second",
+      },
+    });
+    await db
+      .prepare(
+        "UPDATE auth_bootstrap SET state = ?, auth_user_id = NULL, flaremo_user_id = NULL, completed_at = NULL WHERE id = ?",
+      )
+      .bind("recovery_required", "bootstrap/owner")
+      .run();
+
+    const recovery = await fetchRaw("/api/auth/flaremo/recover-bootstrap", {
+      method: "POST",
+      headers: {
+        "x-flaremo-recovery-secret": TEST_RECOVERY_SECRET,
+        origin: "http://flaremo.test",
+      },
+    });
+    expect(recovery.status).toBe(409);
+
+    const counts = await Promise.all([
+      db
+        .prepare("SELECT COUNT(*) AS count FROM auth_users")
+        .first<{ count: number }>(),
+      db
+        .prepare("SELECT COUNT(*) AS count FROM auth_user_links")
+        .first<{ count: number }>(),
+    ]);
+    expect(counts[0]?.count).toBe(2);
+    expect(counts[1]?.count).toBe(1);
+  });
+
   it("requires an exact Origin for cookie auth mutations and keeps Access outside app identity", async () => {
     await bootstrapOwner();
 
@@ -219,6 +322,7 @@ describe("FlareMo native authentication", () => {
       },
     );
     expect(createdPat.status).toBe(201);
+    expect(createdPat.headers.get("cache-control")).toBe("no-store");
     const pat = await json<{ token: string }>(createdPat);
 
     const recovery = await fetchRaw("/api/auth/flaremo/recover", {

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -258,6 +258,11 @@ export function getPublicUrl(env: FlareMoEnv): string {
       "FLAREMO_PUBLIC_URL must use http or https.",
     );
   }
+  if (url.protocol === "http:" && !isLocalDevelopmentHostname(url.hostname)) {
+    throw new AuthConfigurationError(
+      "FLAREMO_PUBLIC_URL must use HTTPS outside local development.",
+    );
+  }
   if (url.pathname !== "/" || url.search || url.hash) {
     throw new AuthConfigurationError(
       "FLAREMO_PUBLIC_URL must be an origin without a path, query, or fragment.",
@@ -304,7 +309,8 @@ export function getTrustedOrigins(
 
 export function getBootstrapSecret(env: FlareMoEnv): string | null {
   const value = env.FLAREMO_BOOTSTRAP_SECRET?.trim();
-  return value || null;
+  if (!value || value.length < 32) return null;
+  return value;
 }
 
 /**
@@ -326,4 +332,13 @@ function getRequiredBetterAuthSecret(env: FlareMoEnv): string {
     );
   }
   return value;
+}
+
+function isLocalDevelopmentHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname.endsWith(".test")
+  );
 }

--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -538,6 +538,7 @@ describe("Memos-compatible API contract", () => {
     );
     expect(signInResponse.status).toBe(200);
     expect(signInResponse.headers.get("set-cookie")).toBeTruthy();
+    expect(signInResponse.headers.get("cache-control")).toBe("no-store");
     const signIn = (await signInResponse.json()) as {
       accessToken: string;
       user: { name: string; role: string; username: string };
@@ -554,6 +555,28 @@ describe("Memos-compatible API contract", () => {
     });
 
     const bearer = { authorization: `Bearer ${signIn.accessToken}` };
+    const refreshWithoutOrigin = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/refresh",
+      { method: "POST", headers: bearer },
+      { authenticated: false },
+    );
+    expect(refreshWithoutOrigin.status).toBe(200);
+    expect(refreshWithoutOrigin.headers.get("cache-control")).toBe("no-store");
+    expect(await refreshWithoutOrigin.json()).toEqual({
+      accessToken: signIn.accessToken,
+      expiresAt: signIn.accessTokenExpiresAt,
+    });
+
+    const refreshWithUntrustedOrigin = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/refresh",
+      {
+        method: "POST",
+        headers: { ...bearer, origin: "https://untrusted.example" },
+      },
+      { authenticated: false },
+    );
+    expect(refreshWithUntrustedOrigin.status).toBe(403);
+
     const meResponse = await fetchCurrent(
       "http://flaremo.test/api/v1/auth/me",
       { headers: bearer },
@@ -748,6 +771,7 @@ describe("Memos-compatible API contract", () => {
       },
     );
     expect(patCreate.status).toBe(200);
+    expect(patCreate.headers.get("cache-control")).toBe("no-store");
     const pat = (await patCreate.json()) as {
       personalAccessToken: { name: string };
       token: string;
@@ -883,6 +907,49 @@ describe("Memos-compatible API contract", () => {
     );
     expect(unauthenticated.status).toBe(401);
     expect(await unauthenticated.json()).toMatchObject({ code: 16 });
+  });
+
+  it("clears the cookie session when current signout receives both credentials", async () => {
+    const signInResponse = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/signin",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          passwordCredentials: {
+            username: "owner",
+            password: TEST_PASSWORD,
+          },
+        }),
+      },
+      { authenticated: false },
+    );
+    const signIn = (await signInResponse.json()) as { accessToken: string };
+    const cookie = extractCookieHeader(signInResponse);
+
+    const signout = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/signout",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${signIn.accessToken}`,
+          cookie,
+          origin: "http://flaremo.test",
+        },
+      },
+      { authenticated: false },
+    );
+    expect(signout.status).toBe(200);
+
+    const cookieOnly = await fetchCurrent(
+      "http://flaremo.test/api/v1/auth/me",
+      { headers: { cookie } },
+      { authenticated: false },
+    );
+    expect(cookieOnly.status).toBe(401);
   });
 });
 

--- a/apps/worker/src/routes/account-api.ts
+++ b/apps/worker/src/routes/account-api.ts
@@ -50,7 +50,7 @@ accountApi.post(
             : null,
         },
       });
-      return c.json(
+      const response = c.json(
         {
           personal_access_token: toPersonalAccessTokenDto(created),
           // Better Auth only returns this plaintext value at creation time.
@@ -58,6 +58,8 @@ accountApi.post(
         },
         201,
       );
+      response.headers.set("cache-control", "no-store");
+      return response;
     } catch (error) {
       return jsonError(c, error);
     }

--- a/apps/worker/src/routes/auth-api.ts
+++ b/apps/worker/src/routes/auth-api.ts
@@ -6,6 +6,7 @@ import {
   getOwnerAuthUserId,
   listMemosPersonalAccessTokens,
   markOwnerBootstrapRecoveryRequired,
+  reconcileOwnerBootstrap,
 } from "@flaremo/domain";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -233,6 +234,44 @@ authApi.post(
     }
   },
 );
+
+/**
+ * Reconcile a partial owner bootstrap without accepting credentials or
+ * caller-supplied identity data. The separate recovery secret keeps this
+ * operator-only path closed by default and prevents it from becoming a second
+ * signup flow.
+ */
+authApi.post("/recover-bootstrap", async (c) => {
+  const recoverySecret = getRecoverySecret(c.env);
+  if (!recoverySecret) {
+    return c.json(
+      { error: { message: "Operator recovery is not configured." } },
+      503,
+    );
+  }
+
+  const suppliedSecret = c.req.header("x-flaremo-recovery-secret");
+  if (!(await secretsMatch(suppliedSecret, recoverySecret))) {
+    return c.json(
+      { error: { message: "Operator recovery is not authorized." } },
+      403,
+    );
+  }
+
+  const db = createDb(c.env.DB);
+  try {
+    await reconcileOwnerBootstrap(db);
+    console.log(
+      JSON.stringify({
+        level: "info",
+        message: "FlareMo owner bootstrap recovery completed",
+      }),
+    );
+    return c.json({ ok: true });
+  } catch (error) {
+    return jsonError(c, error);
+  }
+});
 
 async function secretsMatch(
   supplied: string | undefined,

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -200,6 +200,7 @@ memosCurrentApi.post("/auth/signin", async (c, next) => {
       200,
     );
     copyHeaders(response.headers, result.headers);
+    response.headers.set("cache-control", "no-store");
     return response;
   } catch (error) {
     return currentJsonError(c, error);
@@ -212,19 +213,20 @@ memosCurrentApi.post("/auth/refresh", async (c, next) => {
     const authorization = c.req.header("authorization");
     if (authorization) {
       const token = parseBearerToken(authorization);
-      if (token.startsWith("memos_pat_")) {
+      const authContext = await getRequestContext(c);
+      // Resolve every bearer credential through the shared request context so
+      // session refresh gets the same expiry, PAT rejection, and exact
+      // trusted-Origin checks as the rest of the current API. A Memos PAT is
+      // an application credential, not a refreshable browser session.
+      if (!authContext.bearerSession || !authContext.session) {
         throw new UnauthorizedCurrentError();
       }
-      const authContext = await createAuthContext(c);
-      const session = await getFlaremoUserByAuthSessionToken(
-        authContext.db,
-        token,
+      return noStoreResponse(
+        c.json({
+          accessToken: token,
+          expiresAt: authContext.session.expiresAt.toISOString(),
+        }),
       );
-      if (!session) throw new UnauthorizedCurrentError();
-      return c.json({
-        accessToken: token,
-        expiresAt: session.session.expiresAt.toISOString(),
-      });
     }
 
     if (!authorization) assertTrustedCookieMutation(c);
@@ -234,10 +236,12 @@ memosCurrentApi.post("/auth/refresh", async (c, next) => {
       query: { disableCookieCache: true },
     });
     if (!result) throw new UnauthorizedCurrentError();
-    return c.json({
-      accessToken: result.session.token,
-      expiresAt: result.session.expiresAt.toISOString(),
-    });
+    return noStoreResponse(
+      c.json({
+        accessToken: result.session.token,
+        expiresAt: result.session.expiresAt.toISOString(),
+      }),
+    );
   } catch (error) {
     return currentJsonError(c, error);
   }
@@ -252,20 +256,22 @@ memosCurrentApi.post("/auth/signout", async (c, next) => {
       if (token.startsWith("memos_pat_")) {
         // A PAT does not have a browser session to clear, but it still must be
         // valid. Do not return success for arbitrary bearer strings.
-        await getRequestContext(c);
+        const context = await getRequestContext(c);
+        if (c.req.raw.headers.get("cookie")) {
+          return signOutCookieSession(c, context.db);
+        }
         return c.body(null, 200);
       }
       const context = await getRequestContext(c);
       await revokeAuthSessionByToken(context.db, token);
+      if (c.req.raw.headers.get("cookie")) {
+        return signOutCookieSession(c, context.db);
+      }
       return c.body(null, 200);
     }
 
     const context = await getRequestContext(c);
-    const request = new Request(new URL("/api/auth/sign-out", c.req.url), {
-      method: "POST",
-      headers: c.req.raw.headers,
-    });
-    return createFlareMoAuth(c.env, context.db).handler(request);
+    return signOutCookieSession(c, context.db);
   } catch (error) {
     return currentJsonError(c, error);
   }
@@ -736,10 +742,12 @@ memosCurrentApi.post("/users/:user/personalAccessTokens", async (c, next) => {
             : body.expiresInDays * 24 * 60 * 60,
       },
     });
-    return c.json({
-      personalAccessToken: currentPatToDto(created, context.user.id),
-      token: created.key,
-    });
+    return noStoreResponse(
+      c.json({
+        personalAccessToken: currentPatToDto(created, context.user.id),
+        token: created.key,
+      }),
+    );
   } catch (error) {
     return currentJsonError(c, error);
   }
@@ -1170,6 +1178,24 @@ function copyHeaders(target: Headers, source: Headers) {
   source.forEach((value, key) => {
     target.append(key, value);
   });
+}
+
+function noStoreResponse(response: Response) {
+  response.headers.set("cache-control", "no-store");
+  return response;
+}
+
+function signOutCookieSession(
+  c: Parameters<typeof getRequestContext>[0],
+  db: ReturnType<typeof createDb>,
+) {
+  const headers = new Headers(c.req.raw.headers);
+  headers.delete("authorization");
+  const request = new Request(new URL("/api/auth/sign-out", c.req.url), {
+    method: "POST",
+    headers,
+  });
+  return createFlareMoAuth(c.env, db).handler(request);
 }
 
 function currentJsonError(

--- a/docs/agent-deploy.md
+++ b/docs/agent-deploy.md
@@ -9,9 +9,10 @@
 - Wrangler 已登录目标 Cloudflare 账号。
 - `wrangler.jsonc` 里的 D1、R2 binding 指向目标资源。
 - `wrangler.jsonc` 的 `FLAREMO_PUBLIC_URL` 已设置为生产 canonical origin；需要时设置 `FLAREMO_TRUSTED_ORIGINS`。
-- `BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 已通过 Wrangler secret 或 Cloudflare 控制台配置。`FLAREMO_RECOVERY_SECRET` 只在明确批准的 break-glass recovery 窗口临时配置。Agent 不得要求用户把 secret、密码、cookie 或 PAT 粘贴到聊天中。
+- `BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 已通过 Wrangler secret 或 Cloudflare 控制台配置，且各至少 32 个字符。`FLAREMO_RECOVERY_SECRET` 只在明确批准的 break-glass recovery 窗口临时配置。Agent 不得要求用户把 secret、密码、cookie 或 PAT 粘贴到聊天中。
 - `FLAREMO_SINGLE_USER_EMAIL` 和 `FLAREMO_SINGLE_USER_NAME` 只是既有 `users/owner` domain metadata 的 legacy 公开变量；它们不是 Better Auth 登录身份、用户名、密码或 bootstrap 输入。初始认证身份以部署者在生产 `/setup` 页面提交的值为准。
 - Cloudflare Access 可以作为可选外层防线，但不替代 FlareMo 应用层认证。
+- 生产 Cloudflare WAF/Rate Limiting 已覆盖登录、bootstrap 和 operator recovery 路径；Worker 内置限流只作为单 isolate 补充。
 
 ## 禁止事项
 
@@ -80,7 +81,7 @@ curl "$FLAREMO_URL/api/auth/flaremo/bootstrap/status"
 
 首次安装必须由部署者在浏览器打开 `https://<your-flaremo-origin>/setup`，并在生产 HTTPS 页面手动输入 `FLAREMO_BOOTSTRAP_SECRET`、初始用户名、显示名、邮箱和 12–128 个字符的初始密码。如果启用了 Cloudflare Access，先通过外层 policy 再打开 `/setup`。Agent 不得要求用户把这些值粘贴到聊天、命令行、shell history、issue、日志或 Agent 输出，也不得代用户调用 bootstrap endpoint；部署者完成页面提交后，Agent 只能检查 bootstrap status 和登录结果。
 
-bootstrap endpoint 只保留给明确批准的受控初始化流程；本 runbook 不提供把 secret 或密码放进环境变量、命令行参数或非交互 `curl` 的示例。已完成 bootstrap 后的密码破窗恢复使用单独的 `FLAREMO_RECOVERY_SECRET`，重置现有 owner、撤销全部 session/PAT，不创建第二个 owner；恢复成功后立即轮换或删除该 secret。
+bootstrap endpoint 只保留给明确批准的受控初始化流程；本 runbook 不提供把 secret 或密码放进环境变量、命令行参数或非交互 `curl` 的示例。已完成 bootstrap 后的密码破窗恢复使用单独的 `FLAREMO_RECOVERY_SECRET`，重置现有 owner、撤销全部 session/PAT，不创建第二个 owner；恢复成功后立即轮换或删除该 secret。若 bootstrap 因部分写入进入 `recovery_required`，使用同一 secret 调用 operator-only `POST /api/auth/flaremo/recover-bootstrap` 只协调既有身份映射；该接口不接受用户名、密码，不会重新开放 signup，遇到多个身份或 link 会返回 `409`。
 
 然后验证 cookie session，登录后创建并安全保存 `memos_pat_` PAT，再用 PAT 访问私有 API。PAT 明文只在创建时显示一次。
 

--- a/docs/agent-ingestion.md
+++ b/docs/agent-ingestion.md
@@ -1,15 +1,14 @@
 # Agent 与 IM 渠道写入
 
-FlareMo 不需要新增应用内 Bearer token，也不要求 Agent 经过浏览器登录。外部 Agent、自动化脚本和 IM Bot 使用现有 `/api/v1/memos` 或 `/api/v1/mcp`，并由 Cloudflare Access Service Token 保护。
+FlareMo 的私有 API 始终需要 Better Auth 应用层凭据：浏览器使用 HttpOnly cookie session，外部 Agent、自动化脚本和 IM Bot 使用可撤销的 `memos_pat_` Personal Access Token。Cloudflare Access 是可选的外层 policy；生产仍启用 Access 时，再附加 Access Service Token。Access Service Token 单独不能成为 FlareMo 用户身份。
 
 ## Agent 直接提交
 
-先按 [部署指南](./deploy.md#3-创建-service-token) 创建 Access Service Token，然后：
+先在 FlareMo Web 界面创建一个有明确用途和过期时间的 `memos_pat_` PAT。若目标部署仍启用 Cloudflare Access，再按 [部署指南](./deploy.md#3-创建-service-token) 创建 Access Service Token，然后：
 
 ```bash
 curl -X POST "$FLAREMO_URL/api/v1/memos" \
-  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
-  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
   -H "Content-Type: application/json" \
   --data '{
     "content": "文章摘要与原始链接 #inbox",
@@ -20,6 +19,13 @@ curl -X POST "$FLAREMO_URL/api/v1/memos" \
       "client_id": "agent:source-message-id"
     }
   }'
+```
+
+如果目标入口仍启用 Cloudflare Access，在同一个请求中再追加：
+
+```bash
+  -H "CF-Access-Client-Id: $FLAREMO_ACCESS_CLIENT_ID" \
+  -H "CF-Access-Client-Secret: $FLAREMO_ACCESS_CLIENT_SECRET"
 ```
 
 写入成功后，该 memo 会直接出现在 Web 时间线。`source` 用于标记渠道；`payload.client_id` 建议保存渠道侧消息 ID，方便排查重试。当前 API 不把它当成唯一键，调用方仍应避免重复投递。
@@ -33,8 +39,9 @@ curl -X POST "$FLAREMO_URL/api/v1/memos" \
 1. 校验 Telegram `secret_token` header；
 2. 只接受 `TELEGRAM_ALLOWED_CHAT_IDS` 白名单中的会话；
 3. 将文本、图片 caption 或转发内容写入 FlareMo；
-4. 使用 Access Service Token 穿过生产 Access 边界；
-5. 为 memo 添加 `telegram` 标签和来源元数据。
+4. 使用 `FLAREMO_MEMOS_PAT` 通过 FlareMo 应用层认证；
+5. 如果启用了生产 Access，则额外使用 Access Service Token 穿过外层边界；
+6. 为 memo 添加 `telegram` 标签和来源元数据。
 
 配置公开变量：
 
@@ -43,10 +50,16 @@ cd apps/telegram-bot
 pnpm exec wrangler deploy --config wrangler.jsonc
 ```
 
-真实地址和 chat id 写入 `wrangler.jsonc`，敏感值必须通过 secret 写入，不得提交：
+真实的 FlareMo HTTPS origin 和 chat id 写入 `wrangler.jsonc`，Worker 会拒绝 HTTP、带路径、query 或 fragment 的目标 URL。敏感值必须通过 secret 写入，不得提交：
 
 ```bash
 pnpm exec wrangler secret put TELEGRAM_WEBHOOK_SECRET --config wrangler.jsonc
+pnpm exec wrangler secret put FLAREMO_MEMOS_PAT --config wrangler.jsonc
+```
+
+如果 FlareMo 的生产入口仍由 Cloudflare Access 保护，再配置成对的 Access Service Token secrets；两项必须同时存在：
+
+```bash
 pnpm exec wrangler secret put FLAREMO_ACCESS_CLIENT_ID --config wrangler.jsonc
 pnpm exec wrangler secret put FLAREMO_ACCESS_CLIENT_SECRET --config wrangler.jsonc
 ```
@@ -59,7 +72,7 @@ curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
   --data-urlencode "secret_token=$TELEGRAM_WEBHOOK_SECRET"
 ```
 
-`TELEGRAM_BOT_TOKEN` 只用于调用 Telegram 的 `setWebhook`，不需要存进 Worker。Telegram 的 webhook secret 与 Cloudflare Access Service Token 是两层不同的边界，不能互相替代。
+`TELEGRAM_BOT_TOKEN` 只用于调用 Telegram 的 `setWebhook`，不需要存进 Worker。Telegram 的 webhook secret、FlareMo PAT 与 Cloudflare Access Service Token 是不同边界，不能互相替代；PAT 不能写进 `wrangler.jsonc`、Git 或日志。撤销或轮换 PAT 时，也要同步更新 Telegram Worker secret。
 
 ## 飞书、Discord 和 Slack
 

--- a/docs/deploy-button-test.md
+++ b/docs/deploy-button-test.md
@@ -104,7 +104,7 @@ Deploy Button 自动处理：
 - D1 database 和 R2 bucket 能由部署流程新建并绑定：通过。
 - 部署命令可以自动执行远端 D1 migrations：通过。
 - 首次 Worker 部署和后续 push 自动部署：通过。
-- 生产访问由 Cloudflare Access 接管，FlareMo 不要求应用内 Bearer token：部署后由使用者配置 Access。
+- 生产访问可以由 Cloudflare Access 作为外层防线，但 FlareMo 私有 API 仍要求 Better Auth cookie/session bearer 或 `memos_pat_` PAT。
 
 ## 部署后仍需人工确认
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,6 +65,8 @@ FlareMo 的应用层认证由 Better Auth 提供。当前是“单用户完整�
 
 Cloudflare Access 可以作为额外的外层防线，但 Access 身份或 Access Service Token 不会自动映射为 FlareMo 用户。启用 Access 时必须同时满足外层 policy 和下面的应用层认证。
 
+生产还应在 Cloudflare WAF/Rate Limiting 中为 `/api/auth/sign-in/*`、`/api/auth/flaremo/bootstrap`、`/api/auth/flaremo/recover` 和 `/api/auth/flaremo/recover-bootstrap` 配置按 IP/入口的失败或请求速率限制。Better Auth 的 Worker 内置限流是单 isolate 的补充，不是跨边缘位置的唯一 credential-stuffing 防护；bootstrap/recovery 自定义路由也不自动进入 Better Auth handler 的限流范围。
+
 ### 1. 配置公开变量
 
 在 `wrangler.jsonc` 的 `vars` 中设置：
@@ -99,7 +101,7 @@ pnpm exec wrangler secret put BETTER_AUTH_SECRET --config ./wrangler.jsonc
 pnpm exec wrangler secret put FLAREMO_BOOTSTRAP_SECRET --config ./wrangler.jsonc
 ```
 
-`BETTER_AUTH_SECRET` 至少需要 32 个字符。`BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 应由部署者在密码管理器或安全随机数工具中生成，不能写入 `wrangler.jsonc`、`.dev.vars.example`、Git、issue、PR、日志或聊天记录。`FLAREMO_RECOVERY_SECRET` 是可选的独立 break-glass secret，也至少需要 32 个字符；正常运行时可以不配置，只在明确批准的 operator recovery 窗口临时配置，成功后立即轮换或删除。
+`BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 都至少需要 32 个字符。两者应由部署者在密码管理器或安全随机数工具中生成，不能写入 `wrangler.jsonc`、`.dev.vars.example`、Git、issue、PR、日志或聊天记录。`FLAREMO_RECOVERY_SECRET` 是可选的独立 break-glass secret，也至少需要 32 个字符；正常运行时可以不配置，只在明确批准的 operator recovery 窗口临时配置，成功后立即轮换或删除。生产 `FLAREMO_PUBLIC_URL` 必须使用 HTTPS；HTTP 只允许本地开发 origin。
 
 Wrangler secret 是写入式配置，部署者应把值保存在自己的密码管理器中；不要尝试通过命令回读、打印或把它传给 Agent。后续只验证 secret 已使 bootstrap status 显示 `setup_available: true`，不验证或输出 secret 本身。
 

--- a/docs/en/agent-deploy.md
+++ b/docs/en/agent-deploy.md
@@ -43,7 +43,7 @@ If the instance is protected by Cloudflare Access, unauthenticated requests shou
 curl -sSL "$FLAREMO_URL" | rg "Log in|Cloudflare Access|FlareMo"
 ```
 
-Scripts need an Access Service Token:
+Scripts need a FlareMo `memos_pat_` application token. If the deployment still uses Cloudflare Access, they also need an Access Service Token:
 
 ```bash
 curl "$FLAREMO_URL/api/v1/memos" \

--- a/docs/en/deploy.md
+++ b/docs/en/deploy.md
@@ -39,7 +39,7 @@ The current `/api/v1` wire is the current Memos-style camelCase/protobuf-JSON su
 Recommended boundary:
 
 - Human access: `Allow` identity policy.
-- Scripts, MCP, and Memos-compatible clients: `Service Auth` policy plus Access Service Token.
+- Scripts, MCP, and Memos-compatible clients: FlareMo `memos_pat_` application token; if Access remains enabled, add a `Service Auth` policy plus Access Service Token.
 - Public shares and static assets: narrowly scoped `Bypass` policies.
 
 ### 1. Create an Access application
@@ -72,7 +72,7 @@ This policy protects the browser UI. Authenticated users receive a Cloudflare Ac
 
 ### 3. Create a Service Token
 
-Scripts, MCP, and Memos-compatible clients usually cannot complete a browser login flow. Use an Access Service Token for those clients.
+Scripts, MCP, and Memos-compatible clients usually cannot complete a browser login flow. Use a FlareMo `memos_pat_` application token for the Worker; if the deployment is behind Access, add an Access Service Token for the outer policy.
 
 In the Cloudflare Dashboard, go to `Zero Trust` -> `Access` -> `Service Auth` -> `Service Tokens`, then create a token such as:
 
@@ -180,7 +180,7 @@ curl -I "$FLAREMO_URL/api/public/shares/not-a-real-token"
 
 - The root hostname or Worker URL has a Cloudflare Access application.
 - Human access uses an `Allow` policy scoped to allowed users only.
-- Scripts, MCP, and Memos-compatible clients use a `Service Auth` policy and Access Service Token.
+- Scripts, MCP, and Memos-compatible clients use a FlareMo `memos_pat_` token, plus a `Service Auth` policy and Access Service Token when Access remains enabled.
 - The `Client Secret` is not committed to the repository, issues, PRs, or public logs.
 - `/share/*`, `/api/public/shares/*`, and `/assets/*` have explicit `Bypass` policies.
 - The root application, `/api/v1/*`, and `/openapi.json` are not bypassed.

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -43,7 +43,7 @@ Access Service Token 只通过外层 Access policy，不会自动变成 FlareMo 
 | OpenAPI consumers | API schema 工具 | 当前工作树 | `/openapi.json` | OpenAPI 描述可公开读取；私有 API 请求需 PAT | 可用（schema surface） | `apps/worker/src/memos-compatibility.test.ts` 断言默认 current OpenAPI 和显式 legacy OpenAPI。 |
 | FlareMo legacy MCP endpoint | MCP 客户端 | 当前工作树 | `/api/v1/mcp` | `memos_pat_`；Access 开启时再加 Access headers | 部分可用（旧式 JSON-RPC） | `apps/worker/src/auth.test.ts` 覆盖 PAT `tools/list`；保留给已有 FlareMo 客户端。 |
 | FlareMo current MCP endpoint | MCP 客户端 | 当前工作树 | `/mcp` | Better Auth cookie/session bearer 或 `memos_pat_`；Access 开启时再加 Access headers | 可用（stateless protocol subset） | `apps/worker/src/mcp-streamable.test.ts` 和 `apps/worker/src/memos-compatibility.test.ts` 覆盖 `initialize`、`notifications/initialized`、`tools/list`、`tools/call` 和工具错误 envelope；未验证所有第三方 MCP client。 |
-| FlareMo Telegram Worker example | Telegram Bot | 当前工作树 | Telegram webhook -> `/api/v1/memos` | 需要 PAT；现有示例的 Access-only 发送路径需单独更新 | 部分可用 / 待回归 | 现有示例测试覆盖 webhook 和 Access headers，但不证明新的应用层 PAT 已接通。 |
+| FlareMo Telegram Worker example | Telegram Bot | 当前工作树 | Telegram webhook -> `/api/v1/memos` | 必须使用 PAT；Access headers 仅在生产仍启用 Access 时成对追加 | contract-tested subset | Worker tests cover PAT-only native auth, optional Access headers, fail-closed secret configuration, and webhook validation；不等于真实 Telegram/生产 smoke。 |
 | Public share reader | 浏览器 / curl | 当前工作树 | `/share/*`、`/api/public/shares/*` | 不需要 session/PAT；Access 开启时需 bypass | 可用（share contract） | Worker 测试覆盖 token 隔离、撤销和附件读取。 |
 
 ## 第三方客户端待测矩阵

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -116,7 +116,7 @@ Vectorize V2 的 mutation 可能不是立刻对查询可见，因此查询层必
 ## 隐私边界
 
 - 生产实例仍由 Cloudflare Access 保护。
-- 脚本、MCP 和 Memos-compatible 客户端仍使用 Access Service Token。
+- 脚本、MCP 和 Memos-compatible 客户端使用 FlareMo `memos_pat_` PAT；如果生产入口仍启用 Cloudflare Access，再附加 Access Service Token。Access Service Token 不能替代应用层 PAT。
 - embedding provider 只能接收必要的 memo 文本。
 - 不索引已删除 memo。
 - 私密 memo 可以进入私有语义索引，但查询必须限制在同一用户和同一 Access 边界内。

--- a/packages/domain/src/auth.ts
+++ b/packages/domain/src/auth.ts
@@ -13,6 +13,7 @@ import { ConflictError } from "./errors";
 import { ensureSingleUser, type SingleUserConfig } from "./users";
 
 const OWNER_BOOTSTRAP_ID = "bootstrap/owner";
+const OWNER_FLAREMO_USER_ID = "users/owner";
 
 export type AuthBootstrapState = "ready" | "complete" | "recovery_required";
 
@@ -24,22 +25,35 @@ export type AuthBootstrapStatus = {
 export async function getAuthBootstrapStatus(
   db: FlareMoDb,
 ): Promise<AuthBootstrapStatus> {
-  const [link, bootstrap, unlinkedAuthUser] = await Promise.all([
-    db.query.authUserLinks.findFirst(),
+  const [links, bootstrap, authUserRows] = await Promise.all([
+    db.select().from(authUserLinks),
     db.query.authBootstrap.findFirst({
       where: eq(authBootstrap.id, OWNER_BOOTSTRAP_ID),
     }),
-    db.query.authUsers.findFirst(),
+    db.select({ id: authUsers.id }).from(authUsers),
   ]);
 
-  if (link) {
+  const hasExactCompletedLink = Boolean(
+    bootstrap?.state === "complete" &&
+      bootstrap.authUserId &&
+      bootstrap.flaremoUserId === OWNER_FLAREMO_USER_ID &&
+      links.some(
+        (link) =>
+          link.authUserId === bootstrap.authUserId &&
+          link.flaremoUserId === bootstrap.flaremoUserId,
+      ),
+  );
+
+  if (hasExactCompletedLink) {
     return { initialized: true, state: "complete" };
   }
 
-  // An authentication identity without a FlareMo owner mapping can be the
-  // result of a partial bootstrap. Do not let a new request claim ownership;
-  // require a deliberate operator recovery instead.
-  if (unlinkedAuthUser || bootstrap) {
+  // An authentication identity, link, or bootstrap claim without a fully
+  // consistent completion record can be the result of a partial bootstrap.
+  // Do not let a new request claim ownership; require deliberate operator
+  // recovery instead. In particular, a future user link must not make the
+  // single-user owner bootstrap appear complete.
+  if (authUserRows.length > 0 || links.length > 0 || bootstrap) {
     return { initialized: false, state: "recovery_required" };
   }
 
@@ -102,6 +116,109 @@ export async function markOwnerBootstrapRecoveryRequired(
 }
 
 /**
+ * Reconcile a failed owner bootstrap without opening signup again.
+ *
+ * This deliberately accepts only a recovery-required singleton and only the
+ * shapes that can be proven unambiguous: one Better Auth user, zero or one
+ * auth-to-domain links, and (when present) an exact link to users/owner. It
+ * never creates a Better Auth identity and it does not accept caller-supplied
+ * user data.
+ */
+export async function reconcileOwnerBootstrap(db: FlareMoDb): Promise<UserRow> {
+  const [bootstrap, authUserRows, links] = await Promise.all([
+    db.query.authBootstrap.findFirst({
+      where: eq(authBootstrap.id, OWNER_BOOTSTRAP_ID),
+    }),
+    db.select().from(authUsers),
+    db.select().from(authUserLinks),
+  ]);
+
+  if (bootstrap?.state !== "recovery_required") {
+    throw new ConflictError(
+      "Owner bootstrap recovery requires a recovery-required state.",
+    );
+  }
+  if (authUserRows.length !== 1) {
+    throw new ConflictError(
+      "Owner bootstrap recovery requires exactly one authentication identity.",
+    );
+  }
+  if (links.length > 1) {
+    throw new ConflictError(
+      "Owner bootstrap recovery found an ambiguous identity mapping.",
+    );
+  }
+
+  const authUser = authUserRows[0];
+  if (!authUser) {
+    throw new ConflictError(
+      "Owner bootstrap recovery found no authentication identity.",
+    );
+  }
+
+  if (
+    (bootstrap.authUserId && bootstrap.authUserId !== authUser.id) ||
+    (bootstrap.flaremoUserId &&
+      bootstrap.flaremoUserId !== OWNER_FLAREMO_USER_ID)
+  ) {
+    throw new ConflictError(
+      "Owner bootstrap recovery found an inconsistent completion record.",
+    );
+  }
+
+  const existingLink = links[0];
+  if (
+    existingLink &&
+    (existingLink.authUserId !== authUser.id ||
+      existingLink.flaremoUserId !== OWNER_FLAREMO_USER_ID)
+  ) {
+    throw new ConflictError(
+      "Owner bootstrap recovery found an inconsistent identity mapping.",
+    );
+  }
+
+  const user = await ensureSingleUser(db, {
+    email: authUser.email,
+    name: authUser.name,
+  });
+
+  if (!existingLink) {
+    await db
+      .insert(authUserLinks)
+      .values({
+        authUserId: authUser.id,
+        flaremoUserId: user.id,
+        createdAt: new Date(),
+      })
+      .onConflictDoNothing();
+  }
+
+  const completed = await db
+    .update(authBootstrap)
+    .set({
+      state: "complete",
+      authUserId: authUser.id,
+      flaremoUserId: user.id,
+      completedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(authBootstrap.id, OWNER_BOOTSTRAP_ID),
+        eq(authBootstrap.state, "recovery_required"),
+      ),
+    )
+    .returning({ id: authBootstrap.id });
+
+  if (!completed[0]) {
+    throw new ConflictError(
+      "Owner bootstrap recovery was changed concurrently; retry the operation.",
+    );
+  }
+
+  return user;
+}
+
+/**
  * Return the already-linked owner identity for a completed single-user
  * bootstrap. Recovery must target this identity in place; it must never create
  * another Better Auth user or another domain owner.
@@ -115,7 +232,7 @@ export async function getOwnerAuthUserId(
   if (
     bootstrap?.state !== "complete" ||
     !bootstrap.authUserId ||
-    !bootstrap.flaremoUserId
+    bootstrap.flaremoUserId !== OWNER_FLAREMO_USER_ID
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary

- close partial Better Auth bootstrap recovery and fail-closed identity mapping
- enforce Origin validation on current bearer session refresh
- add no-store handling for credential responses
- make current signout revoke bearer sessions and clear cookie sessions together
- require production HTTPS and a sufficiently strong bootstrap secret
- move Telegram ingestion to a Better Auth memos_pat_ with optional Cloudflare Access outer protection
- document WAF/rate-limit and public-share Access policy boundaries

## Compatibility boundary

This release provides FlareMo native Better Auth, the current camelCase REST subset, PAT foundations, and the tested current MCP/Streamable HTTP subset. It does not claim complete Memos Server parity, native JWT parity, or verified compatibility with every third-party Memos client.

## Database and deployment

- no new D1 migration
- migration-safe changes only
- no secrets, passwords, cookies, PATs, or Access tokens are included

## Verification

- pnpm verify
- pnpm deploy:dry-run
- pnpm backup:drill

Refs #1