### PR TITLE
fix: route native auth metadata through Worker

### DIFF
--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -393,6 +393,30 @@ describe("FlareMo Worker API", () => {
     });
   });
 
+  it("returns JSON authentication errors for protected metadata endpoints", async () => {
+    const health = await fetchApp(
+      "http://flaremo.test/api/app/health",
+      undefined,
+      { authenticated: false },
+    );
+    expect(health.status).toBe(401);
+    expect(health.headers.get("content-type")).toContain("application/json");
+    expect(await health.json()).toEqual({
+      error: { message: "Authentication required" },
+    });
+
+    const openapi = await fetchApp(
+      "http://flaremo.test/api/v1/openapi.json",
+      undefined,
+      { authenticated: false },
+    );
+    expect(openapi.status).toBe(401);
+    expect(openapi.headers.get("content-type")).toContain("application/json");
+    expect(await openapi.json()).toEqual({
+      error: { message: "Authentication required" },
+    });
+  });
+
   it("paginates memos with page tokens", async () => {
     await createMemo("page first");
     await new Promise((resolve) => setTimeout(resolve, 2));

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -102,12 +102,16 @@ app.get("/openapi.json", (c) =>
   ),
 );
 app.get("/api/v1/openapi.json", async (c) => {
-  await getRequestContext(c);
-  return c.json(
-    isLegacyWireRequest(c)
-      ? createOpenApiDocument()
-      : createCurrentOpenApiDocument(),
-  );
+  try {
+    await getRequestContext(c);
+    return c.json(
+      isLegacyWireRequest(c)
+        ? createOpenApiDocument()
+        : createCurrentOpenApiDocument(),
+    );
+  } catch (error) {
+    return jsonError(c, error);
+  }
 });
 
 app.notFound((c) => {

--- a/apps/worker/src/routes/app-api.ts
+++ b/apps/worker/src/routes/app-api.ts
@@ -30,19 +30,25 @@ const FLAREMO_UPDATE_GUIDE_URL =
   "https://github.com/realchendahuang/FlareMo/blob/main/docs/update.md";
 
 appApi.get("/health", async (c) => {
-  await getRequestContext(c);
-  const repository = normalizeGitHubRepository(c.env.FLAREMO_DEPLOY_REPOSITORY);
-  return c.json({
-    ok: true,
-    product: "FlareMo",
-    version: FLAREMO_API_VERSION,
-    update_repository: repository,
-    update_workflow_url: repository
-      ? `https://github.com/${repository}/actions/workflows/flaremo-update.yml`
-      : null,
-    releases_url: FLAREMO_RELEASES_URL,
-    update_guide_url: FLAREMO_UPDATE_GUIDE_URL,
-  });
+  try {
+    await getRequestContext(c);
+    const repository = normalizeGitHubRepository(
+      c.env.FLAREMO_DEPLOY_REPOSITORY,
+    );
+    return c.json({
+      ok: true,
+      product: "FlareMo",
+      version: FLAREMO_API_VERSION,
+      update_repository: repository,
+      update_workflow_url: repository
+        ? `https://github.com/${repository}/actions/workflows/flaremo-update.yml`
+        : null,
+      releases_url: FLAREMO_RELEASES_URL,
+      update_guide_url: FLAREMO_UPDATE_GUIDE_URL,
+    });
+  } catch (error) {
+    return jsonError(c, error);
+  }
 });
 
 appApi.get("/memos", zValidator("query", listMemosQuerySchema), async (c) => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,7 +12,7 @@
     "directory": "./apps/web/dist",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"]
+    "run_worker_first": ["/api/*", "/mcp", "/openapi.json"]
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

- return JSON 401 responses instead of uncaught 500s for unauthenticated health and current OpenAPI metadata requests
- make root /openapi.json and /mcp execute in the Worker before static asset SPA fallback
- add regression coverage for protected metadata error responses

## Verification

- pnpm verify
- pnpm deploy:dry-run
- Worker tests: 37 passed
- E2E: 21 passed

## Deployment boundary

The FlareMo Cloudflare Access application was removed separately in the Cloudflare control plane so Better Auth is now the public application authentication boundary. No secrets, passwords, cookies, PATs, or Access tokens are included.

Refs #1