### PR TITLE
feat: harden Memos compatibility boundaries

### DIFF
--- a/apps/worker/src/context.ts
+++ b/apps/worker/src/context.ts
@@ -88,6 +88,35 @@ export async function getRequestContext(c: Context<HonoBindings>) {
   return getBrowserRequestContext(c, { auth, db });
 }
 
+/**
+ * Read-only Memos endpoints may serve an anonymous public view. Do not use
+ * the single-user owner as a fallback: that would make a missing credential
+ * equivalent to the owner's private session. Any explicit bearer credential
+ * remains fail-closed and is never downgraded to anonymous access.
+ */
+export async function getOptionalRequestContext(c: Context<HonoBindings>) {
+  try {
+    return await getRequestContext(c);
+  } catch (error) {
+    if (
+      error instanceof UnauthorizedError &&
+      !c.req.raw.headers.has("authorization") &&
+      !c.req.raw.headers.has("cookie")
+    ) {
+      return {
+        db: createDb(c.env.DB),
+        user: null,
+        authUserId: null,
+        credential: "anonymous" as const,
+        bearerSession: false,
+        nativeAccessToken: false,
+        session: null,
+      };
+    }
+    throw error;
+  }
+}
+
 export async function getBrowserRequestContext(
   c: Context<HonoBindings>,
   supplied?: {
@@ -128,6 +157,23 @@ export function assertTrustedCookieMutation(c: Context<HonoBindings>) {
   const origin = c.req.header("origin");
   if (!origin || !getTrustedOrigins(c.env).includes(origin)) {
     throw new ForbiddenError("This browser request must use FlareMo's origin.");
+  }
+}
+
+/**
+ * Validate the transport-level credential boundary before a public Connect
+ * method can short-circuit authentication. Public reads may omit credentials,
+ * but a supplied bearer or cookie must still obey the same exact-origin rule
+ * as authenticated private routes.
+ */
+export function assertRequestCredentialBoundary(c: Context<HonoBindings>) {
+  const token = getBearerToken(c.req.raw.headers);
+  if (token) {
+    assertTrustedBearerOrigin(c);
+    return;
+  }
+  if (c.req.raw.headers.has("cookie")) {
+    assertTrustedCookieMutation(c);
   }
 }
 

--- a/apps/worker/src/memos-auth-golden.test.ts
+++ b/apps/worker/src/memos-auth-golden.test.ts
@@ -1,0 +1,256 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createDb } from "@flaremo/db";
+import { completeOwnerBootstrap } from "@flaremo/domain";
+import { Miniflare } from "miniflare";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFlareMoAuth } from "./auth";
+import type { FlareMoEnv } from "./env";
+import {
+  issueMemosNativeTokens,
+  rotateMemosRefreshToken,
+} from "./memos-native-auth";
+
+const TEST_ONLY_EMAIL = "golden-owner@example.test";
+const TEST_ONLY_NAME = "Golden Owner";
+const TEST_ONLY_USERNAME = "owner";
+const FIXTURE_ISSUED_AT = 1_735_689_600;
+const FIXTURE_ACCESS_EXPIRES_AT = 1_735_690_500;
+const FIXTURE_REFRESH_EXPIRES_AT = 1_738_281_600;
+const FIXTURE_FIRST_TOKEN_ID = "00000000-0000-4000-8000-000000000001";
+const FIXTURE_SECOND_TOKEN_ID = "00000000-0000-4000-8000-000000000002";
+
+let runtime: Miniflare;
+let env: Env;
+let database: D1Database;
+
+describe("native Memos auth deterministic golden fixture", () => {
+  beforeEach(async () => {
+    ({ runtime, env, database } = await createTestRuntime());
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    await runtime.dispose();
+  });
+
+  it("keeps Better Auth-linked access and rotating refresh JWT bytes deterministic", async () => {
+    const authUser = await createBetterAuthLinkedOwner();
+    const request = new Request("http://flaremo.test/api/v1/auth/signin", {
+      headers: {
+        "cf-connecting-ip": "127.0.0.1",
+        "user-agent": "memos-auth-golden-test",
+      },
+    });
+
+    vi.useFakeTimers({ now: FIXTURE_ISSUED_AT * 1_000, toFake: ["Date"] });
+    vi.spyOn(globalThis.crypto, "randomUUID")
+      .mockReturnValueOnce(FIXTURE_FIRST_TOKEN_ID)
+      .mockReturnValueOnce(FIXTURE_SECOND_TOKEN_ID);
+
+    const issued = await issueMemosNativeTokens({
+      db: createDb(database),
+      env: env as FlareMoEnv,
+      authUserId: authUser.id,
+      user: authUser.user,
+      request,
+    });
+
+    const expectedAccessToken = await signReferenceJwt(
+      {
+        alg: "HS256",
+        kid: "v1",
+        typ: "JWT",
+      },
+      {
+        type: "access",
+        role: "ADMIN",
+        status: "NORMAL",
+        username: "owner",
+        iss: "memos",
+        sub: "1",
+        aud: ["user.access-token"],
+        exp: FIXTURE_ACCESS_EXPIRES_AT,
+        iat: FIXTURE_ISSUED_AT,
+      },
+      env.BETTER_AUTH_SECRET,
+    );
+    const expectedFirstRefreshToken = await signReferenceJwt(
+      {
+        alg: "HS256",
+        kid: "v1",
+        typ: "JWT",
+      },
+      {
+        type: "refresh",
+        tid: FIXTURE_FIRST_TOKEN_ID,
+        iss: "memos",
+        sub: "1",
+        aud: ["user.refresh-token"],
+        exp: FIXTURE_REFRESH_EXPIRES_AT,
+        iat: FIXTURE_ISSUED_AT,
+      },
+      env.BETTER_AUTH_SECRET,
+    );
+
+    expect(issued).toMatchObject({
+      accessToken: expectedAccessToken,
+      accessTokenExpiresAt: new Date(FIXTURE_ACCESS_EXPIRES_AT * 1_000),
+      refreshTokenExpiresAt: new Date(FIXTURE_REFRESH_EXPIRES_AT * 1_000),
+      subject: 1,
+    });
+    expect(issued.refreshCookie).toContain(
+      `memos_refresh=${expectedFirstRefreshToken};`,
+    );
+    expect(issued.refreshCookie).toContain(
+      "Expires=Fri, 31 Jan 2025 00:00:00 GMT; SameSite=Lax",
+    );
+
+    const rotated = await rotateMemosRefreshToken({
+      db: createDb(database),
+      env: env as FlareMoEnv,
+      expectedAuthUserId: authUser.id,
+      request: new Request("http://flaremo.test/api/v1/auth/refresh", {
+        headers: {
+          cookie: issued.refreshCookie,
+          "user-agent": "memos-auth-golden-test",
+        },
+      }),
+    });
+
+    const expectedSecondRefreshToken = await signReferenceJwt(
+      {
+        alg: "HS256",
+        kid: "v1",
+        typ: "JWT",
+      },
+      {
+        type: "refresh",
+        tid: FIXTURE_SECOND_TOKEN_ID,
+        iss: "memos",
+        sub: "1",
+        aud: ["user.refresh-token"],
+        exp: FIXTURE_REFRESH_EXPIRES_AT,
+        iat: FIXTURE_ISSUED_AT,
+      },
+      env.BETTER_AUTH_SECRET,
+    );
+
+    expect(rotated).toMatchObject({
+      accessToken: expectedAccessToken,
+      accessTokenExpiresAt: new Date(FIXTURE_ACCESS_EXPIRES_AT * 1_000),
+      authUserId: authUser.id,
+      flaremoUserId: "users/owner",
+      subject: 1,
+    });
+    expect(rotated.refreshCookie).toContain(
+      `memos_refresh=${expectedSecondRefreshToken};`,
+    );
+  });
+});
+
+async function createBetterAuthLinkedOwner() {
+  const auth = createFlareMoAuth(env as FlareMoEnv, createDb(database), {
+    allowBootstrapSignUp: true,
+  });
+  const result = await auth.api.signUpEmail({
+    body: {
+      email: TEST_ONLY_EMAIL,
+      name: TEST_ONLY_NAME,
+      password: `test-${crypto.randomUUID()}`,
+      username: TEST_ONLY_USERNAME,
+      displayUsername: TEST_ONLY_USERNAME,
+    },
+  });
+  const user = await completeOwnerBootstrap(createDb(database), {
+    authUserId: result.user.id,
+    singleUser: { email: TEST_ONLY_EMAIL, name: TEST_ONLY_NAME },
+  });
+  return { id: result.user.id, user };
+}
+
+async function createTestRuntime() {
+  const instance = new Miniflare({
+    script: "export default { fetch() { return new Response('ok') } }",
+    modules: true,
+    compatibilityDate: "2026-07-10",
+    compatibilityFlags: ["nodejs_compat"],
+    d1Databases: { DB: `flaremo-auth-golden-${crypto.randomUUID()}` },
+    r2Buckets: {
+      ATTACHMENTS: `flaremo-auth-golden-attachments-${crypto.randomUUID()}`,
+    },
+  });
+  const db = await instance.getD1Database("DB");
+  for (const filename of [
+    "0000_illegal_inhumans.sql",
+    "0001_familiar_morph.sql",
+    "0002_wooden_professor_monster.sql",
+    "0003_equal_maximus.sql",
+    "0004_complex_the_enforcers.sql",
+    "0005_confused_masque.sql",
+    "0006_silent_kylun.sql",
+    "0007_flat_phil_sheldon.sql",
+  ]) {
+    const migration = await readFile(
+      resolve(import.meta.dirname, `../../../migrations/${filename}`),
+      "utf8",
+    );
+    for (const statement of migration
+      .split("--> statement-breakpoint")
+      .map((item) => item.trim())
+      .filter(Boolean)) {
+      await db.prepare(statement).run();
+    }
+  }
+
+  return {
+    runtime: instance,
+    database: db,
+    env: {
+      DB: db,
+      ATTACHMENTS: await instance.getR2Bucket("ATTACHMENTS"),
+      ASSETS: {
+        fetch: async () => new Response("asset"),
+      } as Fetcher,
+      FLAREMO_SINGLE_USER_EMAIL: TEST_ONLY_EMAIL,
+      FLAREMO_SINGLE_USER_NAME: TEST_ONLY_NAME,
+      FLAREMO_PUBLIC_URL: "http://flaremo.test",
+      BETTER_AUTH_SECRET: crypto.randomUUID(),
+    } as Env,
+  };
+}
+
+async function signReferenceJwt(
+  header: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  secret: string,
+) {
+  const encodedHeader = encodeBase64Url(JSON.stringify(header));
+  const encodedPayload = encodeBase64Url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${encodeBase64Url(new Uint8Array(signature))}`;
+}
+
+function encodeBase64Url(value: string | Uint8Array) {
+  const bytes =
+    typeof value === "string" ? new TextEncoder().encode(value) : value;
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/u, "");
+}

--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -484,14 +484,22 @@ describe("Memos-compatible API contract", () => {
       { authenticated: false },
     );
     expect(currentOpenapi.status).toBe(200);
-    expect(await currentOpenapi.json()).toMatchObject({
+    const currentOpenapiBody = await currentOpenapi.json();
+    expect(currentOpenapiBody).toMatchObject({
       info: { title: "FlareMo current Memos-compatible API" },
       paths: {
         "/api/v1/auth/signin": expect.any(Object),
         "/api/v1/memos": expect.any(Object),
+        "/memos.api.v1.MemoService/GetMemoByShare": expect.any(Object),
+        "/memos.api.v1.AttachmentService/ListAttachments": expect.any(Object),
+        "/memos.api.v1.InstanceService/GetInstanceProfile": expect.any(Object),
         "/mcp": expect.any(Object),
       },
     });
+    expect(
+      currentOpenapiBody.paths["/memos.api.v1.MemoService/GetMemo"].post
+        .security,
+    ).toEqual(expect.arrayContaining([{}]));
 
     const legacyOpenapi = await fetchApp(
       "http://flaremo.test/openapi.json",
@@ -1156,8 +1164,10 @@ describe("Memos-compatible API contract", () => {
       undefined,
       { authenticated: false },
     );
-    expect(unauthenticated.status).toBe(401);
-    expect(await unauthenticated.json()).toMatchObject({ code: 16 });
+    expect(unauthenticated.status).toBe(200);
+    expect(await unauthenticated.json()).toMatchObject({
+      memos: expect.any(Array),
+    });
   });
 
   it("clears the cookie session when current signout receives both credentials", async () => {

--- a/apps/worker/src/memos-protobuf.test.ts
+++ b/apps/worker/src/memos-protobuf.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   decodeBinaryRequest,
+  decodeBinaryResponse,
   detectBinaryTransport,
+  encodeBinaryError,
   encodeBinaryResponse,
 } from "./memos-protobuf";
 
@@ -57,5 +59,149 @@ describe("Memos protobuf transport", () => {
     expect(bytes[0]).toBe(0);
     expect(new DataView(bytes.buffer).getUint32(1)).toBe(bytes.length - 5);
     expect(new TextDecoder().decode(bytes)).toContain("memos/one");
+  });
+
+  it("uses upstream service field numbers for attachment and user requests", () => {
+    const content = Uint8Array.from([1, 2, 3]);
+    const attachment = Uint8Array.from([
+      0x1a,
+      5,
+      ...new TextEncoder().encode("a.txt"),
+      0x22,
+      content.length,
+      ...content,
+      0x32,
+      10,
+      ...new TextEncoder().encode("text/plain"),
+    ]);
+    const request = Uint8Array.from([0x0a, attachment.length, ...attachment]);
+    expect(
+      decodeBinaryRequest(
+        "memos.api.v1.AttachmentService",
+        "CreateAttachment",
+        request,
+        "connect-proto",
+      ),
+    ).toEqual({
+      attachment: {
+        filename: "a.txt",
+        content,
+        type: "text/plain",
+      },
+    });
+
+    const userName = new TextEncoder().encode("users/owner");
+    expect(
+      decodeBinaryRequest(
+        "memos.api.v1.UserService",
+        "GetUser",
+        Uint8Array.from([0x0a, userName.length, ...userName]),
+        "connect-proto",
+      ),
+    ).toEqual({ name: "users/owner" });
+  });
+
+  it("keeps protobuf error status code aligned with the transport status", () => {
+    expect(
+      Array.from(encodeBinaryError("unauthenticated", "connect-proto", 16)),
+    ).toEqual([
+      0x08,
+      0x10,
+      0x12,
+      15,
+      ...new TextEncoder().encode("unauthenticated"),
+    ]);
+  });
+
+  it("decodes unary responses for the expanded service subset", () => {
+    const attachmentResponse = encodeBinaryResponse(
+      "memos.api.v1.AttachmentService",
+      "ListAttachments",
+      {
+        attachments: [
+          {
+            name: "attachments/one",
+            filename: "one.txt",
+            type: "text/plain",
+            size: "3",
+            memo: "memos/one",
+          },
+        ],
+        totalSize: 1,
+      },
+      "grpc-web-proto",
+    );
+    expect(
+      decodeBinaryResponse(
+        "memos.api.v1.AttachmentService",
+        "ListAttachments",
+        attachmentResponse as Uint8Array,
+        "grpc-web-proto",
+      ),
+    ).toMatchObject({
+      attachments: [
+        {
+          name: "attachments/one",
+          filename: "one.txt",
+          type: "text/plain",
+          size: "3",
+          memo: "memos/one",
+        },
+      ],
+      totalSize: 1,
+    });
+
+    const settingsResponse = encodeBinaryResponse(
+      "memos.api.v1.InstanceService",
+      "BatchGetInstanceSettings",
+      {
+        settings: [
+          {
+            name: "instance/settings/GENERAL",
+            value: {
+              case: "generalSetting",
+              value: { disallowUserRegistration: true },
+            },
+          },
+        ],
+      },
+      "grpc-web-text-proto",
+    );
+    expect(
+      decodeBinaryResponse(
+        "memos.api.v1.InstanceService",
+        "BatchGetInstanceSettings",
+        new TextEncoder().encode(settingsResponse as string),
+        "grpc-web-text-proto",
+      ),
+    ).toEqual({
+      settings: [
+        {
+          name: "instance/settings/GENERAL",
+          value: {
+            case: "generalSetting",
+            value: { disallowUserRegistration: true },
+          },
+        },
+      ],
+    });
+
+    const usersResponse = encodeBinaryResponse(
+      "memos.api.v1.UserService",
+      "ListUsers",
+      { users: [{ name: "users/owner", username: "owner" }], totalSize: 1 },
+      "connect-proto",
+    );
+    expect(
+      decodeBinaryResponse(
+        "memos.api.v1.UserService",
+        "ListUsers",
+        usersResponse as Uint8Array,
+        "connect-proto",
+      ),
+    ).toMatchObject({
+      users: [{ name: "users/owner", username: "owner" }],
+      totalSize: 1,
+    });
   });
 });

--- a/apps/worker/src/memos-protobuf.ts
+++ b/apps/worker/src/memos-protobuf.ts
@@ -56,14 +56,257 @@ export function encodeBinaryResponse(
   return transport === "grpc-web-text-proto" ? encodeBase64(framed) : framed;
 }
 
-export function encodeBinaryError(message: string, transport: BinaryTransport) {
-  // google.rpc.Status: code=3 (INVALID_ARGUMENT), message=2. HTTP status and
-  // grpc-status headers are still supplied by the route for transport-aware
-  // clients; this body makes Connect protobuf errors inspectable as well.
-  const status = new ProtoWriter().int32(1, 3).string(2, message).finish();
+export function encodeBinaryError(
+  message: string,
+  transport: BinaryTransport,
+  code = 3,
+) {
+  // google.rpc.Status: code=1, message=2. The HTTP status and transport
+  // headers remain authoritative for Connect/gRPC clients, but the body must
+  // carry the same status code instead of always pretending every failure is
+  // INVALID_ARGUMENT.
+  const status = new ProtoWriter().int32(1, code).string(2, message).finish();
   if (transport === "connect-proto") return status;
   const framed = encodeGrpcUnaryFrame(status);
   return transport === "grpc-web-text-proto" ? encodeBase64(framed) : framed;
+}
+
+/**
+ * Decode a unary response with the same wire framing rules used by the
+ * Worker. This is intentionally exported for contract tests and local
+ * compatibility probes; request handlers never need to decode their own
+ * response. Keeping the inverse here makes binary tests assert message
+ * fields, rather than only checking that a response contains some text.
+ */
+export function decodeBinaryResponse(
+  service: string,
+  method: string,
+  input: Uint8Array,
+  transport: BinaryTransport,
+): ProtoMessage {
+  const payload =
+    transport === "connect-proto"
+      ? input
+      : decodeGrpcUnaryFrame(
+          transport === "grpc-web-text-proto" ? decodeBase64(input) : input,
+        );
+  return decodeResponseMessage(service, method, payload);
+}
+
+function decodeResponseMessage(
+  service: string,
+  method: string,
+  payload: Uint8Array,
+): ProtoMessage {
+  const reader = new ProtoReader(payload);
+  if (service === "memos.api.v1.MemoService") {
+    switch (method) {
+      case "CreateMemo":
+      case "GetMemo":
+      case "UpdateMemo":
+      case "CreateMemoComment":
+      case "GetSharedMemo":
+      case "GetMemoByShare":
+        return decodeMemo(reader);
+      case "ListMemos":
+      case "ListMemoComments":
+        return decodeListResponse(reader, "memos", decodeMemo, {
+          totalSize: method === "ListMemoComments",
+        });
+      case "ListMemoAttachments":
+        return decodeListResponse(reader, "attachments", decodeAttachment);
+      case "ListMemoRelations":
+        return decodeListResponse(reader, "relations", decodeRelation);
+      case "ListMemoReactions":
+        return decodeListResponse(reader, "reactions", decodeReaction, {
+          totalSize: true,
+        });
+      case "ListMemoShares":
+        return decodeListResponse(reader, "memoShares", decodeMemoShare);
+      case "BatchGetLinkMetadata":
+        return decodeListResponse(reader, "linkMetadata", decodeLinkMetadata);
+      case "CreateMemoShare":
+        return decodeMemoShare(reader);
+      case "GetLinkMetadata":
+        return decodeLinkMetadata(reader);
+      default:
+        return {};
+    }
+  }
+  if (service === "memos.api.v1.AuthService") {
+    const response: ProtoMessage = {};
+    while (!reader.done) {
+      const [field, wire] = reader.tag();
+      if (method === "GetCurrentUser" && field === 1) {
+        response.user = decodeUser(reader.message(wire));
+      } else if (method === "SignIn" && field === 1) {
+        response.user = decodeUser(reader.message(wire));
+      } else if (method === "SignIn" && field === 2) {
+        response.accessToken = reader.string(wire);
+      } else if (method === "SignIn" && field === 3) {
+        response.accessTokenExpiresAt = decodeTimestamp(reader.message(wire));
+      } else if (method === "RefreshToken" && field === 1) {
+        response.accessToken = reader.string(wire);
+      } else if (method === "RefreshToken" && field === 2) {
+        response.expiresAt = decodeTimestamp(reader.message(wire));
+      } else {
+        reader.skip(wire);
+      }
+    }
+    return response;
+  }
+  if (service === "memos.api.v1.ShortcutService") {
+    if (method === "ListShortcuts") {
+      return decodeListResponse(reader, "shortcuts", decodeShortcut);
+    }
+    if (method === "DeleteShortcut") return {};
+    return decodeShortcut(reader);
+  }
+  if (service === "memos.api.v1.AttachmentService") {
+    if (method === "ListAttachments") {
+      return decodeListResponse(reader, "attachments", decodeAttachment, {
+        totalSize: true,
+      });
+    }
+    if (method === "DeleteAttachment" || method === "BatchDeleteAttachments") {
+      return {};
+    }
+    return decodeAttachment(reader);
+  }
+  if (service === "memos.api.v1.UserService") {
+    switch (method) {
+      case "GetUser":
+      case "CreateUser":
+      case "UpdateUser":
+        return decodeUser(reader);
+      case "ListUsers":
+      case "BatchGetUsers":
+        return decodeListResponse(reader, "users", decodeUser, {
+          totalSize: true,
+        });
+      case "ListAllUserStats":
+        return decodeListResponse(reader, "stats", decodeUserStats);
+      case "GetUserStats":
+        return decodeUserStats(reader);
+      case "GetUserSetting":
+      case "UpdateUserSetting":
+        return decodeUserSetting(reader);
+      case "ListUserSettings":
+        return decodeListResponse(reader, "settings", decodeUserSetting, {
+          totalSize: true,
+        });
+      case "ListLinkedIdentities":
+        return decodeListResponse(
+          reader,
+          "linkedIdentities",
+          decodeLinkedIdentity,
+        );
+      case "GetLinkedIdentity":
+      case "CreateLinkedIdentity":
+        return decodeLinkedIdentity(reader);
+      case "ListPersonalAccessTokens":
+        return decodeListResponse(
+          reader,
+          "personalAccessTokens",
+          decodePersonalAccessToken,
+          { totalSize: true },
+        );
+      case "CreatePersonalAccessToken": {
+        const response: ProtoMessage = {};
+        while (!reader.done) {
+          const [field, wire] = reader.tag();
+          if (field === 1)
+            response.personalAccessToken = decodePersonalAccessToken(
+              reader.message(wire),
+            );
+          else if (field === 2) response.token = reader.string(wire);
+          else reader.skip(wire);
+        }
+        return response;
+      }
+      case "ListUserWebhooks":
+        return decodeListResponse(reader, "webhooks", decodeWebhook);
+      case "CreateUserWebhook":
+      case "UpdateUserWebhook":
+        return decodeWebhook(reader);
+      case "GetUserWebhookSigningSecret": {
+        const response: ProtoMessage = {};
+        while (!reader.done) {
+          const [field, wire] = reader.tag();
+          if (field === 1) response.signingSecret = reader.string(wire);
+          else reader.skip(wire);
+        }
+        return response;
+      }
+      case "ListUserNotifications":
+        return decodeListResponse(reader, "notifications", decodeNotification);
+      case "UpdateUserNotification":
+        return decodeNotification(reader);
+      default:
+        return {};
+    }
+  }
+  if (service === "memos.api.v1.InstanceService") {
+    if (method === "GetInstanceProfile") return decodeInstanceProfile(reader);
+    if (method === "GetInstanceSetting" || method === "UpdateInstanceSetting") {
+      return decodeInstanceSetting(reader);
+    }
+    if (method === "BatchGetInstanceSettings") {
+      return decodeListResponse(reader, "settings", decodeInstanceSetting);
+    }
+    if (method === "GetInstanceStats") return decodeInstanceStats(reader);
+    return {};
+  }
+  if (service === "memos.api.v1.IdentityProviderService") {
+    if (method === "ListIdentityProviders") {
+      return decodeListResponse(
+        reader,
+        "identityProviders",
+        decodeIdentityProvider,
+      );
+    }
+    if (
+      method === "GetIdentityProvider" ||
+      method === "CreateIdentityProvider"
+    ) {
+      return decodeIdentityProvider(reader);
+    }
+    return {};
+  }
+  if (service === "memos.api.v1.AIService" && method === "Transcribe") {
+    const response: ProtoMessage = {};
+    while (!reader.done) {
+      const [field, wire] = reader.tag();
+      if (field === 1) response.text = reader.string(wire);
+      else reader.skip(wire);
+    }
+    return response;
+  }
+  throw new ProtoCodecError(`Unsupported protobuf service: ${service}`);
+}
+
+function decodeListResponse(
+  reader: ProtoReader,
+  itemKey: string,
+  decoder: (reader: ProtoReader) => ProtoMessage,
+  options: { totalSize?: boolean } = {},
+) {
+  const response: ProtoMessage = { [itemKey]: [] };
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) {
+      const values = response[itemKey];
+      if (!Array.isArray(values)) response[itemKey] = [];
+      (response[itemKey] as ProtoMessage[]).push(decoder(reader.message(wire)));
+    } else if (field === 2) {
+      response.nextPageToken = reader.string(wire);
+    } else if (field === 3 && options.totalSize) {
+      response.totalSize = reader.int32(wire);
+    } else {
+      reader.skip(wire);
+    }
+  }
+  return response;
 }
 
 function decodeRequestMessage(
@@ -79,6 +322,21 @@ function decodeRequestMessage(
   }
   if (service === "memos.api.v1.ShortcutService") {
     return decodeShortcutServiceRequest(method, payload);
+  }
+  if (service === "memos.api.v1.AttachmentService") {
+    return decodeAttachmentServiceRequest(method, payload);
+  }
+  if (service === "memos.api.v1.UserService") {
+    return decodeUserServiceRequest(method, payload);
+  }
+  if (service === "memos.api.v1.InstanceService") {
+    return decodeInstanceServiceRequest(method, payload);
+  }
+  if (service === "memos.api.v1.IdentityProviderService") {
+    return decodeIdentityProviderServiceRequest(method, payload);
+  }
+  if (service === "memos.api.v1.AIService") {
+    return decodeAiServiceRequest(method, payload);
   }
   throw new ProtoCodecError(`Unsupported protobuf service: ${service}`);
 }
@@ -96,10 +354,17 @@ function encodeResponseMessage(
       case "UpdateMemo":
       case "CreateMemoComment":
       case "GetSharedMemo":
+      case "GetMemoByShare":
         return encodeMemo(body);
       case "ListMemos":
-      case "ListMemoComments":
         return encodeList(body.memos, encodeMemo, body.nextPageToken);
+      case "ListMemoComments":
+        return encodeList(
+          body.memos,
+          encodeMemo,
+          body.nextPageToken,
+          body.totalSize,
+        );
       case "ListMemoAttachments":
         return encodeList(
           body.attachments,
@@ -109,7 +374,14 @@ function encodeResponseMessage(
       case "ListMemoRelations":
         return encodeList(body.relations, encodeRelation, body.nextPageToken);
       case "ListMemoReactions":
-        return encodeList(body.reactions, encodeReaction, body.nextPageToken);
+        return encodeList(
+          body.reactions,
+          encodeReaction,
+          body.nextPageToken,
+          body.totalSize,
+        );
+      case "UpsertMemoReaction":
+        return encodeReaction(body);
       case "ListMemoShares":
         return encodeList(body.memoShares, encodeMemoShare);
       case "BatchGetLinkMetadata":
@@ -162,6 +434,135 @@ function encodeResponseMessage(
       default:
         throw new ProtoCodecError(`Unsupported protobuf method: ${method}`);
     }
+  }
+  if (service === "memos.api.v1.AttachmentService") {
+    switch (method) {
+      case "CreateAttachment":
+      case "GetAttachment":
+      case "UpdateAttachment":
+        return encodeAttachment(body);
+      case "ListAttachments":
+        return encodeList(
+          body.attachments,
+          encodeAttachment,
+          body.nextPageToken,
+          body.totalSize,
+        );
+      case "DeleteAttachment":
+      case "BatchDeleteAttachments":
+        return new Uint8Array();
+      default:
+        throw new ProtoCodecError(`Unsupported protobuf method: ${method}`);
+    }
+  }
+  if (service === "memos.api.v1.UserService") {
+    switch (method) {
+      case "GetUser":
+      case "CreateUser":
+      case "UpdateUser":
+        return encodeUser(body);
+      case "ListUsers":
+      case "BatchGetUsers":
+        return encodeList(
+          body.users,
+          encodeUser,
+          body.nextPageToken,
+          body.totalSize,
+        );
+      case "ListAllUserStats":
+        return encodeList(body.stats, encodeUserStats);
+      case "GetUserStats":
+        return encodeUserStats(body);
+      case "GetUserSetting":
+      case "UpdateUserSetting":
+        return encodeUserSetting(body);
+      case "ListUserSettings":
+        return encodeList(
+          body.settings,
+          encodeUserSetting,
+          body.nextPageToken,
+          body.totalSize,
+        );
+      case "ListLinkedIdentities":
+        return encodeList(body.linkedIdentities, encodeLinkedIdentity);
+      case "GetLinkedIdentity":
+      case "CreateLinkedIdentity":
+        return encodeLinkedIdentity(body);
+      case "ListPersonalAccessTokens":
+        return encodeList(
+          body.personalAccessTokens,
+          encodePersonalAccessToken,
+          body.nextPageToken,
+          body.totalSize,
+        );
+      case "CreatePersonalAccessToken":
+        return new ProtoWriter()
+          .message(1, encodePersonalAccessToken(body.personalAccessToken))
+          .string(2, stringValue(body.token))
+          .finish();
+      case "ListUserWebhooks":
+        return encodeList(body.webhooks, encodeWebhook);
+      case "CreateUserWebhook":
+      case "UpdateUserWebhook":
+        return encodeWebhook(body);
+      case "GetUserWebhookSigningSecret":
+        return new ProtoWriter()
+          .string(1, stringValue(body.signingSecret))
+          .finish();
+      case "ListUserNotifications":
+        return encodeList(
+          body.notifications,
+          encodeNotification,
+          body.nextPageToken,
+        );
+      case "UpdateUserNotification":
+        return encodeNotification(body);
+      case "DeleteUser":
+      case "DeleteLinkedIdentity":
+      case "DeletePersonalAccessToken":
+      case "DeleteUserWebhook":
+      case "DeleteUserNotification":
+        return new Uint8Array();
+      default:
+        throw new ProtoCodecError(`Unsupported protobuf method: ${method}`);
+    }
+  }
+  if (service === "memos.api.v1.InstanceService") {
+    switch (method) {
+      case "GetInstanceProfile":
+        return encodeInstanceProfile(body);
+      case "GetInstanceSetting":
+      case "UpdateInstanceSetting":
+        return encodeInstanceSetting(body);
+      case "BatchGetInstanceSettings":
+        return encodeList(body.settings, encodeInstanceSetting);
+      case "GetInstanceStats":
+        return encodeInstanceStats(body);
+      case "TestInstanceEmailSetting":
+        return new Uint8Array();
+      default:
+        throw new ProtoCodecError(`Unsupported protobuf method: ${method}`);
+    }
+  }
+  if (service === "memos.api.v1.IdentityProviderService") {
+    switch (method) {
+      case "ListIdentityProviders":
+        return encodeList(body.identityProviders, encodeIdentityProvider);
+      case "GetIdentityProvider":
+      case "CreateIdentityProvider":
+      case "UpdateIdentityProvider":
+        return encodeIdentityProvider(body);
+      case "DeleteIdentityProvider":
+        return new Uint8Array();
+      default:
+        throw new ProtoCodecError(`Unsupported protobuf method: ${method}`);
+    }
+  }
+  if (service === "memos.api.v1.AIService") {
+    if (method === "Transcribe") {
+      return new ProtoWriter().string(1, stringValue(body.text)).finish();
+    }
+    throw new ProtoCodecError(`Unsupported protobuf method: ${method}`);
   }
   throw new ProtoCodecError(`Unsupported protobuf service: ${service}`);
 }
@@ -234,7 +635,10 @@ function decodeMemoServiceRequest(method: string, bytes: Uint8Array) {
         else reader.skip(wire);
         break;
       case "GetSharedMemo":
-        if (field === 1) body.shareToken = reader.string(wire);
+      case "GetMemoByShare":
+        if (field === 1)
+          body[method === "GetMemoByShare" ? "shareId" : "shareToken"] =
+            reader.string(wire);
         else reader.skip(wire);
         break;
       case "GetLinkMetadata":
@@ -298,6 +702,242 @@ function decodeShortcutServiceRequest(method: string, bytes: Uint8Array) {
         break;
       default:
         reader.skip(wire);
+    }
+  }
+  return body;
+}
+
+function decodeAttachmentServiceRequest(method: string, bytes: Uint8Array) {
+  const reader = new ProtoReader(bytes);
+  const body: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    switch (method) {
+      case "CreateAttachment":
+        if (field === 1)
+          body.attachment = decodeAttachment(reader.message(wire));
+        else if (field === 2) body.attachmentId = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "ListAttachments":
+        if (field === 1) body.pageSize = reader.int32(wire);
+        else if (field === 2) body.pageToken = reader.string(wire);
+        else if (field === 3) body.filter = reader.string(wire);
+        else if (field === 4) body.orderBy = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "GetAttachment":
+      case "DeleteAttachment":
+        if (field === 1) body.name = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "UpdateAttachment":
+        if (field === 1)
+          body.attachment = decodeAttachment(reader.message(wire));
+        else if (field === 2)
+          body.updateMask = decodeFieldMask(reader.message(wire));
+        else reader.skip(wire);
+        break;
+      case "BatchDeleteAttachments":
+        if (field === 1) push(body, "names", reader.string(wire));
+        else reader.skip(wire);
+        break;
+      default:
+        reader.skip(wire);
+    }
+  }
+  return body;
+}
+
+function decodeUserServiceRequest(method: string, bytes: Uint8Array) {
+  const reader = new ProtoReader(bytes);
+  const body: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    switch (method) {
+      case "ListUsers":
+        if (field === 1) body.pageSize = reader.int32(wire);
+        else if (field === 2) body.pageToken = reader.string(wire);
+        else if (field === 3) body.filter = reader.string(wire);
+        else if (field === 4) body.showDeleted = reader.bool(wire);
+        else reader.skip(wire);
+        break;
+      case "BatchGetUsers":
+        if (field === 1) push(body, "usernames", reader.string(wire));
+        else reader.skip(wire);
+        break;
+      case "GetUser":
+      case "GetUserStats":
+      case "GetUserSetting":
+      case "GetLinkedIdentity":
+      case "DeleteUser":
+      case "DeleteLinkedIdentity":
+      case "DeletePersonalAccessToken":
+      case "DeleteUserWebhook":
+      case "GetUserWebhookSigningSecret":
+      case "DeleteUserNotification":
+        if (field === 1) body.name = reader.string(wire);
+        else if (field === 2 && method === "GetUser")
+          body.readMask = decodeFieldMask(reader.message(wire));
+        else if (field === 2 && method === "DeleteUser")
+          body.force = reader.bool(wire);
+        else reader.skip(wire);
+        break;
+      case "CreateUser":
+        if (field === 1) body.user = decodeUser(reader.message(wire));
+        else if (field === 2) body.userId = reader.string(wire);
+        else if (field === 3) body.validateOnly = reader.bool(wire);
+        else if (field === 4) body.requestId = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "UpdateUser":
+        if (field === 1) body.user = decodeUser(reader.message(wire));
+        else if (field === 2)
+          body.updateMask = decodeFieldMask(reader.message(wire));
+        else if (field === 3) body.allowMissing = reader.bool(wire);
+        else reader.skip(wire);
+        break;
+      case "ListAllUserStats":
+        if (field === 1) body.state = stateName(reader.int32(wire));
+        else if (field === 2) body.filter = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "ListUserSettings":
+      case "ListLinkedIdentities":
+      case "ListPersonalAccessTokens":
+      case "ListUserWebhooks":
+      case "ListUserNotifications":
+        if (field === 1) body.parent = reader.string(wire);
+        else if (field === 2 && method !== "ListUserWebhooks")
+          body.pageSize = reader.int32(wire);
+        else if (field === 3 && method !== "ListUserWebhooks")
+          body.pageToken = reader.string(wire);
+        else if (field === 4 && method === "ListUserNotifications")
+          body.filter = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "UpdateUserSetting":
+        if (field === 1) body.setting = decodeUserSetting(reader.message(wire));
+        else if (field === 2)
+          body.updateMask = decodeFieldMask(reader.message(wire));
+        else reader.skip(wire);
+        break;
+      case "CreateLinkedIdentity":
+        if (field === 1) body.parent = reader.string(wire);
+        else if (field === 2) body.idpName = reader.string(wire);
+        else if (field === 3) body.code = reader.string(wire);
+        else if (field === 4) body.redirectUri = reader.string(wire);
+        else if (field === 5) body.codeVerifier = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "CreatePersonalAccessToken":
+        if (field === 1) body.parent = reader.string(wire);
+        else if (field === 2) body.description = reader.string(wire);
+        else if (field === 3) body.expiresInDays = reader.int32(wire);
+        else reader.skip(wire);
+        break;
+      case "CreateUserWebhook":
+        if (field === 1) body.parent = reader.string(wire);
+        else if (field === 2)
+          body.webhook = decodeWebhook(reader.message(wire));
+        else reader.skip(wire);
+        break;
+      case "UpdateUserWebhook":
+        if (field === 1) body.webhook = decodeWebhook(reader.message(wire));
+        else if (field === 2)
+          body.updateMask = decodeFieldMask(reader.message(wire));
+        else reader.skip(wire);
+        break;
+      case "UpdateUserNotification":
+        if (field === 1)
+          body.notification = decodeNotification(reader.message(wire));
+        else if (field === 2)
+          body.updateMask = decodeFieldMask(reader.message(wire));
+        else reader.skip(wire);
+        break;
+      default:
+        reader.skip(wire);
+    }
+  }
+  return body;
+}
+
+function decodeInstanceServiceRequest(method: string, bytes: Uint8Array) {
+  const reader = new ProtoReader(bytes);
+  const body: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    switch (method) {
+      case "GetInstanceSetting":
+        if (field === 1) body.name = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "BatchGetInstanceSettings":
+        if (field === 1) push(body, "names", reader.string(wire));
+        else reader.skip(wire);
+        break;
+      case "UpdateInstanceSetting":
+        if (field === 1)
+          body.setting = decodeInstanceSetting(reader.message(wire));
+        else if (field === 2)
+          body.updateMask = decodeFieldMask(reader.message(wire));
+        else reader.skip(wire);
+        break;
+      case "TestInstanceEmailSetting":
+        if (field === 1) body.email = decodeEmailSetting(reader.message(wire));
+        else if (field === 2) body.recipientEmail = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      default:
+        reader.skip(wire);
+    }
+  }
+  return body;
+}
+
+function decodeIdentityProviderServiceRequest(
+  method: string,
+  bytes: Uint8Array,
+) {
+  const reader = new ProtoReader(bytes);
+  const body: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    switch (method) {
+      case "GetIdentityProvider":
+      case "DeleteIdentityProvider":
+        if (field === 1) body.name = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "CreateIdentityProvider":
+        if (field === 1)
+          body.identityProvider = decodeIdentityProvider(reader.message(wire));
+        else if (field === 2) body.identityProviderId = reader.string(wire);
+        else reader.skip(wire);
+        break;
+      case "UpdateIdentityProvider":
+        if (field === 1)
+          body.identityProvider = decodeIdentityProvider(reader.message(wire));
+        else if (field === 2)
+          body.updateMask = decodeFieldMask(reader.message(wire));
+        else reader.skip(wire);
+        break;
+      default:
+        reader.skip(wire);
+    }
+  }
+  return body;
+}
+
+function decodeAiServiceRequest(method: string, bytes: Uint8Array) {
+  const reader = new ProtoReader(bytes);
+  const body: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (method === "Transcribe" && field === 1) {
+      body.audio = decodeTranscriptionAudio(reader.message(wire));
+    } else {
+      reader.skip(wire);
     }
   }
   return body;
@@ -399,12 +1039,411 @@ function decodeAttachment(reader: ProtoReader): ProtoMessage {
   while (!reader.done) {
     const [field, wire] = reader.tag();
     if (field === 1) attachment.name = reader.string(wire);
+    else if (field === 2)
+      attachment.createTime = decodeTimestamp(reader.message(wire));
     else if (field === 3) attachment.filename = reader.string(wire);
+    else if (field === 4) attachment.content = reader.bytesValue(wire);
+    else if (field === 5) attachment.externalLink = reader.string(wire);
     else if (field === 6) attachment.type = reader.string(wire);
+    else if (field === 7) attachment.size = reader.int64(wire);
     else if (field === 8) attachment.memo = reader.string(wire);
     else reader.skip(wire);
   }
   return attachment;
+}
+
+function decodeUser(reader: ProtoReader): ProtoMessage {
+  const user: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) user.name = reader.string(wire);
+    else if (field === 2) user.role = userRoleName(reader.int32(wire));
+    else if (field === 3) user.username = reader.string(wire);
+    else if (field === 4) user.email = reader.string(wire);
+    else if (field === 5) user.displayName = reader.string(wire);
+    else if (field === 6) user.avatarUrl = reader.string(wire);
+    else if (field === 7) user.description = reader.string(wire);
+    else if (field === 8) user.password = reader.string(wire);
+    else if (field === 9) user.state = stateName(reader.int32(wire));
+    else if (field === 10)
+      user.createTime = decodeTimestamp(reader.message(wire));
+    else if (field === 11)
+      user.updateTime = decodeTimestamp(reader.message(wire));
+    else reader.skip(wire);
+  }
+  return user;
+}
+
+function decodeUserSetting(reader: ProtoReader): ProtoMessage {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) setting.name = reader.string(wire);
+    else if (field === 2)
+      setting.value = {
+        case: "generalSetting",
+        value: decodeUserGeneralSetting(reader.message(wire)),
+      };
+    else if (field === 5)
+      setting.value = {
+        case: "webhooksSetting",
+        value: decodeWebhooksSetting(reader.message(wire)),
+      };
+    else if (field === 6)
+      setting.value = {
+        case: "tagsSetting",
+        value: decodeTagsSetting(reader.message(wire)),
+      };
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeUserGeneralSetting(reader: ProtoReader) {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) setting.locale = reader.string(wire);
+    else if (field === 3) setting.memoVisibility = reader.string(wire);
+    else if (field === 4) setting.theme = reader.string(wire);
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeWebhooksSetting(reader: ProtoReader) {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1)
+      push(setting, "webhooks", decodeWebhook(reader.message(wire)));
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeTagsSetting(reader: ProtoReader) {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) reader.skip(wire);
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeWebhook(reader: ProtoReader): ProtoMessage {
+  const webhook: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) webhook.name = reader.string(wire);
+    else if (field === 2) webhook.url = reader.string(wire);
+    else if (field === 3) webhook.displayName = reader.string(wire);
+    else if (field === 4)
+      webhook.createTime = decodeTimestamp(reader.message(wire));
+    else if (field === 5)
+      webhook.updateTime = decodeTimestamp(reader.message(wire));
+    else if (field === 6) webhook.signingSecret = reader.string(wire);
+    else if (field === 7) webhook.signingSecretSet = reader.bool(wire);
+    else reader.skip(wire);
+  }
+  return webhook;
+}
+
+function decodeNotification(reader: ProtoReader): ProtoMessage {
+  const notification: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) notification.name = reader.string(wire);
+    else if (field === 2) notification.sender = reader.string(wire);
+    else if (field === 3)
+      notification.status = notificationStatusName(reader.int32(wire));
+    else if (field === 4)
+      notification.createTime = decodeTimestamp(reader.message(wire));
+    else if (field === 5)
+      notification.type = notificationTypeName(reader.int32(wire));
+    else reader.skip(wire);
+  }
+  return notification;
+}
+
+function decodeInstanceSetting(reader: ProtoReader): ProtoMessage {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) setting.name = reader.string(wire);
+    else if (field === 2)
+      setting.value = {
+        case: "generalSetting",
+        value: decodeInstanceGeneralSetting(reader.message(wire)),
+      };
+    else if (field === 4)
+      setting.value = {
+        case: "memoRelatedSetting",
+        value: decodeMemoRelatedSetting(reader.message(wire)),
+      };
+    else if (field === 6)
+      setting.value = {
+        case: "notificationSetting",
+        value: decodeNotificationSetting(reader.message(wire)),
+      };
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeInstanceGeneralSetting(reader: ProtoReader) {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 2) setting.disallowUserRegistration = reader.bool(wire);
+    else if (field === 3) setting.disallowPasswordAuth = reader.bool(wire);
+    else if (field === 4) setting.additionalScript = reader.string(wire);
+    else if (field === 5) setting.additionalStyle = reader.string(wire);
+    else if (field === 7) setting.weekStartDayOffset = reader.int32(wire);
+    else if (field === 8) setting.disallowChangeUsername = reader.bool(wire);
+    else if (field === 9) setting.disallowChangeNickname = reader.bool(wire);
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeMemoRelatedSetting(reader: ProtoReader) {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 3) setting.contentLengthLimit = reader.int32(wire);
+    else if (field === 4) setting.enableDoubleClickEdit = reader.bool(wire);
+    else if (field === 7) push(setting, "reactions", reader.string(wire));
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeNotificationSetting(reader: ProtoReader) {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) setting.email = decodeEmailSetting(reader.message(wire));
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeEmailSetting(reader: ProtoReader) {
+  const setting: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) setting.enabled = reader.bool(wire);
+    else if (field === 2) setting.smtpHost = reader.string(wire);
+    else if (field === 3) setting.smtpPort = reader.int32(wire);
+    else if (field === 4) setting.smtpUsername = reader.string(wire);
+    else if (field === 5) setting.smtpPassword = reader.string(wire);
+    else if (field === 6) setting.fromEmail = reader.string(wire);
+    else if (field === 7) setting.fromName = reader.string(wire);
+    else if (field === 8) setting.replyTo = reader.string(wire);
+    else if (field === 9) setting.useTls = reader.bool(wire);
+    else if (field === 10) setting.useSsl = reader.bool(wire);
+    else reader.skip(wire);
+  }
+  return setting;
+}
+
+function decodeIdentityProvider(reader: ProtoReader): ProtoMessage {
+  const provider: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) provider.name = reader.string(wire);
+    else if (field === 2)
+      provider.type = reader.int32(wire) === 1 ? "OAUTH2" : "TYPE_UNSPECIFIED";
+    else if (field === 3) provider.title = reader.string(wire);
+    else if (field === 4) provider.identifierFilter = reader.string(wire);
+    else if (field === 5)
+      provider.config = decodeIdentityProviderConfig(reader.message(wire));
+    else reader.skip(wire);
+  }
+  return provider;
+}
+
+function decodeIdentityProviderConfig(reader: ProtoReader) {
+  const config: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1)
+      config.config = {
+        case: "oauth2Config",
+        value: decodeOAuth2Config(reader.message(wire)),
+      };
+    else reader.skip(wire);
+  }
+  return config;
+}
+
+function decodeOAuth2Config(reader: ProtoReader) {
+  const config: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) config.clientId = reader.string(wire);
+    else if (field === 2) config.clientSecret = reader.string(wire);
+    else if (field === 3) config.authUrl = reader.string(wire);
+    else if (field === 4) config.tokenUrl = reader.string(wire);
+    else if (field === 5) config.userInfoUrl = reader.string(wire);
+    else if (field === 6) push(config, "scopes", reader.string(wire));
+    else if (field === 7)
+      config.fieldMapping = decodeFieldMapping(reader.message(wire));
+    else reader.skip(wire);
+  }
+  return config;
+}
+
+function decodeFieldMapping(reader: ProtoReader) {
+  const mapping: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) mapping.identifier = reader.string(wire);
+    else if (field === 2) mapping.displayName = reader.string(wire);
+    else if (field === 3) mapping.email = reader.string(wire);
+    else if (field === 4) mapping.avatarUrl = reader.string(wire);
+    else reader.skip(wire);
+  }
+  return mapping;
+}
+
+function decodeTranscriptionAudio(reader: ProtoReader) {
+  const audio: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) audio.content = reader.bytesValue(wire);
+    else if (field === 2) audio.uri = reader.string(wire);
+    else if (field === 3) audio.filename = reader.string(wire);
+    else if (field === 4) audio.contentType = reader.string(wire);
+    else reader.skip(wire);
+  }
+  return audio;
+}
+
+function decodePersonalAccessToken(reader: ProtoReader): ProtoMessage {
+  const token: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) token.name = reader.string(wire);
+    else if (field === 2) token.description = reader.string(wire);
+    else if (field === 3)
+      token.createdAt = decodeTimestamp(reader.message(wire));
+    else if (field === 4)
+      token.expiresAt = decodeTimestamp(reader.message(wire));
+    else if (field === 5)
+      token.lastUsedAt = decodeTimestamp(reader.message(wire));
+    else reader.skip(wire);
+  }
+  return token;
+}
+
+function decodeLinkedIdentity(reader: ProtoReader): ProtoMessage {
+  const identity: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) identity.name = reader.string(wire);
+    else if (field === 2) identity.idpName = reader.string(wire);
+    else if (field === 3) identity.externUid = reader.string(wire);
+    else reader.skip(wire);
+  }
+  return identity;
+}
+
+function decodeUserStats(reader: ProtoReader): ProtoMessage {
+  const stats: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) stats.name = reader.string(wire);
+    else if (field === 3)
+      stats.memoTypeStats = decodeMemoTypeStats(reader.message(wire));
+    else if (field === 4) {
+      const entry = decodeStringInt32Entry(reader.message(wire));
+      const tagCount = asRecord(stats.tagCount);
+      tagCount[entry.key] = entry.value;
+      stats.tagCount = tagCount;
+    } else if (field === 5) push(stats, "pinnedMemos", reader.string(wire));
+    else if (field === 6) stats.totalMemoCount = reader.int32(wire);
+    else if (field === 7)
+      push(
+        stats,
+        "memoCreatedTimestamps",
+        decodeTimestamp(reader.message(wire)),
+      );
+    else if (field === 8)
+      push(
+        stats,
+        "memoUpdatedTimestamps",
+        decodeTimestamp(reader.message(wire)),
+      );
+    else reader.skip(wire);
+  }
+  return stats;
+}
+
+function decodeMemoTypeStats(reader: ProtoReader): ProtoMessage {
+  const stats: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) stats.linkCount = reader.int32(wire);
+    else if (field === 2) stats.codeCount = reader.int32(wire);
+    else if (field === 3) stats.todoCount = reader.int32(wire);
+    else if (field === 4) stats.undoCount = reader.int32(wire);
+    else reader.skip(wire);
+  }
+  return stats;
+}
+
+function decodeStringInt32Entry(reader: ProtoReader) {
+  let key = "";
+  let value = 0;
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) key = reader.string(wire);
+    else if (field === 2) value = reader.int32(wire);
+    else reader.skip(wire);
+  }
+  return { key, value };
+}
+
+function decodeInstanceProfile(reader: ProtoReader): ProtoMessage {
+  const profile: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 2) profile.version = reader.string(wire);
+    else if (field === 3) profile.demo = reader.bool(wire);
+    else if (field === 6) profile.instanceUrl = reader.string(wire);
+    else if (field === 7) profile.admin = decodeUser(reader.message(wire));
+    else if (field === 8) profile.commit = reader.string(wire);
+    else if (field === 9) profile.needsSetup = reader.bool(wire);
+    else reader.skip(wire);
+  }
+  return profile;
+}
+
+function decodeInstanceStats(reader: ProtoReader): ProtoMessage {
+  const stats: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) stats.database = decodeDatabaseStats(reader.message(wire));
+    else if (field === 2) stats.localStorageBytes = reader.int64(wire);
+    else if (field === 4)
+      stats.generatedTime = decodeTimestamp(reader.message(wire));
+    else reader.skip(wire);
+  }
+  return stats;
+}
+
+function decodeDatabaseStats(reader: ProtoReader): ProtoMessage {
+  const stats: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) stats.driver = reader.string(wire);
+    else if (field === 2) stats.sizeBytes = reader.int64(wire);
+    else reader.skip(wire);
+  }
+  return stats;
 }
 
 function decodeRelation(reader: ProtoReader): ProtoMessage {
@@ -458,6 +1497,19 @@ function decodeMemoShare(reader: ProtoReader): ProtoMessage {
     else reader.skip(wire);
   }
   return share;
+}
+
+function decodeLinkMetadata(reader: ProtoReader): ProtoMessage {
+  const metadata: ProtoMessage = {};
+  while (!reader.done) {
+    const [field, wire] = reader.tag();
+    if (field === 1) metadata.url = reader.string(wire);
+    else if (field === 2) metadata.title = reader.string(wire);
+    else if (field === 3) metadata.description = reader.string(wire);
+    else if (field === 4) metadata.image = reader.string(wire);
+    else reader.skip(wire);
+  }
+  return metadata;
 }
 
 function decodeProperty(reader: ProtoReader) {
@@ -564,6 +1616,219 @@ function encodeAttachment(value: unknown) {
     .string(6, stringValue(attachment.type))
     .int64(7, attachment.size)
     .string(8, stringValue(attachment.memo))
+    .finish();
+}
+
+function encodeUserStats(value: unknown) {
+  const stats = asRecord(value);
+  const memoTypeStats = asRecord(stats.memoTypeStats);
+  return new ProtoWriter()
+    .string(1, stringValue(stats.name))
+    .message(
+      3,
+      new ProtoWriter()
+        .int32(1, numberValue(memoTypeStats.linkCount))
+        .int32(2, numberValue(memoTypeStats.codeCount))
+        .int32(3, numberValue(memoTypeStats.todoCount))
+        .int32(4, numberValue(memoTypeStats.undoCount))
+        .finish(),
+    )
+    .mapStringInt32(4, asRecord(stats.tagCount))
+    .repeatedMessages(7, records(stats.memoCreatedTimestamps), encodeTimestamp)
+    .repeatedMessages(8, records(stats.memoUpdatedTimestamps), encodeTimestamp)
+    .repeatedStrings(5, strings(stats.pinnedMemos))
+    .int32(6, numberValue(stats.totalMemoCount))
+    .finish();
+}
+
+function encodeUserSetting(value: unknown) {
+  const setting = asRecord(value);
+  const oneof = asRecord(setting.value);
+  const nested = asRecord(oneof.value);
+  const writer = new ProtoWriter().string(1, stringValue(setting.name));
+  if (oneof.case === "generalSetting") {
+    writer.message(
+      2,
+      new ProtoWriter()
+        .string(1, stringValue(nested.locale))
+        .string(3, stringValue(nested.memoVisibility))
+        .string(4, stringValue(nested.theme))
+        .finish(),
+    );
+  } else if (oneof.case === "webhooksSetting") {
+    writer.message(
+      5,
+      new ProtoWriter()
+        .repeatedMessages(1, records(nested.webhooks), encodeWebhook)
+        .finish(),
+    );
+  }
+  return writer.finish();
+}
+
+function encodeLinkedIdentity(value: unknown) {
+  const identity = asRecord(value);
+  return new ProtoWriter()
+    .string(1, stringValue(identity.name))
+    .string(2, stringValue(identity.idpName))
+    .string(3, stringValue(identity.externUid))
+    .finish();
+}
+
+function encodePersonalAccessToken(value: unknown) {
+  const token = asRecord(value);
+  return new ProtoWriter()
+    .string(1, stringValue(token.name))
+    .string(2, stringValue(token.description))
+    .message(3, encodeTimestamp(token.createdAt))
+    .message(4, encodeTimestamp(token.expiresAt))
+    .message(5, encodeTimestamp(token.lastUsedAt))
+    .finish();
+}
+
+function encodeWebhook(value: unknown) {
+  const webhook = asRecord(value);
+  return new ProtoWriter()
+    .string(1, stringValue(webhook.name))
+    .string(2, stringValue(webhook.url))
+    .string(3, stringValue(webhook.displayName))
+    .message(4, encodeTimestamp(webhook.createTime))
+    .message(5, encodeTimestamp(webhook.updateTime))
+    .bool(7, webhook.signingSecretSet === true)
+    .finish();
+}
+
+function encodeNotification(value: unknown) {
+  const notification = asRecord(value);
+  return new ProtoWriter()
+    .string(1, stringValue(notification.name))
+    .string(2, stringValue(notification.sender))
+    .int32(3, notificationStatusValue(notification.status))
+    .message(4, encodeTimestamp(notification.createTime))
+    .int32(5, notificationTypeValue(notification.type))
+    .message(8, encodeUser(notification.senderUser))
+    .finish();
+}
+
+function encodeInstanceProfile(value: unknown) {
+  const profile = asRecord(value);
+  return new ProtoWriter()
+    .string(2, stringValue(profile.version))
+    .bool(3, profile.demo === true)
+    .string(6, stringValue(profile.instanceUrl))
+    .message(7, encodeUser(profile.admin))
+    .string(8, stringValue(profile.commit))
+    .bool(9, profile.needsSetup === true)
+    .finish();
+}
+
+function encodeInstanceSetting(value: unknown) {
+  const setting = asRecord(value);
+  const oneof = asRecord(setting.value);
+  const nested = asRecord(oneof.value);
+  const writer = new ProtoWriter().string(1, stringValue(setting.name));
+  if (oneof.case === "generalSetting") {
+    writer.message(
+      2,
+      new ProtoWriter()
+        .bool(2, nested.disallowUserRegistration === true)
+        .bool(3, nested.disallowPasswordAuth === true)
+        .string(4, stringValue(nested.additionalScript))
+        .string(5, stringValue(nested.additionalStyle))
+        .int32(7, numberValue(nested.weekStartDayOffset))
+        .bool(8, nested.disallowChangeUsername === true)
+        .bool(9, nested.disallowChangeNickname === true)
+        .finish(),
+    );
+  } else if (oneof.case === "memoRelatedSetting") {
+    writer.message(
+      4,
+      new ProtoWriter()
+        .int32(3, numberValue(nested.contentLengthLimit))
+        .bool(4, nested.enableDoubleClickEdit === true)
+        .repeatedStrings(7, strings(nested.reactions))
+        .finish(),
+    );
+  } else if (oneof.case === "notificationSetting") {
+    writer.message(
+      6,
+      new ProtoWriter().message(1, encodeEmailSetting(nested.email)).finish(),
+    );
+  }
+  return writer.finish();
+}
+
+function encodeEmailSetting(value: unknown) {
+  const setting = asRecord(value);
+  return new ProtoWriter()
+    .bool(1, setting.enabled === true)
+    .string(2, stringValue(setting.smtpHost))
+    .int32(3, numberValue(setting.smtpPort))
+    .string(4, stringValue(setting.smtpUsername))
+    .string(6, stringValue(setting.fromEmail))
+    .string(7, stringValue(setting.fromName))
+    .string(8, stringValue(setting.replyTo))
+    .bool(9, setting.useTls === true)
+    .bool(10, setting.useSsl === true)
+    .finish();
+}
+
+function encodeInstanceStats(value: unknown) {
+  const stats = asRecord(value);
+  const database = asRecord(stats.database);
+  return new ProtoWriter()
+    .message(
+      1,
+      new ProtoWriter()
+        .string(1, stringValue(database.driver))
+        .int64(2, database.sizeBytes)
+        .finish(),
+    )
+    .int64(2, stats.localStorageBytes)
+    .message(4, encodeTimestamp(stats.generatedTime))
+    .finish();
+}
+
+function encodeIdentityProvider(value: unknown) {
+  const provider = asRecord(value);
+  const config = asRecord(provider.config);
+  const oauth = asRecord(config.config).value;
+  const oauthConfig = asRecord(oauth);
+  const configCase = asRecord(config.config).case;
+  const writer = new ProtoWriter()
+    .string(1, stringValue(provider.name))
+    .int32(2, provider.type === "OAUTH2" ? 1 : 0)
+    .string(3, stringValue(provider.title))
+    .string(4, stringValue(provider.identifierFilter));
+  if (configCase === "oauth2Config") {
+    writer.message(
+      5,
+      new ProtoWriter()
+        .message(
+          1,
+          new ProtoWriter()
+            .string(1, stringValue(oauthConfig.clientId))
+            .string(2, stringValue(oauthConfig.clientSecret))
+            .string(3, stringValue(oauthConfig.authUrl))
+            .string(4, stringValue(oauthConfig.tokenUrl))
+            .string(5, stringValue(oauthConfig.userInfoUrl))
+            .repeatedStrings(6, strings(oauthConfig.scopes))
+            .message(7, encodeFieldMapping(oauthConfig.fieldMapping))
+            .finish(),
+        )
+        .finish(),
+    );
+  }
+  return writer.finish();
+}
+
+function encodeFieldMapping(value: unknown) {
+  const mapping = asRecord(value);
+  return new ProtoWriter()
+    .string(1, stringValue(mapping.identifier))
+    .string(2, stringValue(mapping.displayName))
+    .string(3, stringValue(mapping.email))
+    .string(4, stringValue(mapping.avatarUrl))
     .finish();
 }
 
@@ -675,10 +1940,12 @@ function encodeList(
   value: unknown,
   encoder: (value: unknown) => Uint8Array,
   nextPageToken?: unknown,
+  totalSize?: unknown,
 ) {
   return new ProtoWriter()
     .repeatedMessages(1, records(value), encoder)
     .string(2, stringValue(nextPageToken))
+    .int32(3, numberValue(totalSize))
     .finish();
 }
 
@@ -705,6 +1972,36 @@ function visibilityValue(value: unknown) {
   if (value === "PRIVATE") return 1;
   if (value === "PROTECTED") return 2;
   if (value === "PUBLIC") return 3;
+  return 0;
+}
+
+function userRoleName(value: number) {
+  if (value === 2) return "ADMIN";
+  if (value === 3) return "USER";
+  return "ROLE_UNSPECIFIED";
+}
+
+function notificationStatusName(value: number) {
+  if (value === 1) return "UNREAD";
+  if (value === 2) return "ARCHIVED";
+  return "STATUS_UNSPECIFIED";
+}
+
+function notificationStatusValue(value: unknown) {
+  if (value === "UNREAD") return 1;
+  if (value === "ARCHIVED") return 2;
+  return 0;
+}
+
+function notificationTypeName(value: number) {
+  if (value === 1) return "MEMO_COMMENT";
+  if (value === 2) return "MEMO_MENTION";
+  return "TYPE_UNSPECIFIED";
+}
+
+function notificationTypeValue(value: unknown) {
+  if (value === "MEMO_COMMENT") return 1;
+  if (value === "MEMO_MENTION") return 2;
   return 0;
 }
 
@@ -793,10 +2090,23 @@ class ProtoWriter {
     return this;
   }
 
-  int32(field: number, value: number) {
-    if (!Number.isFinite(value) || value === 0) return this;
+  int32(field: number, value: number | undefined) {
+    if (value === undefined || !Number.isFinite(value) || value === 0)
+      return this;
     this.tag(field, 0);
     this.varint(Math.trunc(value));
+    return this;
+  }
+
+  mapStringInt32(field: number, value: ProtoMessage) {
+    for (const [key, rawValue] of Object.entries(value)) {
+      const parsed = typeof rawValue === "number" ? rawValue : Number(rawValue);
+      if (!Number.isFinite(parsed)) continue;
+      this.message(
+        field,
+        new ProtoWriter().string(1, key).int32(2, parsed).finish(),
+      );
+    }
     return this;
   }
 
@@ -884,6 +2194,10 @@ class ProtoReader {
 
   int32(wire: number) {
     return Number(this.varint(wire));
+  }
+
+  int64(wire: number) {
+    return this.varint(wire).toString();
   }
 
   bool(wire: number) {

--- a/apps/worker/src/memos-transport.test.ts
+++ b/apps/worker/src/memos-transport.test.ts
@@ -158,6 +158,67 @@ describe("Memos native auth and transport boundaries", () => {
   });
 
   it("serves the canonical Connect JSON unary subset and authenticated SSE stream", async () => {
+    const publicProfile = await request(
+      "/memos.api.v1.InstanceService/GetInstanceProfile",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(publicProfile.status).toBe(200);
+    const publicProfileBody = (await publicProfile.json()) as {
+      needsSetup: boolean;
+      admin?: { email?: string };
+    };
+    expect(publicProfileBody).toMatchObject({ needsSetup: false });
+    expect(publicProfileBody.admin?.email).toBeUndefined();
+    const publicProviders = await request(
+      "/memos.api.v1.IdentityProviderService/ListIdentityProviders",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(publicProviders.status).toBe(200);
+    expect(await publicProviders.json()).toEqual({ identityProviders: [] });
+    const publicSensitiveSettings = await request(
+      "/memos.api.v1.InstanceService/BatchGetInstanceSettings",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ names: ["instance/settings/STORAGE"] }),
+      },
+    );
+    expect(publicSensitiveSettings.status).toBe(401);
+    const publicWithWrongBearerOrigin = await request(
+      "/memos.api.v1.InstanceService/GetInstanceProfile",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          origin: "https://untrusted.example",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(publicWithWrongBearerOrigin.status).toBe(403);
+    const publicWithWrongCookieOrigin = await request(
+      "/memos.api.v1.InstanceService/GetInstanceProfile",
+      {
+        method: "POST",
+        headers: {
+          cookie: sessionCookie,
+          origin: "https://untrusted.example",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(publicWithWrongCookieOrigin.status).toBe(403);
+
     const connectPath = "/memos.api.v1.MemoService/CreateMemo";
     const unsupported = await request(connectPath, {
       method: "POST",
@@ -194,6 +255,55 @@ describe("Memos native auth and transport boundaries", () => {
     expect(created).toMatchObject({
       name: expect.stringMatching(/^memos\//),
       content: "Connect JSON memo",
+    });
+
+    const publicMemo = await connect("CreateMemo", {
+      memo: { content: "Connect public memo", visibility: "PUBLIC" },
+    });
+    const publicComment = await connect("CreateMemoComment", {
+      name: publicMemo.name,
+      comment: { content: "Public comment" },
+    });
+    const anonymousCurrentList = await request("/api/v1/memos");
+    expect(anonymousCurrentList.status).toBe(200);
+    const anonymousCurrentListBody = (await anonymousCurrentList.json()) as {
+      memos: Array<{ name: string }>;
+    };
+    expect(anonymousCurrentListBody.memos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: publicMemo.name }),
+      ]),
+    );
+    expect(anonymousCurrentListBody.memos).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: created.name })]),
+    );
+    const anonymousConnectMemo = await request(
+      "/memos.api.v1.MemoService/GetMemo",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: publicMemo.name }),
+      },
+    );
+    expect(anonymousConnectMemo.status).toBe(200);
+    expect(await anonymousConnectMemo.json()).toMatchObject({
+      name: publicMemo.name,
+    });
+    const anonymousConnectPrivate = await request(
+      "/memos.api.v1.MemoService/GetMemo",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: created.name }),
+      },
+    );
+    expect(anonymousConnectPrivate.status).toBe(404);
+    const anonymousComments = await request(
+      `/api/v1/${publicMemo.name}/comments`,
+    );
+    expect(anonymousComments.status).toBe(200);
+    expect(await anonymousComments.json()).toMatchObject({
+      memos: [expect.objectContaining({ name: publicComment.name })],
     });
 
     const listed = await connect("ListMemos", {
@@ -307,7 +417,78 @@ describe("Memos native auth and transport boundaries", () => {
     });
     expect(shared.status).toBe(200);
     expect(await shared.json()).toMatchObject({ name: created.name });
+    const canonicalShared = await request(
+      "/memos.api.v1.MemoService/GetMemoByShare",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ shareId: shareToken }),
+      },
+    );
+    expect(canonicalShared.status).toBe(200);
+    expect(await canonicalShared.json()).toMatchObject({ name: created.name });
     await connect("DeleteMemoShare", { name: share.name });
+
+    const profile = await connectService(
+      "InstanceService",
+      "GetInstanceProfile",
+      {},
+    );
+    expect(profile).toMatchObject({
+      demo: false,
+      needsSetup: false,
+      admin: { name: "users/owner" },
+    });
+    const instanceSettings = await connectService(
+      "InstanceService",
+      "BatchGetInstanceSettings",
+      {
+        names: ["instance/settings/GENERAL", "instance/settings/MEMO_RELATED"],
+      },
+    );
+    expect(instanceSettings.settings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "instance/settings/GENERAL",
+          value: expect.objectContaining({ case: "generalSetting" }),
+        }),
+      ]),
+    );
+
+    const listedUsers = await connectService("UserService", "ListUsers", {});
+    expect(listedUsers).toMatchObject({
+      users: [expect.objectContaining({ name: "users/owner" })],
+      totalSize: 1,
+    });
+    const userSettings = await connectService(
+      "UserService",
+      "ListUserSettings",
+      {
+        parent: "users/owner",
+      },
+    );
+    expect(userSettings.settings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "users/owner/settings/GENERAL" }),
+      ]),
+    );
+    const providers = await connectService(
+      "IdentityProviderService",
+      "ListIdentityProviders",
+      {},
+    );
+    expect(providers).toEqual({ identityProviders: [] });
+
+    const connectAttachments = await connectService(
+      "AttachmentService",
+      "ListAttachments",
+      { pageSize: 10 },
+    );
+    expect(connectAttachments.attachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: attachmentBody.name }),
+      ]),
+    );
 
     const invalidLink = await request(
       "/memos.api.v1.MemoService/GetLinkMetadata",
@@ -453,6 +634,17 @@ describe("Memos native auth and transport boundaries", () => {
     });
     expect(compressed.status).toBe(400);
 
+    const unauthenticatedBinary = await request(
+      "/memos.api.v1.UserService/ListUsers",
+      {
+        method: "POST",
+        headers: { "content-type": "application/grpc+proto" },
+        body: frameProto(new Uint8Array()),
+      },
+    );
+    expect(unauthenticatedBinary.status).toBe(401);
+    expect(unauthenticatedBinary.headers.get("grpc-status")).toBe("16");
+
     const deleted = await connect("DeleteMemo", {
       name: created.name,
       force: true,
@@ -495,7 +687,15 @@ describe("Memos native auth and transport boundaries", () => {
 });
 
 async function connect(method: string, body: Record<string, unknown>) {
-  const response = await request(`/memos.api.v1.MemoService/${method}`, {
+  return connectService("MemoService", method, body);
+}
+
+async function connectService(
+  service: string,
+  method: string,
+  body: Record<string, unknown>,
+) {
+  const response = await request(`/memos.api.v1.${service}/${method}`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${accessToken}`,

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -1,6 +1,8 @@
+import type { UserRow } from "@flaremo/db";
 import { createDb } from "@flaremo/db";
 import {
   bindMemoAttachments,
+  createAttachmentMetadata,
   createMemo,
   createMemoComment,
   createMemoShare,
@@ -8,28 +10,45 @@ import {
   type DomainError,
   deleteMemoReaction,
   deleteShortcut,
+  finalizeAttachmentDelete,
+  getAttachmentById,
+  getAuthBootstrapStatus,
   getAuthUserById,
   getFlaremoUserByAuthSessionToken,
+  getFlaremoUserById,
   getMemoById,
+  getMemoByIdForViewer,
   getMemoParent,
+  getMemoStats,
   getPublicShareByToken,
   getShortcut,
+  getStoredSetting,
   hardDeleteMemo,
+  listAttachments,
   listMemoAttachments,
+  listMemoAttachmentsForViewer,
   listMemoComments,
   listMemoReactions,
   listMemoRelations,
   listMemoShares,
   listMemos,
+  listMemosForViewer,
+  listMemosPersonalAccessTokens,
   listShortcuts,
+  markAttachmentDeleting,
   markMemoAttachmentsDeleting,
   replaceMemoRelations,
+  revokeAuthSessionByToken,
   revokeMemoShare,
+  updateAttachmentMemo,
+  updateFlaremoUserProfile,
   updateMemo,
   updateShortcut,
   upsertMemoReaction,
+  upsertStoredSetting,
 } from "@flaremo/domain";
 import {
+  currentAttachmentsToListResponse,
   currentAttachmentToDto,
   currentMemoToDto,
   currentReactionToDto,
@@ -38,11 +57,18 @@ import {
   currentShortcutsToListResponse,
   currentShortcutToDto,
   currentUserToDto,
+  publicUserToDto,
 } from "@flaremo/memos";
 import { type Context, Hono } from "hono";
+import {
+  createAttachmentObjectKey,
+  MAX_ATTACHMENT_BYTES,
+} from "../attachment-http";
 import { createFlareMoAuth } from "../auth";
 import {
+  assertRequestCredentialBoundary,
   assertTrustedCookieMutation,
+  getOptionalRequestContext,
   getRequestContext,
   type HonoBindings,
 } from "../context";
@@ -113,6 +139,7 @@ memosConnectApi.post("/:service/:method", async (c) => {
   }
 
   try {
+    assertRequestCredentialBoundary(c);
     const service = c.req.param("service") ?? "";
     const method = c.req.param("method") ?? "";
     if (service === "memos.api.v1.AuthService" && method === "SignIn") {
@@ -121,7 +148,10 @@ memosConnectApi.post("/:service/:method", async (c) => {
     if (service === "memos.api.v1.AuthService" && method === "RefreshToken") {
       return connectAuthRefresh(c, binaryTransport);
     }
-    if (service === memoService && method === "GetSharedMemo") {
+    if (
+      service === memoService &&
+      (method === "GetMemoByShare" || method === "GetSharedMemo")
+    ) {
       return await connectGetSharedMemo(c, body, binaryTransport);
     }
     if (service === memoService && method === "GetLinkMetadata") {
@@ -129,6 +159,40 @@ memosConnectApi.post("/:service/:method", async (c) => {
     }
     if (service === memoService && method === "BatchGetLinkMetadata") {
       return await connectBatchGetLinkMetadata(c, body, binaryTransport);
+    }
+    if (service === memoService && isPublicMemoReadMethod(method)) {
+      return await connectPublicMemoRead(
+        c,
+        await getOptionalRequestContext(c),
+        method,
+        body,
+        binaryTransport,
+      );
+    }
+    if (
+      service === "memos.api.v1.IdentityProviderService" &&
+      method === "ListIdentityProviders"
+    ) {
+      return connectValue(c, { identityProviders: [] }, binaryTransport);
+    }
+    if (
+      service === "memos.api.v1.InstanceService" &&
+      [
+        "GetInstanceProfile",
+        "GetInstanceSetting",
+        "BatchGetInstanceSettings",
+      ].includes(method)
+    ) {
+      const optionalContext = await getOptionalRequestContext(c);
+      return connectInstanceMethod(
+        c,
+        optionalContext.user
+          ? (optionalContext as ConnectRequestContext)
+          : await getPublicInstanceContext(c),
+        method,
+        body,
+        binaryTransport,
+      );
     }
     const context = await getRequestContext(c);
     if (service === "memos.api.v1.AuthService" && method === "GetCurrentUser") {
@@ -141,6 +205,33 @@ memosConnectApi.post("/:service/:method", async (c) => {
     }
     if (service === "memos.api.v1.AuthService" && method === "SignOut") {
       return connectAuthSignOut(c, context, binaryTransport);
+    }
+    if (service === "memos.api.v1.AttachmentService") {
+      return connectAttachmentMethod(c, context, method, body, binaryTransport);
+    }
+    if (service === "memos.api.v1.UserService") {
+      return connectUserMethod(c, context, method, body, binaryTransport);
+    }
+    if (service === "memos.api.v1.InstanceService") {
+      return connectInstanceMethod(c, context, method, body, binaryTransport);
+    }
+    if (service === "memos.api.v1.IdentityProviderService") {
+      return connectIdentityProviderMethod(
+        c,
+        context,
+        method,
+        body,
+        binaryTransport,
+      );
+    }
+    if (service === "memos.api.v1.AIService") {
+      return connectErrorForTransport(
+        c,
+        binaryTransport,
+        "unimplemented",
+        "AI transcription is not configured on FlareMo",
+        501,
+      );
     }
     if (service === "memos.api.v1.ShortcutService") {
       return connectShortcutMethod(c, context, method, body, binaryTransport);
@@ -323,6 +414,574 @@ async function connectShortcutMethod(
   }
 }
 
+type ConnectRequestContext = Awaited<ReturnType<typeof getRequestContext>>;
+
+async function connectAttachmentMethod(
+  c: ConnectContext,
+  context: ConnectRequestContext,
+  method: string,
+  value: unknown,
+  transport?: BinaryTransport,
+) {
+  const body = record(value);
+  switch (method) {
+    case "CreateAttachment": {
+      const attachment = await createConnectAttachment(
+        c.env,
+        context,
+        record(body.attachment),
+        optionalString(body.attachmentId),
+      );
+      return connectValue(c, currentAttachmentToDto(attachment), transport);
+    }
+    case "ListAttachments": {
+      const filter = optionalString(body.filter);
+      const memoId = filter ? parseAttachmentMemoFilter(filter) : undefined;
+      const attachments = await listAttachments(context.db, context.user, {
+        memoId,
+        pageSize: pageSize(body.pageSize),
+      });
+      return connectValue(
+        c,
+        currentAttachmentsToListResponse(attachments, {
+          totalSize: attachments.length,
+        }),
+        transport,
+      );
+    }
+    case "GetAttachment": {
+      const attachment = await getAttachmentById(
+        context.db,
+        context.user,
+        normalizeAttachmentName(requiredString(body.name, "name")),
+      );
+      return connectValue(c, currentAttachmentToDto(attachment), transport);
+    }
+    case "UpdateAttachment": {
+      const attachment = record(body.attachment);
+      const fields = fieldMaskPaths(body.updateMask);
+      if (fields.length !== 1 || fields[0] !== "memo") {
+        throw new ConnectInputError(
+          "Only the attachment memo field is mutable",
+        );
+      }
+      const updated = await updateAttachmentMemo(
+        context.db,
+        context.user,
+        normalizeAttachmentName(
+          requiredString(attachment.name, "attachment.name"),
+        ),
+        optionalString(attachment.memo) ?? null,
+      );
+      return connectValue(c, currentAttachmentToDto(updated), transport);
+    }
+    case "DeleteAttachment": {
+      await deleteConnectAttachment(
+        c.env,
+        context,
+        requiredString(body.name, "name"),
+      );
+      return connectValue(c, {}, transport);
+    }
+    case "BatchDeleteAttachments": {
+      const names = list(body.names).map((name) =>
+        requiredString(name, "names[]"),
+      );
+      for (const name of names) {
+        await deleteConnectAttachment(c.env, context, name);
+      }
+      return connectValue(c, {}, transport);
+    }
+    default:
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        `Attachment method is not implemented: ${method}`,
+        501,
+      );
+  }
+}
+
+async function createConnectAttachment(
+  env: FlareMoEnv,
+  context: ConnectRequestContext,
+  attachment: Record<string, unknown>,
+  attachmentId?: string,
+) {
+  if (attachmentId) {
+    throw new ConnectInputError(
+      "attachmentId is not supported; FlareMo generates attachment resource names",
+    );
+  }
+  if (optionalString(attachment.externalLink)) {
+    throw new ConnectInputError(
+      "External attachments are not supported by FlareMo",
+    );
+  }
+  const filename = requiredString(attachment.filename, "attachment.filename");
+  const type = requiredString(attachment.type, "attachment.type");
+  const bytes = attachmentBytes(attachment.content);
+  if (bytes.byteLength === 0) {
+    throw new ConnectInputError("attachment.content is required");
+  }
+  if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+    throw new ConnectInputError("Attachment exceeds the 25 MiB limit");
+  }
+  const objectKey = createAttachmentObjectKey(
+    context.user.id,
+    filename,
+    "memos",
+  );
+  const object = await env.ATTACHMENTS.put(objectKey, bytes, {
+    httpMetadata: { contentType: type },
+  });
+  try {
+    return await createAttachmentMetadata(context.db, context.user, {
+      memoId: optionalString(attachment.memo) ?? null,
+      filename,
+      contentType: type,
+      size: bytes.byteLength,
+      r2Key: objectKey,
+      etag: object.httpEtag,
+    });
+  } catch (error) {
+    await env.ATTACHMENTS.delete(objectKey);
+    throw error;
+  }
+}
+
+async function deleteConnectAttachment(
+  env: FlareMoEnv,
+  context: ConnectRequestContext,
+  name: string,
+) {
+  const attachment = await markAttachmentDeleting(
+    context.db,
+    context.user,
+    normalizeAttachmentName(name),
+  );
+  await env.ATTACHMENTS.delete(attachment.r2Key);
+  await finalizeAttachmentDelete(context.db, context.user, attachment.id);
+}
+
+async function connectUserMethod(
+  c: ConnectContext,
+  context: ConnectRequestContext,
+  method: string,
+  value: unknown,
+  transport?: BinaryTransport,
+) {
+  const body = record(value);
+  const authUser = await getAuthUserById(context.db, context.authUserId);
+  const currentUser = currentUserToDto(context.user, authUser);
+  switch (method) {
+    case "ListUsers": {
+      const filter = optionalString(body.filter);
+      if (filter && !filter.includes(currentUser.username)) {
+        return connectValue(c, { users: [], totalSize: 0 }, transport);
+      }
+      return connectValue(c, { users: [currentUser], totalSize: 1 }, transport);
+    }
+    case "BatchGetUsers": {
+      const usernames = list(body.usernames).filter(
+        (username): username is string => typeof username === "string",
+      );
+      const users =
+        usernames.length === 0 || usernames.includes(currentUser.username)
+          ? [currentUser]
+          : [];
+      return connectValue(c, { users }, transport);
+    }
+    case "GetUser":
+      assertConnectUserPath(body.name, context.user.id);
+      return connectValue(c, currentUser, transport);
+    case "CreateUser":
+    case "DeleteUser":
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        "FlareMo is single-user and does not expose user creation or deletion",
+        501,
+      );
+    case "UpdateUser": {
+      if (context.credential === "pat") {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "permission_denied",
+          "A session credential is required to update the user",
+          403,
+        );
+      }
+      const user = record(body.user);
+      assertConnectUserPath(user.name, context.user.id);
+      const fields = fieldMaskPaths(body.updateMask);
+      if (fields.length === 0)
+        throw new ConnectInputError("updateMask is required");
+      let nextAuthUser = authUser;
+      if (fields.includes("username")) {
+        const username = requiredString(user.username, "user.username");
+        await updateBetterAuthUsername(c, context, username);
+        nextAuthUser = await getAuthUserById(context.db, context.authUserId);
+      }
+      const updatedUser = await updateFlaremoUserProfile(
+        context.db,
+        context.user,
+        {
+          ...(fields.includes("displayName")
+            ? { name: requiredString(user.displayName, "user.displayName") }
+            : {}),
+          ...(fields.includes("avatarUrl")
+            ? { avatarUrl: optionalString(user.avatarUrl) ?? null }
+            : {}),
+        },
+      );
+      return connectValue(
+        c,
+        currentUserToDto(updatedUser, nextAuthUser),
+        transport,
+      );
+    }
+    case "GetUserStats": {
+      assertConnectUserPath(body.name, context.user.id);
+      const stats = await getMemoStats(context.db, context.user, {
+        time_zone: "UTC",
+      });
+      return connectValue(
+        c,
+        userStatsFromMemoStats(context.user.id, stats),
+        transport,
+      );
+    }
+    case "ListAllUserStats": {
+      const stats = await getMemoStats(context.db, context.user, {
+        time_zone: "UTC",
+      });
+      return connectValue(
+        c,
+        { stats: [userStatsFromMemoStats(context.user.id, stats)] },
+        transport,
+      );
+    }
+    case "GetUserSetting": {
+      assertConnectUserSettingPath(body.name, context.user.id);
+      return connectValue(
+        c,
+        userSettingResponse(context, requiredString(body.name, "name")),
+        transport,
+      );
+    }
+    case "ListUserSettings": {
+      assertConnectUserPath(body.parent, context.user.id);
+      const settings = await listConnectUserSettings(context);
+      return connectValue(
+        c,
+        { settings, totalSize: settings.length },
+        transport,
+      );
+    }
+    case "UpdateUserSetting": {
+      if (context.credential === "pat") {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "permission_denied",
+          "A session credential is required to update settings",
+          403,
+        );
+      }
+      const setting = record(body.setting);
+      assertConnectUserSettingPath(setting.name, context.user.id);
+      const key = userSettingKey(requiredString(setting.name, "setting.name"));
+      await upsertStoredSetting(
+        context.db,
+        context.user,
+        `memos.user.${key}`,
+        setting.value,
+      );
+      return connectValue(c, setting, transport);
+    }
+    case "ListLinkedIdentities":
+      assertConnectUserPath(body.parent, context.user.id);
+      return connectValue(c, { linkedIdentities: [] }, transport);
+    case "CreateLinkedIdentity":
+    case "GetLinkedIdentity":
+    case "DeleteLinkedIdentity":
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        "SSO linked identities are not configured on FlareMo",
+        501,
+      );
+    case "ListPersonalAccessTokens": {
+      assertConnectUserPath(body.parent, context.user.id);
+      const tokens = await listMemosPersonalAccessTokens(
+        context.db,
+        context.authUserId,
+      );
+      return connectValue(
+        c,
+        {
+          personalAccessTokens: tokens.map((token) =>
+            connectPatToDto(token, context.user.id),
+          ),
+          totalSize: tokens.length,
+        },
+        transport,
+      );
+    }
+    case "CreatePersonalAccessToken": {
+      if (context.credential === "pat") {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "permission_denied",
+          "A session credential is required to create a PAT",
+          403,
+        );
+      }
+      assertConnectUserPath(body.parent, context.user.id);
+      const expiresInDays =
+        body.expiresInDays === undefined ? 0 : Number(body.expiresInDays);
+      if (
+        !Number.isInteger(expiresInDays) ||
+        expiresInDays < 0 ||
+        expiresInDays > 365
+      ) {
+        throw new ConnectInputError(
+          "expiresInDays must be an integer between 0 and 365",
+        );
+      }
+      const created = await createFlareMoAuth(
+        c.env,
+        context.db,
+      ).api.createApiKey({
+        body: {
+          configId: "memos",
+          userId: context.authUserId,
+          name: optionalString(body.description) ?? "Memos API token",
+          expiresIn: expiresInDays === 0 ? null : expiresInDays * 24 * 60 * 60,
+        },
+      });
+      return connectValue(
+        c,
+        {
+          personalAccessToken: connectPatToDto(created, context.user.id),
+          token: created.key,
+        },
+        transport,
+      );
+    }
+    case "DeletePersonalAccessToken": {
+      if (context.credential === "pat") {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "permission_denied",
+          "A session credential is required to revoke a PAT",
+          403,
+        );
+      }
+      assertConnectPatPath(body.name, context.user.id);
+      const tokenId = requiredString(body.name, "name").split("/").at(-1) ?? "";
+      const token = (
+        await listMemosPersonalAccessTokens(context.db, context.authUserId)
+      ).find((item) => item.id === tokenId);
+      if (!token)
+        throw new ConnectInputError("Personal access token not found");
+      await createFlareMoAuth(c.env, context.db).api.updateApiKey({
+        body: {
+          configId: "memos",
+          keyId: token.id,
+          userId: context.authUserId,
+          enabled: false,
+        },
+      });
+      return connectValue(c, {}, transport);
+    }
+    case "ListUserWebhooks":
+      assertConnectUserPath(body.parent, context.user.id);
+      return connectValue(c, { webhooks: [] }, transport);
+    case "ListUserNotifications":
+      assertConnectUserPath(body.parent, context.user.id);
+      return connectValue(c, { notifications: [] }, transport);
+    case "UpdateUserNotification":
+    case "DeleteUserNotification":
+    case "CreateUserWebhook":
+    case "UpdateUserWebhook":
+    case "DeleteUserWebhook":
+    case "GetUserWebhookSigningSecret":
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        "Webhooks and notifications are not configured on FlareMo",
+        501,
+      );
+    default:
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        `User method is not implemented: ${method}`,
+        501,
+      );
+  }
+}
+
+async function connectInstanceMethod(
+  c: ConnectContext,
+  context: ConnectRequestContext,
+  method: string,
+  value: unknown,
+  transport?: BinaryTransport,
+) {
+  const body = record(value);
+  switch (method) {
+    case "GetInstanceProfile": {
+      const bootstrap = await getAuthBootstrapStatus(context.db);
+      const admin = context.authUserId
+        ? currentUserToDto(
+            context.user,
+            await getAuthUserById(context.db, context.authUserId),
+          )
+        : publicUserToDto(context.user);
+      return connectValue(
+        c,
+        {
+          version: "0.4.3",
+          demo: false,
+          instanceUrl: c.env.FLAREMO_PUBLIC_URL ?? new URL(c.req.url).origin,
+          admin,
+          needsSetup: bootstrap.state !== "complete",
+        },
+        transport,
+      );
+    }
+    case "GetInstanceSetting": {
+      const name = requiredString(body.name, "name");
+      if (!context.authUserId && !isPublicInstanceSettingKey(name)) {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "unauthenticated",
+          "This instance setting requires authentication",
+          401,
+        );
+      }
+      return connectValue(
+        c,
+        await instanceSettingResponse(context, name),
+        transport,
+      );
+    }
+    case "BatchGetInstanceSettings": {
+      const names = list(body.names).map((name) =>
+        requiredString(name, "names[]"),
+      );
+      if (names.length > 20) {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "invalid_argument",
+          "A maximum of 20 instance settings may be requested",
+          400,
+        );
+      }
+      if (
+        !context.authUserId &&
+        names.some((name) => !isPublicInstanceSettingKey(name))
+      ) {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "unauthenticated",
+          "One or more instance settings require authentication",
+          401,
+        );
+      }
+      const settings = await Promise.all(
+        names.map((name) => instanceSettingResponse(context, name)),
+      );
+      return connectValue(c, { settings }, transport);
+    }
+    case "UpdateInstanceSetting": {
+      if (context.credential === "pat" || context.user.role !== "owner") {
+        return connectErrorForTransport(
+          c,
+          transport,
+          "permission_denied",
+          "A session credential is required to update instance settings",
+          403,
+        );
+      }
+      const setting = record(body.setting);
+      const name = requiredString(setting.name, "setting.name");
+      const key = instanceSettingKey(name);
+      await upsertStoredSetting(
+        context.db,
+        context.user,
+        `memos.instance.${key}`,
+        setting.value,
+      );
+      return connectValue(c, setting, transport);
+    }
+    case "GetInstanceStats": {
+      const stats = await getMemoStats(context.db, context.user, {
+        time_zone: "UTC",
+      });
+      return connectValue(
+        c,
+        {
+          database: { driver: "sqlite", sizeBytes: "-1" },
+          localStorageBytes: "-1",
+          generatedTime: new Date().toISOString(),
+          memoCount: stats.counts.total,
+        },
+        transport,
+      );
+    }
+    case "TestInstanceEmailSetting":
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        "Email delivery is not configured on FlareMo",
+        501,
+      );
+    default:
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        `Instance method is not implemented: ${method}`,
+        501,
+      );
+  }
+}
+
+async function connectIdentityProviderMethod(
+  c: ConnectContext,
+  _context: ConnectRequestContext,
+  method: string,
+  _value: unknown,
+  transport?: BinaryTransport,
+) {
+  if (method === "ListIdentityProviders") {
+    return connectValue(c, { identityProviders: [] }, transport);
+  }
+  return connectErrorForTransport(
+    c,
+    transport,
+    "unimplemented",
+    "Identity providers are not configured on FlareMo",
+    501,
+  );
+}
+
 async function createConnectMemoComment(
   context: Awaited<ReturnType<typeof getRequestContext>>,
   value: unknown,
@@ -363,6 +1022,7 @@ async function listConnectMemoComments(
   );
   return {
     memos: comments,
+    totalSize: comments.length,
     ...(result.nextPageToken ? { nextPageToken: result.nextPageToken } : {}),
   };
 }
@@ -381,6 +1041,7 @@ async function listConnectMemoReactions(
   });
   return {
     reactions: result.reactions.map(currentReactionToDto),
+    totalSize: result.reactions.length,
     ...(result.nextPageToken ? { nextPageToken: result.nextPageToken } : {}),
   };
 }
@@ -471,7 +1132,7 @@ async function connectGetSharedMemo(
   const db = createDb(c.env.DB);
   const shared = await getPublicShareByToken(
     db,
-    requiredString(body.shareToken, "shareToken"),
+    requiredString(body.shareId ?? body.shareToken, "shareId"),
   );
   const reactions = await listMemoReactions(db, shared.user, shared.memo.id, {
     pageSize: 1_000,
@@ -484,6 +1145,209 @@ async function connectGetSharedMemo(
     }),
     transport,
   );
+}
+
+type ConnectReadContext = Awaited<ReturnType<typeof getOptionalRequestContext>>;
+
+async function connectPublicMemoRead(
+  c: ConnectContext,
+  context: ConnectReadContext,
+  method: string,
+  value: unknown,
+  transport?: BinaryTransport,
+) {
+  const body = record(value);
+  switch (method) {
+    case "ListMemos": {
+      const result = await listMemosForViewer(context.db, context.user, {
+        page_size: pageSize(body.pageSize),
+        page_token: optionalString(body.pageToken),
+        order_by: normalizeOrderBy(
+          optionalString(body.orderBy) ?? "create_time desc",
+        ),
+        state: stateToLegacy(optionalString(body.state)),
+        filter: optionalString(body.filter),
+        include_deleted: body.showDeleted === true,
+      });
+      const memos = await Promise.all(
+        result.memos.map((memo) =>
+          connectPublicMemoWithDetails(context, memo.id),
+        ),
+      );
+      return connectValue(
+        c,
+        {
+          memos,
+          ...(result.nextPageToken
+            ? { nextPageToken: result.nextPageToken }
+            : {}),
+        },
+        transport,
+      );
+    }
+    case "GetMemo":
+      return connectValue(
+        c,
+        await connectPublicMemoWithDetails(
+          context,
+          requiredString(body.name, "name"),
+        ),
+        transport,
+      );
+    case "ListMemoComments": {
+      const parentName = normalizeMemoName(requiredString(body.name, "name"));
+      const result = await listMemoComments(context.db, context.user, {
+        memoName: parentName,
+        pageSize: pageSize(body.pageSize),
+        ...(optionalString(body.pageToken)
+          ? { pageToken: optionalString(body.pageToken) }
+          : {}),
+        orderBy: optionalString(body.orderBy) ?? "create_time desc",
+      });
+      const memos = await Promise.all(
+        result.memos.map((memo) =>
+          connectPublicMemoWithDetails(context, memo.id, parentName),
+        ),
+      );
+      return connectValue(
+        c,
+        {
+          memos,
+          totalSize: memos.length,
+          ...(result.nextPageToken
+            ? { nextPageToken: result.nextPageToken }
+            : {}),
+        },
+        transport,
+      );
+    }
+    case "ListMemoReactions": {
+      const result = await listMemoReactions(context.db, context.user, {
+        memoName: normalizeMemoName(requiredString(body.name, "name")),
+        pageSize: pageSize(body.pageSize),
+        ...(optionalString(body.pageToken)
+          ? { pageToken: optionalString(body.pageToken) }
+          : {}),
+      });
+      return connectValue(
+        c,
+        {
+          reactions: result.reactions.map(currentReactionToDto),
+          totalSize: result.reactions.length,
+          ...(result.nextPageToken
+            ? { nextPageToken: result.nextPageToken }
+            : {}),
+        },
+        transport,
+      );
+    }
+    case "ListMemoAttachments": {
+      const attachments = await listMemoAttachmentsForViewer(
+        context.db,
+        context.user,
+        normalizeMemoName(requiredString(body.name, "name")),
+      );
+      return connectValue(
+        c,
+        { attachments: attachments.map(currentAttachmentToDto) },
+        transport,
+      );
+    }
+    case "ListMemoRelations": {
+      const memoId = normalizeMemoName(requiredString(body.name, "name"));
+      const memo = await getMemoByIdForViewer(context.db, context.user, memoId);
+      const rows = await listMemoRelations(context.db, context.user, memoId);
+      const relations = await Promise.all(
+        rows.map(async (relation) => {
+          try {
+            const relatedMemo = await getMemoByIdForViewer(
+              context.db,
+              context.user,
+              relation.relatedMemoId,
+            );
+            return currentRelationToDto(relation, memo, relatedMemo);
+          } catch {
+            return null;
+          }
+        }),
+      );
+      return connectValue(
+        c,
+        {
+          relations: relations.filter(
+            (relation): relation is NonNullable<typeof relation> =>
+              relation !== null,
+          ),
+        },
+        transport,
+      );
+    }
+    default:
+      return connectErrorForTransport(
+        c,
+        transport,
+        "unimplemented",
+        `Public Memos read method is not implemented: ${method}`,
+        501,
+      );
+  }
+}
+
+async function connectPublicMemoWithDetails(
+  context: ConnectReadContext,
+  memoId: string,
+  parent?: string,
+) {
+  const memo = await getMemoByIdForViewer(context.db, context.user, memoId);
+  const [attachments, reactions, relationRows] = await Promise.all([
+    listMemoAttachmentsForViewer(context.db, context.user, memo.id),
+    listMemoReactions(context.db, context.user, memo.id, { pageSize: 1_000 }),
+    listMemoRelations(context.db, context.user, memo.id),
+  ]);
+  const relations = await Promise.all(
+    relationRows.map(async (relation) => {
+      try {
+        const relatedMemo = await getMemoByIdForViewer(
+          context.db,
+          context.user,
+          relation.relatedMemoId,
+        );
+        return currentRelationToDto(relation, memo, relatedMemo);
+      } catch {
+        return null;
+      }
+    }),
+  );
+  const creator = await getMemoCreatorForViewer(context, memo);
+  return currentMemoToDto(memo, creator, {
+    attachments,
+    reactions: reactions.reactions,
+    relations: relations.filter(
+      (relation): relation is NonNullable<typeof relation> => relation !== null,
+    ),
+    ...(parent ? { parent } : {}),
+  });
+}
+
+async function getMemoCreatorForViewer(
+  context: ConnectReadContext,
+  memo: Awaited<ReturnType<typeof getMemoByIdForViewer>>,
+) {
+  if (context.user?.id === memo.userId) return context.user;
+  const creator = await getFlaremoUserById(context.db, memo.userId);
+  if (!creator) throw new Error("Memo creator not found");
+  return creator;
+}
+
+function isPublicMemoReadMethod(method: string) {
+  return [
+    "GetMemo",
+    "ListMemos",
+    "ListMemoComments",
+    "ListMemoReactions",
+    "ListMemoAttachments",
+    "ListMemoRelations",
+  ].includes(method);
 }
 
 async function connectGetLinkMetadata(
@@ -893,6 +1757,362 @@ function shareTokenFromName(value: string) {
   return token;
 }
 
+function normalizeAttachmentName(value: string) {
+  return value.startsWith("attachments/") ? value : `attachments/${value}`;
+}
+
+async function getPublicInstanceContext(
+  c: ConnectContext,
+): Promise<ConnectRequestContext> {
+  const db = createDb(c.env.DB);
+  const user =
+    (await getFlaremoUserById(db, "users/owner")) ??
+    publicOwnerFallback(c.env.FLAREMO_SINGLE_USER_NAME);
+  return {
+    db,
+    user,
+    authUserId: "",
+    credential: "session",
+    bearerSession: false,
+    nativeAccessToken: false,
+    session: null,
+  };
+}
+
+function publicOwnerFallback(name: string | undefined): UserRow {
+  const timestamp = new Date(0).toISOString();
+  return {
+    id: "users/owner",
+    email: "",
+    name: name?.trim() || "Owner",
+    avatarUrl: null,
+    role: "owner",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function attachmentBytes(value: unknown) {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (typeof value === "string") {
+    try {
+      const binary = atob(value);
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+      return bytes;
+    } catch {
+      throw new ConnectInputError("attachment.content must be valid base64");
+    }
+  }
+  return new Uint8Array();
+}
+
+function parseAttachmentMemoFilter(value: string) {
+  const match = /^memo\s*(?:==|=)\s*["']([^"']+)["']$/i.exec(value.trim());
+  if (!match?.[1]) {
+    throw new ConnectInputError(
+      'Attachment filter only supports memo == "memos/{id}"',
+    );
+  }
+  return match[1];
+}
+
+function fieldMaskPaths(value: unknown) {
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((field) => field.trim())
+      .filter(Boolean);
+  }
+  const paths = record(value).paths;
+  return Array.isArray(paths)
+    ? paths.filter(
+        (path): path is string =>
+          typeof path === "string" && Boolean(path.trim()),
+      )
+    : [];
+}
+
+function assertConnectUserPath(value: unknown, currentUserId: string) {
+  const name = requiredString(value, "user");
+  const normalized = name.startsWith("users/") ? name : `users/${name}`;
+  if (normalized !== currentUserId) {
+    throw new ConnectInputError("Only the current FlareMo user is available");
+  }
+}
+
+function assertConnectUserSettingPath(value: unknown, currentUserId: string) {
+  const name = requiredString(value, "setting");
+  const prefix = `${currentUserId}/settings/`;
+  if (!name.startsWith(prefix) || name.slice(prefix.length).includes("/")) {
+    throw new ConnectInputError(
+      "Only the current FlareMo user settings are available",
+    );
+  }
+}
+
+function assertConnectPatPath(value: unknown, currentUserId: string) {
+  const name = requiredString(value, "name");
+  if (!name.startsWith(`${currentUserId}/personalAccessTokens/`)) {
+    throw new ConnectInputError(
+      "Only the current FlareMo user's PATs are available",
+    );
+  }
+}
+
+function userSettingKey(name: string) {
+  return name.split("/").at(-1) ?? "GENERAL";
+}
+
+async function userSettingResponse(
+  context: ConnectRequestContext,
+  name: string,
+) {
+  const key = userSettingKey(name);
+  const stored = await getStoredSetting(
+    context.db,
+    context.user,
+    `memos.user.${key}`,
+  );
+  return {
+    name,
+    value:
+      stored?.value && typeof stored.value === "object"
+        ? stored.value
+        : { case: "generalSetting", value: {} },
+  };
+}
+
+async function listConnectUserSettings(context: ConnectRequestContext) {
+  const username =
+    (await getAuthUserById(context.db, context.authUserId))?.username ??
+    "owner";
+  const generalName = `${context.user.id}/settings/GENERAL`;
+  const stored = await getStoredSetting(
+    context.db,
+    context.user,
+    "memos.user.GENERAL",
+  );
+  return [
+    {
+      name: generalName.replace(context.user.id, `users/${username}`),
+      value:
+        stored?.value && typeof stored.value === "object"
+          ? stored.value
+          : { case: "generalSetting", value: {} },
+    },
+  ];
+}
+
+function instanceSettingKey(name: string) {
+  const key = name.split("/").at(-1)?.toUpperCase();
+  if (!key || !/^[A-Z_]+$/.test(key)) {
+    throw new ConnectInputError("Invalid instance setting name");
+  }
+  return key;
+}
+
+async function instanceSettingResponse(
+  context: ConnectRequestContext,
+  name: string,
+) {
+  if (!name.startsWith("instance/settings/")) {
+    throw new ConnectInputError("Invalid instance setting name");
+  }
+  const key = instanceSettingKey(name);
+  const stored = await getStoredSetting(
+    context.db,
+    context.user,
+    `memos.instance.${key}`,
+  );
+  if (!context.authUserId) {
+    return {
+      name,
+      value: publicInstanceSettingValue(key, stored?.value),
+    };
+  }
+  return {
+    name,
+    value:
+      stored?.value && typeof stored.value === "object"
+        ? stored.value
+        : defaultInstanceSetting(key),
+  };
+}
+
+function isPublicInstanceSettingKey(name: string) {
+  if (!name.startsWith("instance/settings/")) return false;
+  const key = name.split("/").at(-1)?.toUpperCase();
+  return key === "GENERAL" || key === "MEMO_RELATED";
+}
+
+function publicInstanceSettingValue(key: string, value: unknown) {
+  const stored = record(record(value).value);
+  if (key === "GENERAL") {
+    return {
+      case: "generalSetting",
+      value: {
+        disallowUserRegistration:
+          typeof stored.disallowUserRegistration === "boolean"
+            ? stored.disallowUserRegistration
+            : true,
+        disallowPasswordAuth:
+          typeof stored.disallowPasswordAuth === "boolean"
+            ? stored.disallowPasswordAuth
+            : false,
+        disallowChangeUsername:
+          typeof stored.disallowChangeUsername === "boolean"
+            ? stored.disallowChangeUsername
+            : false,
+        disallowChangeNickname:
+          typeof stored.disallowChangeNickname === "boolean"
+            ? stored.disallowChangeNickname
+            : false,
+      },
+    };
+  }
+  if (key === "MEMO_RELATED") {
+    const reactions = Array.isArray(stored.reactions)
+      ? stored.reactions.filter(
+          (reaction): reaction is string =>
+            typeof reaction === "string" && reaction.length <= 32,
+        )
+      : ["👍", "❤️", "😂", "😢", "😡"];
+    return {
+      case: "memoRelatedSetting",
+      value: {
+        contentLengthLimit:
+          typeof stored.contentLengthLimit === "number" &&
+          Number.isSafeInteger(stored.contentLengthLimit) &&
+          stored.contentLengthLimit > 0
+            ? Math.min(stored.contentLengthLimit, 10_000_000)
+            : 1_000_000,
+        enableDoubleClickEdit:
+          typeof stored.enableDoubleClickEdit === "boolean"
+            ? stored.enableDoubleClickEdit
+            : true,
+        reactions: reactions.slice(0, 64),
+      },
+    };
+  }
+  throw new ConnectInputError("This instance setting requires authentication");
+}
+
+function defaultInstanceSetting(key: string) {
+  switch (key) {
+    case "GENERAL":
+      return {
+        case: "generalSetting",
+        value: {
+          disallowUserRegistration: true,
+          disallowPasswordAuth: false,
+          disallowChangeUsername: false,
+          disallowChangeNickname: false,
+        },
+      };
+    case "MEMO_RELATED":
+      return {
+        case: "memoRelatedSetting",
+        value: {
+          contentLengthLimit: 1_000_000,
+          enableDoubleClickEdit: true,
+          reactions: ["👍", "❤️", "😂", "😢", "😡"],
+        },
+      };
+    case "STORAGE":
+      return {
+        case: "storageSetting",
+        value: {
+          storageType: "S3",
+          filepathTemplate: "memos/{timestamp}_{filename}",
+        },
+      };
+    case "NOTIFICATION":
+      return {
+        case: "notificationSetting",
+        value: { email: { enabled: false } },
+      };
+    case "AI":
+      return { case: "aiSetting", value: { providers: [] } };
+    case "TAGS":
+      return { case: "tagsSetting", value: { tags: {} } };
+    default:
+      throw new ConnectInputError(`Unsupported instance setting: ${key}`);
+  }
+}
+
+function userStatsFromMemoStats(
+  userId: string,
+  stats: Awaited<ReturnType<typeof getMemoStats>>,
+) {
+  return {
+    name: userId,
+    memoTypeStats: { linkCount: 0, codeCount: 0, todoCount: 0, undoCount: 0 },
+    tagCount: Object.fromEntries(
+      stats.tags.map((tag) => [tag.name, tag.count]),
+    ),
+    totalMemoCount: stats.counts.total,
+    pinnedMemos: [],
+    memoCreatedTimestamps: [],
+    memoUpdatedTimestamps: [],
+  };
+}
+
+function connectPatToDto(
+  token: {
+    id: string;
+    name: string | null;
+    createdAt: Date;
+    expiresAt: Date | null;
+    lastRequest: Date | null;
+  },
+  userId: string,
+) {
+  return {
+    name: `${userId}/personalAccessTokens/${token.id}`,
+    ...(token.name ? { description: token.name } : {}),
+    createdAt: token.createdAt.toISOString(),
+    ...(token.expiresAt ? { expiresAt: token.expiresAt.toISOString() } : {}),
+    ...(token.lastRequest
+      ? { lastUsedAt: token.lastRequest.toISOString() }
+      : {}),
+  };
+}
+
+async function updateBetterAuthUsername(
+  c: ConnectContext,
+  context: ConnectRequestContext,
+  username: string,
+) {
+  if (!c.req.raw.headers.get("cookie")) {
+    throw new ConnectInputError(
+      "A Better Auth cookie session is required to update the username",
+    );
+  }
+  const headers = new Headers(c.req.raw.headers);
+  headers.set("content-type", "application/json");
+  const request = new Request(new URL("/api/auth/update-user", c.req.url), {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ username }),
+  });
+  const response = await createFlareMoAuth(c.env, context.db).handler(request);
+  if (response.ok) return;
+  let message = "Better Auth rejected the username update";
+  try {
+    const payload = (await response.json()) as { message?: unknown };
+    if (typeof payload.message === "string" && payload.message) {
+      message = payload.message;
+    }
+  } catch {
+    // Keep the stable compatibility error when Better Auth did not return JSON.
+  }
+  throw new ConnectInputError(message);
+}
+
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   return value as Record<string, unknown>;
@@ -1000,6 +2220,22 @@ async function connectAuthSignIn(
     response.headers.set("cache-control", "no-store");
     return response;
   } catch (error) {
+    if (isBetterAuthCredentialError(error)) {
+      return transport
+        ? connectErrorForTransport(
+            c,
+            transport,
+            "invalid_argument",
+            "unmatched username and password",
+            400,
+          )
+        : connectError(
+            c,
+            "invalid_argument",
+            "unmatched username and password",
+            400,
+          );
+    }
     return transport
       ? connectBinaryError(c, transport, error)
       : connectDomainError(c, error);
@@ -1059,6 +2295,21 @@ async function connectAuthSignOut(
       expectedAuthUserId: context.authUserId,
     });
     const response = connectValue(c, {}, transport);
+    const bearer = c.req.header("authorization");
+    if (context.bearerSession && bearer) {
+      await revokeAuthSessionByToken(context.db, parseBearerForSignOut(bearer));
+    }
+    if (c.req.raw.headers.get("cookie")) {
+      const headers = new Headers(c.req.raw.headers);
+      headers.delete("authorization");
+      const authResponse = await createFlareMoAuth(c.env, context.db).handler(
+        new Request(new URL("/api/auth/sign-out", c.req.url), {
+          method: "POST",
+          headers,
+        }),
+      );
+      copyResponseHeaders(response.headers, authResponse.headers);
+    }
     response.headers.append("set-cookie", clearMemosRefreshCookie(c.req.raw));
     response.headers.set("cache-control", "no-store");
     return response;
@@ -1101,10 +2352,13 @@ function connectErrorForTransport(
     "grpc-message": encodeURIComponent(message),
     "grpc-status": String(grpcStatusForCode(code)),
   });
-  return new Response(encodeBinaryError(message, transport), {
-    status,
-    headers,
-  });
+  return new Response(
+    encodeBinaryError(message, transport, grpcStatusForCode(code)),
+    {
+      status,
+      headers,
+    },
+  );
 }
 
 function connectBinaryError(
@@ -1221,4 +2475,17 @@ function domainCode(status: number) {
   if (status === 404) return "not_found";
   if (status === 409) return "already_exists";
   return "invalid_argument";
+}
+
+function isBetterAuthCredentialError(error: unknown) {
+  const value = record(error);
+  return value.code === "INVALID_USERNAME_OR_PASSWORD";
+}
+
+function parseBearerForSignOut(value: string) {
+  const parts = value.trim().split(/\s+/);
+  if (parts.length !== 2 || parts[0]?.toLowerCase() !== "bearer" || !parts[1]) {
+    throw new ConnectInputError("Invalid authorization header");
+  }
+  return parts[1];
 }

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -9,16 +9,18 @@ import {
   getAttachmentById,
   getAuthUserById,
   getFlaremoUserByAuthSessionToken,
-  getMemoById,
+  getFlaremoUserById,
+  type getMemoById,
+  getMemoByIdForViewer,
   getMemosPersonalAccessToken,
   getPublicShareByToken,
   hardDeleteMemo,
   listAttachments,
-  listAttachmentsForMemos,
-  listMemoAttachments,
+  listAttachmentsForMemosForViewer,
+  listMemoAttachmentsForViewer,
   listMemoRelations,
   listMemoShares,
-  listMemos,
+  listMemosForViewer,
   listMemosPersonalAccessTokens,
   markAttachmentDeleting,
   moveMemoToTrash,
@@ -44,6 +46,7 @@ import {
 import { createFlareMoAuth } from "../auth";
 import {
   assertTrustedCookieMutation,
+  getOptionalRequestContext,
   getRequestContext,
   type HonoBindings,
 } from "../context";
@@ -361,13 +364,13 @@ memosCurrentApi.post("/auth/signout", async (c, next) => {
 memosCurrentApi.get("/memos", async (c, next) => {
   if (isLegacyWireRequest(c)) return next();
   try {
-    const context = await getRequestContext(c);
-    const result = await listMemos(
+    const context = await getOptionalRequestContext(c);
+    const result = await listMemosForViewer(
       context.db,
       context.user,
       currentListQuery(c),
     );
-    const attachments = await listAttachmentsForMemos(
+    const attachments = await listAttachmentsForMemosForViewer(
       context.db,
       context.user,
       result.memos.map((memo) => memo.id),
@@ -380,10 +383,12 @@ memosCurrentApi.get("/memos", async (c, next) => {
       byMemo.set(attachment.memoId, values);
     }
     return c.json({
-      memos: result.memos.map((memo) =>
-        currentMemoToDto(memo, context.user, {
-          attachments: byMemo.get(memo.id) ?? [],
-        }),
+      memos: await Promise.all(
+        result.memos.map(async (memo) =>
+          currentMemoToDto(memo, await currentMemoCreator(context, memo), {
+            attachments: byMemo.get(memo.id) ?? [],
+          }),
+        ),
       ),
       ...(result.nextPageToken ? { nextPageToken: result.nextPageToken } : {}),
     });
@@ -422,8 +427,8 @@ memosCurrentApi.post("/memos", async (c, next) => {
 memosCurrentApi.get("/memos/:memo", async (c, next) => {
   if (isLegacyWireRequest(c)) return next();
   try {
-    const context = await getRequestContext(c);
-    const memo = await getMemoById(
+    const context = await getOptionalRequestContext(c);
+    const memo = await getMemoByIdForViewer(
       context.db,
       context.user,
       normalizeMemoName(c.req.param("memo")),
@@ -476,8 +481,8 @@ memosCurrentApi.delete("/memos/:memo", async (c, next) => {
 memosCurrentApi.get("/memos/:memo/attachments", async (c, next) => {
   if (isLegacyWireRequest(c)) return next();
   try {
-    const context = await getRequestContext(c);
-    const attachments = await listMemoAttachments(
+    const context = await getOptionalRequestContext(c);
+    const attachments = await listMemoAttachmentsForViewer(
       context.db,
       context.user,
       normalizeMemoName(c.req.param("memo")),
@@ -513,7 +518,7 @@ memosCurrentApi.patch("/memos/:memo/attachments", async (c, next) => {
 memosCurrentApi.get("/memos/:memo/relations", async (c, next) => {
   if (isLegacyWireRequest(c)) return next();
   try {
-    const context = await getRequestContext(c);
+    const context = await getOptionalRequestContext(c);
     const relations = await currentRelations(
       context,
       normalizeMemoName(c.req.param("memo")),
@@ -876,28 +881,31 @@ memosCurrentApi.get("/users/:user", async (c, next) => {
 });
 
 async function currentMemoWithDetails(
-  context: Awaited<ReturnType<typeof getRequestContext>>,
+  context: Awaited<ReturnType<typeof getOptionalRequestContext>>,
   memo: Awaited<ReturnType<typeof getMemoById>>,
 ) {
   const [attachments, relations] = await Promise.all([
-    listMemoAttachments(context.db, context.user, memo.id),
+    listMemoAttachmentsForViewer(context.db, context.user, memo.id),
     currentRelations(context, memo.id),
   ]);
-  return currentMemoToDto(memo, context.user, { attachments, relations });
+  return currentMemoToDto(memo, await currentMemoCreator(context, memo), {
+    attachments,
+    relations,
+  });
 }
 
 async function currentRelations(
-  context: Awaited<ReturnType<typeof getRequestContext>>,
+  context: Awaited<ReturnType<typeof getOptionalRequestContext>>,
   memoId: string,
 ) {
-  const memo = await getMemoById(context.db, context.user, memoId, {
+  const memo = await getMemoByIdForViewer(context.db, context.user, memoId, {
     includeDeleted: true,
   });
   const rows = await listMemoRelations(context.db, context.user, memoId);
   const related = await Promise.all(
     rows.map(async (relation) => {
       try {
-        const relatedMemo = await getMemoById(
+        const relatedMemo = await getMemoByIdForViewer(
           context.db,
           context.user,
           relation.relatedMemoId,
@@ -912,6 +920,16 @@ async function currentRelations(
   return related.filter(
     (value): value is NonNullable<typeof value> => value !== null,
   );
+}
+
+async function currentMemoCreator(
+  context: Awaited<ReturnType<typeof getOptionalRequestContext>>,
+  memo: Awaited<ReturnType<typeof getMemoById>>,
+) {
+  if (context.user?.id === memo.userId) return context.user;
+  const creator = await getFlaremoUserById(context.db, memo.userId);
+  if (!creator) throw new Error("Memo creator not found");
+  return creator;
 }
 
 async function currentUserForContext(context: {
@@ -1272,6 +1290,7 @@ function currentJsonError(
 function currentErrorStatus(error: unknown) {
   if (error instanceof CurrentHttpError) return error.status;
   if (isDomainError(error)) return error.status;
+  if (isBetterAuthCredentialError(error)) return 400;
   if (isRecord(error) && typeof error.statusCode === "number")
     return error.statusCode;
   if (isRecord(error) && typeof error.status === "number") return error.status;
@@ -1289,6 +1308,8 @@ function currentErrorStatus(error: unknown) {
 function currentErrorMessage(error: unknown) {
   if (error instanceof CurrentHttpError) return error.message;
   if (isDomainError(error)) return error.message;
+  if (isBetterAuthCredentialError(error))
+    return "unmatched username and password";
   if (isRecord(error) && typeof error.message === "string")
     return error.message;
   if (isRecord(error) && Array.isArray(error.issues)) {
@@ -1301,6 +1322,10 @@ function currentErrorMessage(error: unknown) {
       .join("; ");
   }
   return "Internal server error";
+}
+
+function isBetterAuthCredentialError(error: unknown) {
+  return isRecord(error) && error.code === "INVALID_USERNAME_OR_PASSWORD";
 }
 
 function currentErrorCode(status: number) {

--- a/apps/worker/src/routes/memos-social-api.ts
+++ b/apps/worker/src/routes/memos-social-api.ts
@@ -5,9 +5,10 @@ import {
   type DomainError,
   deleteMemoReaction,
   deleteShortcut,
-  getMemoById,
+  getFlaremoUserById,
+  getMemoByIdForViewer,
   getShortcut,
-  listMemoAttachments,
+  listMemoAttachmentsForViewer,
   listMemoComments,
   listMemoReactions,
   listMemoRelations,
@@ -24,7 +25,7 @@ import {
 import type { Context } from "hono";
 import { Hono } from "hono";
 import type { HonoBindings } from "../context";
-import { getRequestContext } from "../context";
+import { getOptionalRequestContext, getRequestContext } from "../context";
 
 /**
  * Mount this app at `/api/v1`, before the legacy Memos app:
@@ -74,7 +75,7 @@ export const memosSocialApi = new Hono<HonoBindings>();
 
 memosSocialApi.get("/memos/:memo/comments", async (c) => {
   try {
-    const context = await getRequestContext(c);
+    const context = await getOptionalRequestContext(c);
     const memoName = normalizeMemoName(c.req.param("memo"));
     const page = readPageOptions(c, "create_time desc");
     const result: MemoCommentPage = await listMemoComments(
@@ -133,7 +134,7 @@ memosSocialApi.post("/memos/:memo/comments", async (c) => {
 
 memosSocialApi.get("/memos/:memo/reactions", async (c) => {
   try {
-    const context = await getRequestContext(c);
+    const context = await getOptionalRequestContext(c);
     const memoName = normalizeMemoName(c.req.param("memo"));
     const page = readPageOptions(c);
     const result: MemoReactionPage = await listMemoReactions(
@@ -338,7 +339,7 @@ memosSocialApi.delete("/users/:user/shortcuts/:shortcut", async (c) => {
 });
 
 async function memoToCurrentDto(
-  context: Awaited<ReturnType<typeof getRequestContext>>,
+  context: Awaited<ReturnType<typeof getOptionalRequestContext>>,
   memo: MemoRow,
   parentName?: string,
 ) {
@@ -351,14 +352,14 @@ async function memoToCurrentDto(
     },
   );
   const [attachments, relationRows, reactionPage] = await Promise.all([
-    listMemoAttachments(context.db, context.user, memo.id),
+    listMemoAttachmentsForViewer(context.db, context.user, memo.id),
     listMemoRelations(context.db, context.user, memo.id),
     reactionPagePromise,
   ]);
   const relations = await Promise.all(
     relationRows.map(async (relation) => {
       try {
-        const relatedMemo = await getMemoById(
+        const relatedMemo = await getMemoByIdForViewer(
           context.db,
           context.user,
           relation.relatedMemoId,
@@ -370,8 +371,13 @@ async function memoToCurrentDto(
       }
     }),
   );
+  const creator =
+    context.user?.id === memo.userId
+      ? context.user
+      : await getFlaremoUserById(context.db, memo.userId);
+  if (!creator) throw new Error("Memo creator not found");
   return {
-    ...currentMemoToDto(memo, context.user, {
+    ...currentMemoToDto(memo, creator, {
       attachments,
       relations: relations.filter(
         (value): value is NonNullable<typeof value> => value !== null,

--- a/docs/memos-compatibility.md
+++ b/docs/memos-compatibility.md
@@ -1,8 +1,35 @@
 # Memos 兼容矩阵
 
-FlareMo 是一个运行在 Cloudflare Workers 上的 Memos-compatible 个人知识系统，不是 Memos Server 的 Go fork。当前默认公开的是 current Memos 风格的 camelCase / protobuf-JSON REST 子集，同时保留旧 FlareMo snake_case wire 作为显式兼容模式；canonical service/method 路径还提供 Connect JSON、protobuf unary、gRPC unary、gRPC-Web protobuf/text 的已实现子集；根路径 `/mcp` 提供无状态 Streamable HTTP MCP 子集。
+> 矩阵快照：2026-08-04。本页按当前工作树、当前 `git diff` 和仓库测试整理；它描述的是 FlareMo 的兼容边界，不是对任意 Memos 客户端的线上承诺。
 
-这意味着当前可以把 FlareMo 当作“内核不同、对外协议尽量兼容”的实现，但不能宣称已经完成完整 Memos Server parity。第三方客户端、Memos 官方客户端和周边工具仍必须逐一真实连接验证；仓库自己的 contract tests 不能替代真实客户端 smoke test。实测记录见 [memos-ecosystem.md](./memos-ecosystem.md)。
+FlareMo 是运行在 Cloudflare Workers 上的个人知识系统，不是 Memos Server 的 Go fork。它的定位是“内核不同、对外协议尽量兼容”：应用层使用 Better Auth，数据由 D1/Drizzle 和 R2 承载，并提供 Memos 风格 current camelCase REST、旧 FlareMo legacy wire、canonical Connect/protobuf unary adapter、有限 SSE 和无状态 Streamable HTTP MCP。
+
+当前可以准确地说 FlareMo 已经有 Better Auth 原生鉴权、Memos 风格 access/refresh token、可撤销 `memos_pat_` PAT，以及 Memo/Auth/Shortcut 为主并扩展到 Attachment、单用户 User、Instance 和空 IdentityProvider 列表的兼容基础。不能宣称已经完成完整 Memos Server parity，也不能把仓库 contract tests 写成官方 Web 或第三方客户端已经可用。
+
+## 状态定义
+
+| 状态 | 含义 |
+| --- | --- |
+| 已实现 | 当前工作树存在对应 Worker/domain handler；不代表所有字段、错误、ACL 或 wire transport 都与上游一致。 |
+| 已测试 | 仓库中的测试对该路径或边界做了断言；这些是 FlareMo contract tests，不是第三方客户端 smoke。 |
+| 仅静态审计 | 只检查了当前参考快照中的 Memos proto/generated client 或第三方客户端源码，没有用该客户端真实请求 FlareMo。 |
+| 未实现 | 当前没有对应 handler，或 handler 明确返回 `501`。 |
+| 未验证 | 代码路径存在，但没有足够的端到端、generated client 或线上证据支撑“兼容”。 |
+
+## 总体矩阵
+
+| 能力面 | 代码状态 | 仓库测试状态 | 当前结论 |
+| --- | --- | --- | --- |
+| Better Auth 原生登录、单用户 bootstrap、cookie session | 已实现 | 已测试 | 应用层身份事实源是 Better Auth；不是 Cloudflare Access identity。 |
+| Memos 风格 sign-in/refresh/sign-out facade | 已实现 | 已测试 | 返回 FlareMo 生成的 HS256 access JWT，并轮换 `memos_refresh`；不是 Memos JWT 的字节级 parity。 |
+| `memos_pat_` Personal Access Token | 已实现 | 已测试 | PAT 可创建、列出、撤销；明文只在创建响应中出现一次。 |
+| current camelCase REST | 已实现 | 已测试 | memo、attachment、social、share、PAT 和有限 filter/order 的子集。 |
+| Connect JSON unary | 已实现 | 已测试 | 主要服务和新增单用户基础服务有 Worker contract 覆盖。 |
+| protobuf / gRPC-style / gRPC-Web unary | 部分实现 | 部分已测试 | 有手写 codec 和 framing；部分请求/响应已测，未达到 generated schema/runtime parity。 |
+| SSE | 已实现 | 已测试 | D1 outbox + polling + cursor replay 的 FlareMo 实现；不是上游进程内 SSEHub parity。 |
+| Streamable HTTP MCP | 已实现 | 已测试 | 根 `/mcp` 是无状态 JSON 子集；不承诺有状态 session、SSE 或完整工具面。 |
+| 官方 Memos Web、第三方客户端 | 未验证 | 未测 | 已做源码静态审计的候选见 [memos-ecosystem.md](./memos-ecosystem.md)，没有真实客户端 smoke 记录。 |
+| 完整 Memos Server parity | 未实现 | 未验证 | 当前明确不能宣称完成。 |
 
 ## Wire 模式
 
@@ -11,9 +38,7 @@ FlareMo 是一个运行在 Cloudflare Workers 上的 Memos-compatible 个人知�
 | current（默认） | 不加 header；或 `X-FlareMo-Wire: current` | 使用 camelCase 字段、大写 protobuf 风格枚举和 current 标准错误。 |
 | legacy | `X-FlareMo-Wire: legacy`；或 `Accept: application/vnd.flaremo.legacy+json` | 保留既有 FlareMo snake_case API，供旧脚本和旧客户端迁移使用。 |
 
-current REST 的资源名仍使用 Memos 风格，例如 `memos/{id}`、`attachments/{id}`、`users/{id}`。`GET /openapi.json` 默认返回 current OpenAPI；显式 legacy wire 时返回旧文档。
-
-Connect 和 protobuf transport 目前只实现 unary 请求/响应，服务端一次返回一个未压缩消息帧。它覆盖 `MemoService` 的 memo、attachment binding、relation、comment、reaction、share、shared-memo 和 link-metadata 子集，`AuthService` 的 current-user/sign-in/refresh/sign-out 子集，以及 `ShortcutService` 的 CRUD 子集。具体方法和未覆盖服务见下文；transport 可用不等于完整 Memos Server 或完整 gRPC parity。
+current REST 的资源名使用 Memos 风格，例如 `memos/{id}`、`attachments/{id}`、`users/{id}`。`GET /openapi.json` 默认返回 current OpenAPI；显式 legacy wire 时返回旧文档。
 
 ## 认证边界
 
@@ -21,41 +46,31 @@ Better Auth 是应用层认证事实源，Cloudflare Access 只能作为可选�
 
 | 入口 | 当前认证方式 | 兼容说明 |
 | --- | --- | --- |
-| Web / Better Auth | 用户名 + 密码，登录后使用 `HttpOnly` cookie session | 当前是一套单用户 bootstrap；公共 signup 关闭，数据模型保留未来用户映射边界。 |
-| current auth facade | `POST /api/v1/auth/signin`、`refresh`、`signout`，以及 `GET /api/v1/auth/me` | Better Auth 提供身份和账户事实源；signin 返回 Memos 风格 HS256 access JWT，并设置轮换的 `memos_refresh` HttpOnly cookie。旧 Better Auth session bearer 仍保留兼容。 |
-| `/api/v1/*` 私有 API | cookie session，或 `Authorization: Bearer memos_pat_...` | PAT 由已登录账户创建、只在创建时显示一次、可撤销，并由 Better Auth API key/plugin 数据承载。 |
-| current PAT 资源 | `/api/v1/users/{user}/personalAccessTokens` | 提供当前用户的 list/create/revoke 基础；要求 cookie session 或 Better Auth session bearer，`memos_pat_` 本身不能管理 PAT。PAT 与 native JWT 是两种明确的应用凭据。 |
-| root `/mcp` | cookie session、Better Auth session bearer，或 `memos_pat_` PAT | Streamable HTTP 是无状态 JSON 响应子集，不创建 MCP session。 |
+| Web / Better Auth | 用户名 + 密码，登录后使用 `HttpOnly` cookie session | 当前是一套单用户 bootstrap；公共 signup 关闭，认证表和 `auth_user_links` 为未来多用户保留扩展边界。 |
+| current auth facade | `POST /api/v1/auth/signin`、`refresh`、`signout`，以及 `GET /api/v1/auth/me` | Better Auth 提供身份和账户事实源；signin 返回 FlareMo 生成的 Memos 风格 HS256 access JWT，并设置轮换的 `memos_refresh` HttpOnly cookie。旧 Better Auth session bearer 仍保留兼容。 |
+| `/api/v1/*` 私有 API | cookie session，或 `Authorization: Bearer memos_pat_...` | PAT 由已登录账户创建、只在创建时显示一次、可撤销，并由 Better Auth API key/plugin 数据承载。native JWT 和 PAT 是两种明确的应用凭据。 |
+| current PAT 资源 | `/api/v1/users/{user}/personalAccessTokens` | 提供当前用户的 list/create/revoke 基础；`memos_pat_` 本身不能管理 PAT。 |
+| 根 `/mcp` | cookie session、Better Auth session bearer、FlareMo native access JWT，或 `memos_pat_` PAT | Streamable HTTP 是无状态 JSON 子集，不创建 MCP session。 |
 | Origin policy | cookie session 状态变更必须携带并精确匹配 `FLAREMO_PUBLIC_URL` / `FLAREMO_TRUSTED_ORIGINS`；PAT 可无 Origin，带 Origin 时同样必须匹配 | 缺失或不可信 Origin 返回 `403`；Access headers 不替代应用层 Origin。 |
-| Cloudflare Access | 可选外层 policy / Service Auth | Access 只解决外层网络门禁；启用时仍要提供上面的 cookie、session bearer 或 PAT。 |
+| Cloudflare Access | 可选外层 policy / Service Auth | Access 只解决外层网络门禁；启用时仍要提供上面的 cookie、session bearer、native JWT 或 PAT。 |
 
-## 已实现的 current 子集
+## current REST 矩阵
 
-### REST 路由
+| 能力 | 代码状态 | 仓库测试状态 | current 路径 / 边界 |
+| --- | --- | --- | --- |
+| current 用户与 auth facade | 已实现 | 已测试 | `GET /api/v1/auth/me`、`POST /api/v1/auth/signin`、`refresh`、`signout`；`memos-compatibility.test.ts`、`auth.test.ts` 覆盖账户和凭据边界。 |
+| memo 创建、列表、详情、更新、删除 | 已实现 | 已测试 | `POST/GET /api/v1/memos`、`GET/PATCH/DELETE /api/v1/memos/{memo}`；支持 current `{ memo: {...} }` wrapper、有限 `pageSize`、`pageToken`、`orderBy`、filter 和 `updateMask`。 |
+| memo 字段、状态、可见性、tags、property、location | 已实现 | 已测试 | 已做 DTO/枚举映射；FlareMo 的 trash/deleted 与 current Memos 状态模型并非完全相同。 |
+| memo 附件、relations、comments、reactions | 已实现 | 已测试 | `memos/{memo}/attachments`、`relations`、`comments`、`reactions` 的 current 子集；完整上游资源语义仍未证明。 |
+| attachment 资源 | 已实现 | 已测试 | `GET/POST /api/v1/attachments`、`GET/PATCH/DELETE /api/v1/attachments/{attachment}`；支持 current wrapper、R2 blob 和 memo 绑定，客户端指定 `attachmentId` 仍明确拒绝。 |
+| shortcuts | 已实现 | 已测试 | `GET/POST /api/v1/users/{user}/shortcuts` 及单项 CRUD；覆盖有限 CEL 校验、`validateOnly` 和 `updateMask`。 |
+| memo shares | 已实现 | 已测试 | `GET/POST /api/v1/memos/{memo}/shares`、`DELETE`；匿名读取仍由 share token、过期时间和 memo 状态控制。 |
+| current PAT 资源 | 已实现 | 已测试 | `/api/v1/users/{user}/personalAccessTokens` 的 list/create/revoke；PAT 不能反过来管理 PAT。 |
+| link metadata | 已实现 | 已测试 | Connect `GetLinkMetadata` / `BatchGetLinkMetadata` 提供受限 Open Graph 抓取；限制 HTTP(S)、redirect、HTML 大小和内网字面量地址。完整 DNS rebinding/egress policy 仍是部署边界。 |
+| 标准错误 | 已实现 | 已测试 | current 错误使用 `{ code, message, details }`；Better Auth 无效凭据映射为 Memos 风格 `400` / code `3`。 |
+| current OpenAPI | 已实现 | 已测试 | `GET /openapi.json` 及认证后的 current 文档；`memos-compatibility.test.ts` 检查 current/legacy wire 文档和主要路径。 |
 
-| 能力 | 状态 | current 路径 / 说明 |
-| --- | --- | --- |
-| current 用户 | 已实现 | `GET /api/v1/auth/me`、`GET /api/v1/users`、`GET /api/v1/users/{user}`。 |
-| Better Auth / native Memos auth facade | 已实现子集 | `POST /api/v1/auth/signin`、`POST /api/v1/auth/refresh`、`POST /api/v1/auth/signout`；Better Auth 负责身份，返回 `iss=memos`、`aud=user.access-token` 的 HS256 access JWT，并通过 `memos_refresh` cookie 做 refresh rotation。 |
-| 创建/列表 memo | 已实现子集 | `POST /api/v1/memos`、`GET /api/v1/memos`；支持 `pageSize`、`pageToken`、有限 `orderBy` 和有限 filter。 |
-| memo 详情/更新/删除 | 已实现子集 | `GET/PATCH/DELETE /api/v1/memos/{memo}`；支持 current `{ memo: {...} }` body wrapper、`updateMask` 和 `memoId` 明确拒绝。 |
-| memo 状态与可见性 | 已实现映射 | `NORMAL`、`ARCHIVED`、`PRIVATE`、`PROTECTED`、`PUBLIC`；FlareMo 的 trash/deleted 与 current Memos 状态模型不完全相同。 |
-| memo 属性 | 已实现子集 | `tags`、`property`、`location`、`snippet` 以及基本字段映射。 |
-| memo 附件绑定 | 已实现子集 | `GET/PATCH /api/v1/memos/{memo}/attachments`；PATCH 主要是替换 memo 的附件集合，不是完整 Attachment update parity。 |
-| memo relations | 已实现子集 | `GET/PATCH /api/v1/memos/{memo}/relations`；返回 nested `memo` / `relatedMemo` DTO 和 current relation enum。 |
-| memo comments | 已实现子集 | `GET/POST /api/v1/memos/{memo}/comments`；comment 是带 `COMMENT` relation 的 memo，返回 current camelCase memo DTO。 |
-| memo reactions | 已实现子集 | `GET/POST /api/v1/memos/{memo}/reactions`、`DELETE /api/v1/memos/{memo}/reactions/{reaction}`；按 creator/content/type 做幂等 upsert。 |
-| shortcuts | 已实现子集 | `GET/POST /api/v1/users/{user}/shortcuts`、`GET/PATCH/DELETE /api/v1/users/{user}/shortcuts/{shortcut}`；支持 CEL filter 校验、`validateOnly` 和 `updateMask`。 |
-| memo shares | 已实现子集 | `GET/POST /api/v1/memos/{memo}/shares`、`DELETE /api/v1/memos/{memo}/shares/{share}`；current share name 使用 `memos/{id}/shares/{token}` 兼容形态。 |
-| 匿名 share 读取 | 已实现 | `GET /api/v1/shares/{share_id}`；仍由 share token、过期时间和 memo 状态控制。 |
-| link metadata | 已实现子集 | Connect `GetLinkMetadata` / `BatchGetLinkMetadata` 提供受限 Open Graph title/description/image 抓取；只接受 HTTP(S)，限制 redirect、HTML 大小和内网字面量地址。 |
-| 附件资源 | 已实现子集 | `GET/POST /api/v1/attachments`、`GET/PATCH/DELETE /api/v1/attachments/{attachment}`；支持 current `{ attachment: {...} }` wrapper，`attachmentId` 明确拒绝。 |
-| 附件列表 | 已实现子集 | 返回 `attachments`、可选 `nextPageToken`；`size` 按 protobuf JSON 以十进制字符串输出。 |
-| PAT 资源 | 已实现基础 | `GET/POST /api/v1/users/{user}/personalAccessTokens`、`DELETE /api/v1/users/{user}/personalAccessTokens/{token}`。 |
-| 标准错误 | 已实现 | current 错误使用 `{ code, message, details }`，不把 FlareMo 内部异常直接暴露给客户端。 |
-| current OpenAPI | 已实现 | `GET /openapi.json`、认证后 `GET /api/v1/openapi.json`；文档描述 current/legacy wire、native JWT/refresh cookie、social 路由、SSE、Connect/protobuf subset 和 `/mcp`。 |
-
-### 有限 filter / order 支持
+### current filter / order 边界
 
 为了保持 Workers 上的安全和可预测性，current adapter 不解释任意 CEL。当前只接受已经实现并测试的有限表达式，例如：
 
@@ -66,71 +81,83 @@ pinned == true
 visibility == "PUBLIC"
 ```
 
-`orderBy` 当前只支持单字段的 `create_time` / `update_time` asc/desc 子集。未支持的 filter 或排序会返回 current 标准错误，而不是静默改变语义。
+`orderBy` 当前只支持单字段的 `create_time` / `update_time` asc/desc 子集。未支持的 filter 或排序会返回 current 标准错误，而不是静默改变语义。大小写、层级 tag、RE2 与 JavaScript regex、`name` 变量、复杂宏、完整分页和大数据量 bounded execution 仍未完成上游对照。
 
-### 根 `/mcp`
+普通 `GetMemo`、`ListMemos`、comments、reactions、memo relations 和 memo attachments 已经有独立的 optional viewer：匿名只读 `PUBLIC + NORMAL`，认证用户继续使用 Better Auth/PAT 的 owner-scoped 读取；创建、更新、删除和 share/social mutation 仍需认证。User profile/stats 的完整 public projection 尚未实现，不能把这一段扩大成完整 Memos ACL parity。
 
-`POST /mcp` 是无状态 JSON Streamable HTTP MCP 子集，支持协议版本 `2025-03-26` 和 `2024-11-05`，核心方法为：
+## Connect / protobuf / gRPC-Web 矩阵
 
-- `initialize`
-- `notifications/initialized`
-- `tools/list`
-- `tools/call`
-
-current 工具名使用 `memo_`、`attachment_`、`shortcut_`、`auth_` 前缀，覆盖 memo CRUD、attachments、relations、comments、reactions、shortcuts、附件 list/get/delete 和 current user。成功结果同时提供 text content 与 object-shaped `structuredContent`；工具执行失败保留在 MCP result 的 `isError: true` 中。
-
-### Connect、protobuf、gRPC-Web 与 SSE
-
-Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter，接受以下 media type：
+Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter，接受：
 
 - `application/json`：Connect JSON message。
 - `application/proto`：Connect protobuf unary message。
-- `application/grpc+proto`：单个未压缩 gRPC unary frame。
+- `application/grpc+proto`：单个未压缩 gRPC-style unary frame。
 - `application/grpc-web+proto`：单个未压缩 gRPC-Web protobuf frame。
 - `application/grpc-web-text+proto`：上面 frame 的 base64 文本形式。
 
-当前 binary/Connect service 子集包括：
+这里是 Worker 上的手写 `ProtoReader` / `ProtoWriter` 适配层，不是从上游 proto 生成的完整 runtime。能返回 unary frame 不等于原生 HTTP/2 gRPC server、generated Connect client 或完整 schema parity。
 
-- `MemoService`：`CreateMemo`、`ListMemos`、`GetMemo`、`UpdateMemo`、`DeleteMemo`、`SetMemoAttachments`、`ListMemoAttachments`、`SetMemoRelations`、`ListMemoRelations`、`CreateMemoComment`、`ListMemoComments`、`ListMemoReactions`、`UpsertMemoReaction`、`DeleteMemoReaction`、`CreateMemoShare`、`ListMemoShares`、`DeleteMemoShare`、`GetSharedMemo`、`GetLinkMetadata`、`BatchGetLinkMetadata`。
-- `AuthService`：`GetCurrentUser`、`SignIn`、`RefreshToken`、`SignOut`。
-- `ShortcutService`：`ListShortcuts`、`GetShortcut`、`CreateShortcut`、`UpdateShortcut`、`DeleteShortcut`。
+| 上游 service | 当前已接入方法 | 代码状态 | 仓库测试状态 | 重要边界 |
+| --- | --- | --- | --- | --- |
+| `MemoService` | `CreateMemo`、`ListMemos`、`GetMemo`、`UpdateMemo`、`DeleteMemo`；附件 binding；relations；comments；reactions；shares；`GetMemoByShare`；旧 `GetSharedMemo` alias；`GetLinkMetadata`、`BatchGetLinkMetadata` | 已实现子集 | 已测试 | JSON unary 和部分 protobuf/gRPC-Web framing 有覆盖；canonical `GetMemoByShare` 已有 JSON 测试。普通 memo RPC 仍需应用凭据。 |
+| `AuthService` | `GetCurrentUser`、`SignIn`、`RefreshToken`、`SignOut` | 已实现子集 | 部分已测试 | Better Auth 是身份事实源；native JWT/refresh 是 facade，不是上游 token 的字节级 parity；REST/native auth 和 binary `SignIn` 有覆盖，但完整 generated-client RPC roundtrip 未测。 |
+| `ShortcutService` | `ListShortcuts`、`GetShortcut`、`CreateShortcut`、`UpdateShortcut`、`DeleteShortcut` | 已实现 | 已测试 | 有 JSON、gRPC-Web framing 和 social contract 覆盖；filter 仍是有限 CEL。 |
+| `AttachmentService` | `CreateAttachment`、`ListAttachments`、`GetAttachment`、`UpdateAttachment`、`DeleteAttachment`、`BatchDeleteAttachments` | 已实现子集 | 部分已测试 | JSON `ListAttachments`、R2/D1 domain path 和 protobuf 请求字段有测试；binary 上传、binary response 的 generated-client roundtrip 未测。只允许有限 memo 字段更新；`externalLink`、客户端指定 `attachmentId` 等能力明确拒绝。 |
+| `UserService` | current user list/batch/get/update；stats；user settings；空的 linked identities/webhooks/notifications list；PAT list/create/delete | 已实现子集 | 部分已测试 | 单用户模型；JSON `ListUsers`、`ListUserSettings` 和 protobuf request field 有覆盖。完整用户生命周期、完整 stats/settings oneof、binary response 和多用户语义未完成。 |
+| `InstanceService` | `GetInstanceProfile`、`GetInstanceSetting`、`BatchGetInstanceSettings`、`UpdateInstanceSetting`、`GetInstanceStats`；`TestInstanceEmailSetting` 明确返回 `501` | 部分实现 | 部分已测试 | profile、公开 settings 和 batch settings 有 JSON contract；Storage/Tags/AI 等 setting oneof、stats binary roundtrip 和 email delivery 未完成。 |
+| `IdentityProviderService` | `ListIdentityProviders` 返回空列表 | 仅有限实现 | 已测试（空列表） | 没有 OAuth2 provider CRUD 或 linked identity 流程；其余方法明确返回 `501`。 |
+| `AIService` | 无可用业务实现；transcription 请求明确返回 `501` | 未实现 | 未验证 | protobuf codec 中存在字段映射代码不代表 AI provider 已配置或可调用。 |
+| 其他 service / 未列出 method | 无 | 未实现 | 未验证 | route 对未知 service/method 返回 unimplemented，不做泛化伪成功。 |
 
-`GetSharedMemo` 和 link metadata RPC 可以匿名调用；其余资源 RPC 仍需要 Better Auth cookie/session bearer、native Memos access JWT 或 `memos_pat_`。binary 错误体是简化的 `google.rpc.Status` protobuf；当前没有完整 gRPC trailer/metadata、压缩 frame、streaming RPC 或所有上游 service 的 schema/wire coverage。
+`GetMemoByShare` 使用 canonical `shareId`；旧 `GetSharedMemo` 保留 `shareToken` 形态，目的是兼容已有 FlareMo 调用，不应把旧 alias 当成上游额外 RPC。
 
-`GET /api/v1/sse` 提供 authenticated `text/event-stream`，由 D1 `memos_sse_events` outbox 跨 Worker isolate 保存 mutation cursor。新连接从当前最新 event 开始；带 `Last-Event-ID` 时按 `id` replay，事件帧包含 `id` 和 JSON data；当前覆盖 memo create/update/delete、comment create、reaction upsert/delete，并提供连接注释与 30 秒 heartbeat。Worker 以 D1 polling 方式读取，流断开后客户端应使用最后一个 event id 重连。
+### binary transport 的已测与未测边界
 
-这仍不是完整上游 SSEHub：当前没有 Durable Object broadcaster、retention/pruning、所有资源事件（如关系、附件、shortcut 等）或第三方 EventSource smoke。
+已测证据包括：media type detection、upstream field number 的 `CreateMemo`/attachment/user 请求解码、Connect/gRPC/gRPC-Web/text gRPC-Web framing、部分 memo/shortcut/auth response bytes，以及 binary error body 与 `grpc-status` 的 code 对齐（例如 unauthenticated 为 `16`）。测试中的部分 response 只验证了 frame 或字节内容，没有交给官方 generated client 解码。
 
-`/mcp` 当前是无状态 JSON response，不承诺 SSE、MCP session、完整 method surface 或所有第三方 MCP client 的实测兼容。旧的 `POST /api/v1/mcp` JSON-RPC 工具名继续保留，供已有 FlareMo 客户端使用。
+仍未验证或未实现的 binary 边界包括：
 
-## 仍未完成或未验证
+- `InstanceSetting` 的 Storage/Tags/AI oneof、S3/AI/transcription 配置、UserSetting 完整 oneof、notification payload、attachment `motionMedia` / `externalLink` 等字段。
+- memo create/update 的完整时间、initial attachments/relations/location、完整 update mask、pagination token，以及 comments/reactions 的完整 response schema。
+- canonical `GetMemoByShare`、Attachment create/list/update/delete、User/Instance/IdentityProvider 的全部 generated-client binary roundtrip。
+- 原生 gRPC HTTP/2、完整 metadata/trailer、gRPC-Web trailer frame、压缩、streaming RPC、取消和 deadline 语义。
+- Memos 官方 generated Connect client 的实际连接和解码。
 
-以下能力不能写成“完整兼容”：
+## SSE 与 MCP
 
-- 完整 Memos Server parity，以及完整 Connect/gRPC parity。
-- 完整 CEL filter、复杂分页/排序和附件 filter/order/page-token 语义。
-- current attachment batch delete，以及超出 memo binding subset 的 Attachment update。
-- comments、reactions、shortcuts 的完整上游 service/wire parity，以及 notifications、admin/instance surfaces。
-- Durable Object 级别的完整 SSE event hub、retention/pruning、全部资源事件和有状态 MCP session 行为；当前已有 D1 outbox、cursor replay 和有限事件集。
-- Memos 原生 JWT/refresh-token 的字节级、版本级 parity；当前只验证 FlareMo 自己的 HS256 facade claims、rotation 和 revoke 行为。
-- 未覆盖的 Memos service、完整 protobuf schema、完整 gRPC metadata/trailer、压缩/streaming frame，以及超出当前 unary 子集的原生 gRPC/gRPC-Web parity。
-- link metadata 的完整上游行为、缓存策略和 DNS pinning；当前只提供受限抓取，域名解析后的 DNS rebinding 防护仍需 Cloudflare egress/network policy。
-- 官方 Memos 客户端、MemoFlow、Dynos、Raycast、浏览器插件等第三方客户端的真实 smoke test。
-- Cloudflare Access policy 本身的配置正确性；它是部署环境外层策略，不是 FlareMo 应用协议。
+`GET /api/v1/sse` 是 authenticated `text/event-stream`。当前实现使用 D1 `memos_sse_events` outbox、5 秒 polling、`Last-Event-ID` cursor replay、连接注释和 30 秒 heartbeat；当前事件包括 memo create/update/delete、comment create、reaction upsert/delete。仓库测试覆盖 authenticated handshake、replay、visibility filtering 和 cancellation。
 
-## 兼容测试目标
+这不是上游进程内 SSEHub parity：当前没有 Durable Object broadcaster、retention/pruning、关系/附件/shortcut/share/user/notification 的完整事件集，也没有第三方 EventSource smoke。
 
-每次扩大兼容面，都要补测试：
+根 `POST /mcp` 是无状态 JSON Streamable HTTP 子集，覆盖 `initialize`、`notifications/initialized`、`tools/list`、`tools/call`；成功结果提供 text content 和 `structuredContent`，工具失败留在 MCP result 的 `isError: true` 中。旧的 `POST /api/v1/mcp` JSON-RPC 工具名继续保留。当前不承诺 SSE MCP transport、MCP session、完整 method surface 或所有第三方 MCP client。
 
-- DTO 字段映射、current 大写枚举和标准错误。
-- resource name parser、nested relation/share DTO。
-- 分页、有限排序和不支持 filter 的拒绝行为。
-- import/export roundtrip。
-- 附件上传、列表、绑定和下载。
-- share token 隔离以及匿名读取。
-- OpenAPI current/legacy wire negotiation。
-- Better Auth cookie、session bearer、PAT Bearer、PAT 撤销和公开分享边界。
-- `/mcp` initialize、tools/list、tools/call 和工具错误 envelope。
-- native JWT header/claims、refresh cookie attributes、rotation/reuse rejection、Connect JSON/protobuf/gRPC-Web transport、binary error boundary、link metadata 输入限制和 SSE handshake/cursor replay/cancel。
+## 仅静态审计与明确未实现
 
-这些仓库测试证明的是 FlareMo 自己的协议契约，不等于第三方客户端已经可用。第三方连接结果必须回写到 [memos-ecosystem.md](./memos-ecosystem.md)，未真实连接的客户端只能标记为“未测”。
+对当前参考快照 `Temp/memos` 的 proto 和 generated Web Connect client 做过静态审计，确认上游参考面包含 Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI 八类 service，并确认官方 Web 使用 binary Connect、cookie credentials 和 bearer/refresh 生命周期。这个审计只用于列出协议面，不能证明 FlareMo 或官方 Web 已互通。
+
+当前明确未实现或未验证的能力：
+
+- 完整 Memos Server parity，以及完整 REST/Connect/gRPC/protobuf schema parity。
+- 单用户以外的用户创建、删除、权限、协作和完整用户资源语义。
+- SSO/OAuth2 provider、linked identity、webhook、notification 的完整 CRUD/投递。
+- AI transcription、instance email testing/delivery、完整 instance setting provider 配置。
+- 普通 public memo 的完整匿名 ACL、完整 CEL filter、复杂排序/分页和所有上游错误细节。
+- generated client 端到端 binary roundtrip、原生 gRPC metadata/trailer/streaming/compression。
+- 完整 SSE event hub、事件保留策略和第三方 EventSource/MCP/client smoke。
+- Memos native JWT/refresh token 的版本级、字节级 parity。
+
+## 仓库测试证据
+
+当前相关测试文件包括：
+
+- `apps/worker/src/auth.test.ts`：Better Auth bootstrap、cookie session、账户变更、Origin、session/PAT 撤销和恢复边界。
+- `apps/worker/src/memos-auth-golden.test.ts`：固定测试时间和 test-only token id 下的 FlareMo access/refresh JWT 与 refresh rotation golden bytes；这证明 FlareMo 自己的确定性，不证明 Memos 上游版本级 parity。
+- `apps/worker/src/memos-compatibility.test.ts`：current/legacy REST、memo/attachment/share、PAT、native auth facade、OpenAPI、MCP contract。
+- `apps/worker/src/memos-social.test.ts`：comments、reactions、shortcuts 和错误/Origin 边界。
+- `apps/worker/src/memos-transport.test.ts`：native JWT、refresh cookie、Connect JSON、部分新增 service、protobuf/gRPC-Web framing、SSE 和 canonical share RPC。
+- `apps/worker/src/memos-protobuf.test.ts`：media type、请求 field number、部分 response serialization 和 binary error status。
+- `apps/worker/src/mcp-streamable.test.ts`：无状态 Streamable HTTP MCP 的初始化、工具列表、调用错误和 legacy route。
+- `apps/worker/src/memos-link-metadata.test.ts`、`packages/memos/src/adapter.test.ts`、`packages/memos/src/current-adapter.test.ts`：link metadata 输入限制、resource name 和 DTO 映射。
+- `apps/telegram-bot/src/index.test.ts`：项目自带 Telegram Worker 示例的 PAT、可选 Access headers 和 webhook fail-closed contract；不是对真实 Telegram 或生产 FlareMo 的 smoke。
+
+这些测试证明的是 FlareMo 自己的协议契约和安全边界，不等于第三方客户端已经可用。真实连接结果、客户端 commit、FlareMo commit、请求路径、认证方式、失败请求和日期必须记录在 [memos-ecosystem.md](./memos-ecosystem.md) 后，才能把某个生态工具标记为真实可用。

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -1,117 +1,129 @@
 # Memos 生态兼容记录
 
-FlareMo 的目标是复用 Memos 生态，但兼容必须被验证。这个文档记录第三方客户端、脚本和工具对 FlareMo 的真实可用性，不把“接口长得像”当成“已经兼容”。当前工作树已经提供 Better Auth-backed identity、Memos-style HS256 access JWT/rotating `memos_refresh` cookie、current camelCase REST 的 memo/social 子集、PAT 资源、Connect JSON/protobuf/gRPC-Web unary 子集、D1 outbox/cursor replay SSE 和根 `/mcp` 无状态 Streamable HTTP MCP 子集；完整 Memos Server parity 和第三方客户端实测仍未完成。
-
-生产实例迁移期建议放在 Cloudflare Access 后面。第三方工具访问私有 FlareMo 时，必须满足应用层认证：
-
-```text
-Authorization: Bearer memos_pat_...
-```
-
-如果外层仍启用 Cloudflare Access，还必须额外发送：
-
-```text
-CF-Access-Client-Id
-CF-Access-Client-Secret
-```
-
-Access Service Token 只通过外层 Access policy，不会自动变成 FlareMo 用户 session；不能发送应用层 `Authorization` 的工具无法访问私有 API，除非使用额外代理层。公开分享仍只依赖 share token、过期和 memo 状态校验。
-
-## Origin 安全契约
-
-浏览器 cookie session 的 `POST`、`PATCH`、`DELETE` 等状态变更必须携带 `Origin`，并精确命中 `FLAREMO_PUBLIC_URL` 或 `FLAREMO_TRUSTED_ORIGINS`；缺失或不匹配返回 `403`。桌面脚本、MCP 和其他非浏览器客户端使用 PAT 时可以不发送 Origin；若 PAT 请求主动携带 Origin，也必须命中同一 allowlist，否则返回 `403`。不使用 wildcard、`Referer` 或 Access headers 替代 Origin。
-
-这与 [Memos 0.30 MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 模型方向一致，只说明安全边界相似。FlareMo 的 current wire 是当前已实现的兼容子集；它不等于完整 Memos 协议或完整服务端 parity。
+FlareMo 的目标是复用 Memos 生态，但兼容必须被验证。本文把“代码已接入”“仓库 contract 已测试”“源码静态审计”和“真实客户端 smoke”分开记录，不把“接口长得像”当成“已经兼容”。截至本次快照，FlareMo 已有 Better Auth-backed identity、Memos 风格 HS256 access JWT/轮换 `memos_refresh` cookie、current camelCase REST 的 memo/social 子集、PAT、Connect/protobuf/gRPC-Web unary 子集、D1 outbox/cursor replay SSE 和根 `/mcp` 无状态 Streamable HTTP MCP 子集；完整 Memos Server parity 和第三方客户端实测仍未完成。
 
 ## 状态定义
 
 | 状态 | 含义 |
 | --- | --- |
-| 可用 | 已连接 FlareMo，并用 cookie session 或 `memos_pat_` PAT 完成核心读写路径；如生产启用 Access，还验证了两层认证。 |
-| 部分可用 | 核心路径有一部分可用，或只验证了 Access 外层而没有验证应用层 PAT。 |
-| 不支持 | 当前客户端能力或认证模型与 FlareMo 不匹配。 |
-| 未测 | 只完成资料收集，还没有实际连接 FlareMo。 |
+| 已实现 | FlareMo 当前工作树有对应 route/domain handler。 |
+| 已测试（仓库契约） | FlareMo 自己的测试以 Miniflare/Worker 或纯 codec 断言了行为；不是外部客户端已连接。 |
+| 仅静态审计 | 阅读了上游 proto/generated client 或第三方客户端源码，推断潜在兼容面；没有真实请求 FlareMo。 |
+| 未测 | 没有足够的源码结论或真实连接记录，不能判断可用。 |
+| 未实现 | FlareMo 没有 handler，或明确返回 `501`。 |
 
-## 已验证工具和脚本
+本文中的“可用”只用于 FlareMo 自己的 contract surface。第三方工具在没有实际请求记录前，一律不能标记为“可用”。
 
-这些条目已经由仓库自动化测试覆盖，可以作为脚本和工具接入 FlareMo 的当前事实基线。
+## 应用层认证和 Access 边界
 
-| 工具 / 路径 | 类型 | 测试版本 | 请求路径 | 应用层认证 | 当前状态 | 证据 |
-| --- | --- | --- | --- | --- | --- | --- |
-| curl / HTTP script | 通用脚本 | 当前工作树 | `/api/v1/memos`、`/api/v1/attachments`、`/api/v1/export`、`/api/v1/import` | `memos_pat_`；Access 开启时再加 Access headers | 可用（Worker contract） | `apps/worker/src/auth.test.ts` 和 `apps/worker/src/api.test.ts` 覆盖 cookie、PAT、memo CRUD、分页、搜索、附件、分享、revisions、export/import。 |
-| current REST script | 通用脚本 | 当前工作树 | `/api/v1/auth/*`、`/api/v1/memos`、`/api/v1/memos/{memo}/comments`、`reactions`、`/api/v1/users/*/shortcuts`、`/api/v1/attachments`、`/api/v1/shares/*` | Better Auth cookie/session bearer、native Memos access JWT 或 `memos_pat_`；Access 开启时再加 Access headers | 可用（FlareMo contract） | `apps/worker/src/memos-compatibility.test.ts`、`memos-social.test.ts` 覆盖 current DTO、enum、updateMask、PAT、native JWT claims/rotation、social 资源、标准错误和匿名 share read；不是第三方客户端 smoke。 |
-| OpenAPI consumers | API schema 工具 | 当前工作树 | `/openapi.json` | OpenAPI 描述可公开读取；私有 API 请求需 PAT | 可用（schema surface） | `apps/worker/src/memos-compatibility.test.ts` 断言默认 current OpenAPI 和显式 legacy OpenAPI。 |
-| FlareMo legacy MCP endpoint | MCP 客户端 | 当前工作树 | `/api/v1/mcp` | `memos_pat_`；Access 开启时再加 Access headers | 部分可用（旧式 JSON-RPC） | `apps/worker/src/auth.test.ts` 覆盖 PAT `tools/list`；保留给已有 FlareMo 客户端。 |
-| FlareMo current MCP endpoint | MCP 客户端 | 当前工作树 | `/mcp` | Better Auth cookie/session bearer、native Memos access JWT 或 `memos_pat_`；Access 开启时再加 Access headers | 可用（stateless protocol subset） | `apps/worker/src/mcp-streamable.test.ts` 和 `apps/worker/src/memos-compatibility.test.ts` 覆盖 `initialize`、`notifications/initialized`、`tools/list`、memo/social/attachment tool calls 和工具错误 envelope；未验证所有第三方 MCP client。 |
-| Connect / protobuf client | HTTP unary client | 当前工作树 | `/memos.api.v1/{Service}/{Method}` | Cookie session、native Memos access JWT 或 `memos_pat_`；`GetSharedMemo` 和 link metadata 可匿名 | 部分可用（当前 service/transport subset） | 支持 `application/json`、`application/proto`、`application/grpc+proto`、`application/grpc-web+proto`、`application/grpc-web-text+proto`；覆盖 Memo/Auth/Shortcut 的明确 unary 方法集、comments/reactions/shares 和 link metadata；完整 gRPC metadata/trailer、压缩/streaming、其他 service 和第三方 Connect client 仍未测。 |
-| Memos SSE consumer | SSE client | 当前工作树 | `/api/v1/sse` | Cookie session、native Memos access JWT 或 `memos_pat_` | 部分可用（D1 outbox/replay subset） | Worker contract 覆盖 authenticated stream、connected/heartbeat、`id`/`Last-Event-ID` replay、private/public visibility filter 和 cancellation；当前使用 D1 polling，事件集有限，第三方消费端未测。 |
-| FlareMo Telegram Worker example | Telegram Bot | 当前工作树 | Telegram webhook -> `/api/v1/memos` | 必须使用 PAT；Access headers 仅在生产仍启用 Access 时成对追加 | contract-tested subset | Worker tests cover PAT-only native auth, optional Access headers, fail-closed secret configuration, and webhook validation；不等于真实 Telegram/生产 smoke。 |
-| Public share reader | 浏览器 / curl | 当前工作树 | `/share/*`、`/api/public/shares/*` | 不需要 session/PAT；Access 开启时需 bypass | 可用（share contract） | Worker 测试覆盖 token 隔离、撤销和附件读取。 |
+应用层使用 Better Auth；Cloudflare Access 是可选的外层 policy，不是 FlareMo 用户身份。
 
-## 第三方客户端待测矩阵
+```text
+浏览器：Better Auth username/password -> HttpOnly cookie session
+脚本 / Memos-compatible client / MCP：Authorization: Bearer memos_pat_...
+可选外层：Cloudflare Access Service Token -> 仍需上面的 FlareMo 应用凭据
+```
 
-这些条目还没有实际连接 FlareMo，不能写成支持。
+如果生产实例仍放在 Cloudflare Access 后面，机器客户端需要同时满足 Access policy 和 FlareMo 应用层认证：
 
-| 工具 | 类型 | 仓库 | 待测版本 | 是否支持自定义 header | 是否可发送 PAT | 当前状态 | 需要验证的请求路径 / 下一步 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| memos-desktop | 桌面客户端 | https://github.com/xudaolong/memos-desktop | 待测 | 未确认 | 未确认 | 未测 | 验证 API base URL、PAT 配置/注入、memo CRUD；若 Access 开启，再验证双层 headers。 |
-| memos_wmp | 微信小程序 | https://github.com/Rabithua/memos_wmp | 待测 | 未确认 | 未确认 | 未测 | 验证网络层是否允许添加 `Authorization` PAT 和可选 Access headers。 |
-| memoflow | 移动端客户端 | https://github.com/hzc073/memoflow | 待测 | 未确认 | 未确认 | 未测 | 验证登录模型、PAT/API base URL、memo CRUD 和附件路径。 |
-| telegramMemoBot | 第三方 Telegram bot | https://github.com/qazxcdswe123/telegramMemoBot | 待测 | 未确认 | 未确认 | 未测 | 验证是否支持 FlareMo `memos_pat_`，不能只验证 Cloudflare Access headers。 |
-| Dynos | 移动端客户端 | https://github.com/HonKLam/Dynos | 待测 | 未确认 | 未确认 | 未测 | 验证离线同步和 FlareMo API 子集的重叠范围。 |
-| mcp-server-memos | MCP server | https://github.com/LeslieLeung/mcp-server-memos | 待测 | 未确认 | 未确认 | 未测 | FlareMo 自带 MCP endpoint；仍可验证外部 MCP server 是否能作为兼容客户端使用。 |
-| memos-raycast | Raycast extension | https://github.com/JakeLaoyu/memos-raycast | 待测 | 未确认 | 未确认 | 未测 | 验证 Raycast preferences 是否能配置 PAT；若 Access 开启，再验证 Access headers。 |
-| memos-extensions | 浏览器插件 | https://github.com/yozi9257/memos-extensions | 待测 | 未确认 | 未确认 | 未测 | 验证扩展权限、header 注入和创建 memo 路径。 |
-| notum | 离线优先笔记 | https://github.com/nikita-popov/notum | 待测 | 未确认 | 未确认 | 未测 | 验证同步协议是否只依赖 FlareMo 已支持的 `/api/v1` 子集。 |
+```text
+CF-Access-Client-Id: ...
+CF-Access-Client-Secret: ...
+Authorization: Bearer memos_pat_...
+```
 
-## 验证标准
+Access Service Token 不会自动变成 FlareMo 用户 session；不能发送应用层 `Authorization` 的工具不能访问私有 API，除非增加明确的代理层。公开 share 仍只依赖 FlareMo 的 share token、过期时间和 memo 状态校验。
 
-一个客户端标记为“可用”前，至少要完成：
+浏览器 cookie session 的 `POST`、`PATCH`、`DELETE` 等状态变更必须携带 `Origin`，并精确命中 `FLAREMO_PUBLIC_URL` 或 `FLAREMO_TRUSTED_ORIGINS`；缺失或不匹配返回 `403`。PAT 的桌面脚本、MCP 请求可以没有 Origin；若主动携带 Origin，也必须命中同一 allowlist。不能用 wildcard、`Referer` 或 Access headers 替代 Origin。
 
-- 配置 FlareMo base URL。
-- 用 cookie session 或 `memos_pat_` PAT 访问应用层；若通过受保护生产实例，再加 Cloudflare Access Service Token。
-- 验证 cookie session 的状态变更带 trusted Origin；缺失或不可信 Origin 返回 `403`。
-- 验证无 Origin 的 PAT 桌面/脚本/MCP 请求可以工作；带未授权 Origin 的 PAT 请求返回 `403`。
-- 不要把只通过 Cloudflare Access headers 当成应用层兼容证据。
-- 记录客户端名称、版本、测试日期、FlareMo version 或 commit。
-- 创建 memo。
-- 列出 memo。
-- 编辑 memo。
-- 删除或归档 memo。
-- 如果客户端支持附件，验证上传和下载。
-- 如果客户端支持分享，验证创建分享和公开读取。
-- 记录部署方式、已知缺口和是否需要代理层。
+这与 [Memos MCP 文档](https://usememos.com/docs/integrations/mcp) 的 browser-origin 安全方向相似，但只说明安全边界相似，不说明 FlareMo 已达到完整 Memos 协议或 server parity。
 
-## 记录模板
+## FlareMo 自己的已实现 / 已测试 surface
+
+| 工具或路径 | 类型 | FlareMo 状态 | 仓库测试证据 | 外部客户端结论 |
+| --- | --- | --- | --- | --- |
+| current REST script / curl | 通用 HTTP 脚本 | 已实现 | `memos-compatibility.test.ts`、`memos-social.test.ts`、`auth.test.ts` 覆盖 current DTO、memo/attachment/share、social、PAT、native auth、Origin 和标准错误；`memos-auth-golden.test.ts` 固定验证 FlareMo 自己的 JWT/refresh bytes。 | 已测试的是 FlareMo contract；没有独立客户端或线上实例 smoke，也不证明上游 token parity。 |
+| legacy REST script / curl | 兼容迁移脚本 | 已实现 | current/legacy OpenAPI 和 wire negotiation 有测试。 | 未对历史第三方脚本逐一重放。 |
+| generic Connect JSON client | HTTP unary client | 已实现子集 | `memos-transport.test.ts` 覆盖 Memo/Shortcut 及部分 Auth、Attachment/User/Instance/IdentityProvider JSON RPC。 | 尚未使用官方 generated Connect client 连接。 |
+| generic protobuf / gRPC-style client | HTTP binary client | 已实现子集 | `memos-protobuf.test.ts`、`memos-transport.test.ts` 覆盖 media type、部分 upstream field number、unary framing、gRPC-Web/text 和 error status。 | response 多数只做 frame/字节断言；generated schema roundtrip 未测。 |
+| FlareMo current MCP endpoint | MCP client | 已实现子集 | `mcp-streamable.test.ts`、`memos-compatibility.test.ts` 覆盖 `initialize`、`notifications/initialized`、`tools/list`、`tools/call` 和工具错误 envelope。 | 根 `/mcp` 是无状态 JSON 子集；未测所有第三方 MCP client。 |
+| FlareMo legacy MCP endpoint | 旧 MCP JSON-RPC | 已实现子集 | `mcp-streamable.test.ts` 和 `auth.test.ts` 覆盖旧工具名/PAT 边界。 | 不能从旧 endpoint 推断完整 Memos MCP 兼容。 |
+| FlareMo SSE consumer | EventSource / SSE client | 已实现子集 | `memos-transport.test.ts` 覆盖 authenticated stream、connected/heartbeat、`Last-Event-ID` replay、visibility 和 cancellation。 | D1 polling 实现，未做第三方 EventSource smoke。 |
+| FlareMo Telegram Worker example | Telegram webhook adapter | 已实现示例 | `apps/telegram-bot/src/index.test.ts` 覆盖 PAT-only、可选 Access headers、secret 校验和 fail-closed。 | 不是真实 Telegram API 或生产 FlareMo smoke。 |
+| public share reader | 浏览器 / curl | 已实现 | `memos-compatibility.test.ts`、`api.test.ts` 覆盖 share token 隔离、撤销、过期/状态和附件读取。 | 仍需在实际部署域名上验证 Access bypass 规则；不绕过 FlareMo share 校验。 |
+
+## 官方 Memos Web：仅静态审计
+
+当前本地参考快照 `Temp/memos` 的 Web 代码和 generated proto client 已被用于协议面静态审计，不能作为真实互通证据。审计得到的关键事实是：
+
+- 官方 Web 使用 8 类 generated Connect client：Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI。
+- `connect.ts` 选择 binary format，并使用 `credentials: include`；认证生命周期包含 bearer access token、refresh cookie、Unauthenticated 后 refresh/retry。
+- 因此仅有 Connect JSON 或“HTTP 返回 200”不够；必须把 Attachment/User/Instance 等 response 交给同一 generated client 解码，并真实验证 refresh、signout、memo CRUD 和附件路径。
+
+当前结论：`仅静态审计`，没有官方 Web 指向 FlareMo 的真实请求、客户端版本记录或 smoke 结果。FlareMo 的手写 protobuf codec 仍有字段和 transport 边界，不能宣称官方 Web 已兼容。
+
+## 第三方客户端矩阵
+
+下面的“仅静态审计”表示从客户端源码、README 或依赖关系得到的候选结论，不代表已安装、已配置或已连接 FlareMo。
+
+| 工具 | 类型 | 仓库 | 当前证据级别 | 静态审计结论 | 真实状态 / 下一步 |
+| --- | --- | --- | --- | --- | --- |
+| `memos-extensions` | 浏览器插件 | https://github.com/yozi9257/memos-extensions | 仅静态审计 | 看起来走 modern REST，是最高优先级的 PAT/header 注入候选。 | 未测；先验证扩展权限、`Authorization` 注入、创建/列表 memo。 |
+| `memoflow` | Flutter / 移动端 | https://github.com/hzc073/memoflow | 仅静态审计 | 看起来依赖 modern REST/PAT，适合验证移动端基本 CRUD。 | 未测；需要 Flutter 环境和实际 base URL/PAT。 |
+| `notum` | 离线优先笔记 | https://github.com/nikita-popov/notum | 仅静态审计 | 看起来使用 modern REST/PAT；同步协议和附件行为仍需实连。 | 未测；先验证同步、冲突和附件路径。 |
+| `Dynos` | 移动端客户端 | https://github.com/HonKLam/Dynos | 仅静态审计 | 静态上存在 updateMask、connection check 等与 FlareMo 子集可能不一致的点。 | 未测；先记录第一条失败请求，不把静态 mismatch 直接写成“不支持”。 |
+| `memos_wmp` | 微信小程序 | https://github.com/Rabithua/memos_wmp | 仅静态审计 | 是否能注入 `Authorization` PAT 和自定义 Access headers 尚未证明。 | 未测；需要微信网络层和 header 能力验证。 |
+| `telegramMemoBot` | 第三方 Telegram bot | https://github.com/qazxcdswe123/telegramMemoBot | 仅静态审计 | 不能只验证 Cloudflare Access；必须确认它能使用 `memos_pat_` 或增加明确代理。 | 未测；区分该项目和 FlareMo 自带 Telegram Worker example。 |
+| `memos-raycast` | Raycast extension | https://github.com/JakeLaoyu/memos-raycast | 仅静态审计 | preferences、API base URL 和 PAT/header 注入需要实际检查。 | 未测；先验证创建/列表/删除 memo。 |
+| `mcp-server-memos` | 外部 MCP server | https://github.com/LeslieLeung/mcp-server-memos | 仅静态审计 | 它是另一个 adapter/server，不能从 FlareMo 自带 `/mcp` 推断互相兼容。 | 未测；验证其作为客户端连接 FlareMo 的 endpoint、认证和工具映射。 |
+| `memos-desktop` | 桌面客户端 | https://github.com/xudaolong/memos-desktop | 仅静态审计 | 默认启动自己的内置 Memos 的路径不能代表远程 FlareMo 连接。 | 未测；需要显式 API base URL、PAT 和远程 CRUD 配置。 |
+
+目前没有第三方条目可以标记为“可用”。“modern REST/PAT 候选”只表示值得优先 smoke，不是兼容承诺。
+
+## 服务器侧明确未实现或不应误判为兼容
+
+- 不是完整 Memos Server parity；不能把 current REST、Connect JSON、手写 protobuf 或 `/mcp` 子集合并成“完整兼容”。
+- `AIService/Transcribe`、Instance email test、OAuth2/IdentityProvider CRUD、User create/delete、linked identity CRUD、webhook CRUD、notification update/delete 当前明确未实现或返回 `501`。
+- User/Instance/Attachment 的部分方法虽然已经接入 route，但没有完整 generated-client binary roundtrip；不能把“JSON handler 存在”写成 binary 客户端可用。
+- public memo read 已接入 current REST 和 Connect 的明确 viewer policy：匿名只读 `PUBLIC + NORMAL`，private/protected/archived/trashed/deleted 不可见；comments、relations、attachments、reactions 会先检查 parent/read visibility。公开 share 仍是独立 token 入口，不等于普通 memo public ACL。
+- 没有完整 CEL、复杂分页/排序、全部 protobuf 字段、metadata/trailer、压缩、streaming、gRPC-Web trailer frame 或原生 HTTP/2 gRPC parity。
+- SSE 是 D1 outbox/polling/replay，不是上游 SSEHub；没有完整事件集、retention/pruning 和第三方 EventSource 实测。
+- 根 `/mcp` 没有有状态 MCP session，不承诺 SSE transport 或所有 MCP client 的 method surface。
+
+## 真实客户端标记为“可用”的验收标准
+
+在没有下列证据前，状态保持“未测”或“仅静态审计”：
+
+- 客户端仓库、commit/tag、测试日期和 FlareMo commit。
+- 实际配置 FlareMo base URL，并说明是 local、unprotected test 还是 protected production。
+- 用 cookie session 或 `memos_pat_` 完成应用层认证；生产启用 Access 时同时验证 Access Service Token。
+- 验证 cookie 状态变更的 trusted Origin；验证 PAT 无 Origin 可以工作，未授权 Origin 返回 `403`。
+- 至少完成 create、list、edit、archive/delete memo；客户端支持时再完成 attachment 和 share。
+- 记录实际请求 endpoint、HTTP/media type、认证方式、第一条失败请求、响应和已知缺口。
+
+## 实测记录模板
 
 ```markdown
 ### <client name>
 
-- 客户端版本：
+- 客户端版本 / commit：
 - FlareMo version / commit：
+- 测试日期：
 - 部署方式：local / protected production / unprotected test
-- 应用层 PAT：required / not required / unsupported
+- 应用层认证：cookie / memos_pat_ / unsupported
 - Access Service Token：required / not required / unsupported
-- 请求路径：
-- 结果：可用 / 部分可用 / 不支持
+- 实际请求路径和 media type：
+- 结果：已测试可用 / 部分可用 / 不支持 / 未测
 - 已验证：
+  - sign in / refresh / sign out:
   - create memo:
   - list memo:
   - edit memo:
   - archive/delete memo:
   - attachment:
   - share:
+- 第一条失败请求：
 - 缺口：
 ```
 
-## 当前自动化覆盖
-
-仓库里的 Memos 兼容测试覆盖 FlareMo 自己的 API contract：
-
-- `packages/memos/src/adapter.test.ts`
-- `apps/worker/src/memos-compatibility.test.ts`
-- `apps/worker/src/api.test.ts`
-
-这些测试证明 FlareMo 自己的 current/legacy 公开子集、Better Auth 认证边界、Connect/protobuf unary transport、有限 SSE cursor replay 和无状态 `/mcp` 协议切片，但不能替代真实 Memos 客户端兼容测试，也不能证明完整 Memos Server parity。真实客户端结果必须回写到本文；在没有实际连接、版本和日期证据前，第三方客户端保持“未测”。
-
-当前已知的 transport 兼容边界：binary error body 只提供简化 `google.rpc.Status`，没有完整 gRPC trailer/metadata；只接受单个未压缩 unary frame；没有 AttachmentService、UserService、InstanceService、AIService、IdentityProviderService 等完整上游 service；link metadata 只抓取受限 Open Graph surface，并受 SSRF/redirect/HTML 大小限制。生产环境还应控制 Worker 外连策略，以补足域名解析后的 DNS rebinding 风险。
+真实客户端结果必须写回本文；在没有版本、日期和请求证据前，不能把静态审计结论升级为“生态兼容”。

--- a/packages/contracts/src/openapi-current.ts
+++ b/packages/contracts/src/openapi-current.ts
@@ -30,6 +30,7 @@ const response = (description: string, schema: JsonSchema) => ({
 const emptyResponse = (description: string) => ({ description });
 
 const bearerSecurity = [{ bearerAuth: [] }, { cookieAuth: [] }];
+const optionalReadSecurity = [...bearerSecurity, {}];
 
 const memoName = {
   name: "memo",
@@ -359,6 +360,7 @@ export function createCurrentOpenApiDocument() {
           operationId: "listMemosCurrent",
           summary: "List memos",
           tags: ["Memos"],
+          security: optionalReadSecurity,
           parameters: [
             {
               name: "pageSize",
@@ -420,6 +422,7 @@ export function createCurrentOpenApiDocument() {
           operationId: "getMemoCurrent",
           summary: "Get a memo",
           tags: ["Memos"],
+          security: optionalReadSecurity,
           parameters: [memoName],
           responses: {
             "200": response("Memo.", { $ref: "#/components/schemas/Memo" }),
@@ -474,6 +477,7 @@ export function createCurrentOpenApiDocument() {
           operationId: "listMemoAttachmentsCurrent",
           summary: "List memo attachments",
           tags: ["Attachments"],
+          security: optionalReadSecurity,
           parameters: [memoName],
           responses: {
             "200": response("Attachments.", {
@@ -514,6 +518,7 @@ export function createCurrentOpenApiDocument() {
           operationId: "listMemoRelationsCurrent",
           summary: "List memo relations",
           tags: ["Relations"],
+          security: optionalReadSecurity,
           parameters: [memoName],
           responses: {
             "200": response("Relations.", {
@@ -554,6 +559,7 @@ export function createCurrentOpenApiDocument() {
           operationId: "listMemoCommentsCurrent",
           summary: "List comments represented as child memos",
           tags: ["Social"],
+          security: optionalReadSecurity,
           parameters: [
             memoName,
             {
@@ -611,6 +617,7 @@ export function createCurrentOpenApiDocument() {
           operationId: "listMemoReactionsCurrent",
           summary: "List reactions on a memo",
           tags: ["Social"],
+          security: optionalReadSecurity,
           parameters: [
             memoName,
             {
@@ -1078,10 +1085,18 @@ export function createCurrentOpenApiDocument() {
         post: connectOperation("connectCreateMemo", "Create a memo"),
       },
       "/memos.api.v1.MemoService/ListMemos": {
-        post: connectOperation("connectListMemos", "List memos"),
+        post: connectOperation(
+          "connectListMemos",
+          "List memos",
+          optionalReadSecurity,
+        ),
       },
       "/memos.api.v1.MemoService/GetMemo": {
-        post: connectOperation("connectGetMemo", "Get a memo"),
+        post: connectOperation(
+          "connectGetMemo",
+          "Get a memo",
+          optionalReadSecurity,
+        ),
       },
       "/memos.api.v1.MemoService/UpdateMemo": {
         post: connectOperation("connectUpdateMemo", "Update a memo"),
@@ -1099,6 +1114,7 @@ export function createCurrentOpenApiDocument() {
         post: connectOperation(
           "connectListMemoAttachments",
           "List memo attachments",
+          optionalReadSecurity,
         ),
       },
       "/memos.api.v1.MemoService/SetMemoRelations": {
@@ -1111,6 +1127,7 @@ export function createCurrentOpenApiDocument() {
         post: connectOperation(
           "connectListMemoRelations",
           "List memo relations",
+          optionalReadSecurity,
         ),
       },
       "/memos.api.v1.MemoService/CreateMemoComment": {
@@ -1120,12 +1137,17 @@ export function createCurrentOpenApiDocument() {
         ),
       },
       "/memos.api.v1.MemoService/ListMemoComments": {
-        post: connectOperation("connectListMemoComments", "List memo comments"),
+        post: connectOperation(
+          "connectListMemoComments",
+          "List memo comments",
+          optionalReadSecurity,
+        ),
       },
       "/memos.api.v1.MemoService/ListMemoReactions": {
         post: connectOperation(
           "connectListMemoReactions",
           "List memo reactions",
+          optionalReadSecurity,
         ),
       },
       "/memos.api.v1.MemoService/UpsertMemoReaction": {
@@ -1151,6 +1173,13 @@ export function createCurrentOpenApiDocument() {
       },
       "/memos.api.v1.MemoService/GetSharedMemo": {
         post: connectOperation("connectGetSharedMemo", "Get a shared memo", []),
+      },
+      "/memos.api.v1.MemoService/GetMemoByShare": {
+        post: connectOperation(
+          "connectGetMemoByShare",
+          "Get a memo by share token",
+          [],
+        ),
       },
       "/memos.api.v1.MemoService/GetLinkMetadata": {
         post: connectOperation(
@@ -1192,6 +1221,169 @@ export function createCurrentOpenApiDocument() {
       },
       "/memos.api.v1.ShortcutService/DeleteShortcut": {
         post: connectOperation("connectDeleteShortcut", "Delete a shortcut"),
+      },
+      "/memos.api.v1.AttachmentService/CreateAttachment": {
+        post: connectOperation(
+          "connectCreateAttachment",
+          "Create an attachment",
+        ),
+      },
+      "/memos.api.v1.AttachmentService/ListAttachments": {
+        post: connectOperation("connectListAttachments", "List attachments"),
+      },
+      "/memos.api.v1.AttachmentService/GetAttachment": {
+        post: connectOperation("connectGetAttachment", "Get an attachment"),
+      },
+      "/memos.api.v1.AttachmentService/UpdateAttachment": {
+        post: connectOperation(
+          "connectUpdateAttachment",
+          "Update an attachment",
+        ),
+      },
+      "/memos.api.v1.AttachmentService/DeleteAttachment": {
+        post: connectOperation(
+          "connectDeleteAttachment",
+          "Delete an attachment",
+        ),
+      },
+      "/memos.api.v1.AttachmentService/BatchDeleteAttachments": {
+        post: connectOperation(
+          "connectBatchDeleteAttachments",
+          "Delete multiple attachments",
+        ),
+      },
+      "/memos.api.v1.UserService/ListUsers": {
+        post: connectOperation("connectListUsers", "List users"),
+      },
+      "/memos.api.v1.UserService/BatchGetUsers": {
+        post: connectOperation("connectBatchGetUsers", "Get multiple users"),
+      },
+      "/memos.api.v1.UserService/GetUser": {
+        post: connectOperation("connectGetUser", "Get a user"),
+      },
+      "/memos.api.v1.UserService/UpdateUser": {
+        post: connectOperation("connectUpdateUser", "Update a user"),
+      },
+      "/memos.api.v1.UserService/GetUserStats": {
+        post: connectOperation("connectGetUserStats", "Get user statistics"),
+      },
+      "/memos.api.v1.UserService/ListAllUserStats": {
+        post: connectOperation(
+          "connectListAllUserStats",
+          "List user statistics",
+        ),
+      },
+      "/memos.api.v1.UserService/GetUserSetting": {
+        post: connectOperation("connectGetUserSetting", "Get a user setting"),
+      },
+      "/memos.api.v1.UserService/ListUserSettings": {
+        post: connectOperation("connectListUserSettings", "List user settings"),
+      },
+      "/memos.api.v1.UserService/UpdateUserSetting": {
+        post: connectOperation(
+          "connectUpdateUserSetting",
+          "Update a user setting",
+        ),
+      },
+      "/memos.api.v1.UserService/ListLinkedIdentities": {
+        post: connectOperation(
+          "connectListLinkedIdentities",
+          "List linked identities",
+        ),
+      },
+      "/memos.api.v1.UserService/GetLinkedIdentity": {
+        post: connectOperation(
+          "connectGetLinkedIdentity",
+          "Get a linked identity",
+        ),
+      },
+      "/memos.api.v1.UserService/CreateLinkedIdentity": {
+        post: connectOperation(
+          "connectCreateLinkedIdentity",
+          "Create a linked identity",
+        ),
+      },
+      "/memos.api.v1.UserService/DeleteLinkedIdentity": {
+        post: connectOperation(
+          "connectDeleteLinkedIdentity",
+          "Delete a linked identity",
+        ),
+      },
+      "/memos.api.v1.UserService/ListPersonalAccessTokens": {
+        post: connectOperation(
+          "connectListPersonalAccessTokens",
+          "List personal access tokens",
+        ),
+      },
+      "/memos.api.v1.UserService/CreatePersonalAccessToken": {
+        post: connectOperation(
+          "connectCreatePersonalAccessToken",
+          "Create a personal access token",
+        ),
+      },
+      "/memos.api.v1.UserService/DeletePersonalAccessToken": {
+        post: connectOperation(
+          "connectDeletePersonalAccessToken",
+          "Delete a personal access token",
+        ),
+      },
+      "/memos.api.v1.UserService/ListUserWebhooks": {
+        post: connectOperation("connectListUserWebhooks", "List user webhooks"),
+      },
+      "/memos.api.v1.UserService/ListUserNotifications": {
+        post: connectOperation(
+          "connectListUserNotifications",
+          "List user notifications",
+        ),
+      },
+      "/memos.api.v1.InstanceService/GetInstanceProfile": {
+        post: connectOperation(
+          "connectGetInstanceProfile",
+          "Get the instance profile",
+          optionalReadSecurity,
+        ),
+      },
+      "/memos.api.v1.InstanceService/GetInstanceSetting": {
+        post: connectOperation(
+          "connectGetInstanceSetting",
+          "Get an instance setting",
+          optionalReadSecurity,
+        ),
+      },
+      "/memos.api.v1.InstanceService/BatchGetInstanceSettings": {
+        post: connectOperation(
+          "connectBatchGetInstanceSettings",
+          "Get multiple instance settings",
+          optionalReadSecurity,
+        ),
+      },
+      "/memos.api.v1.InstanceService/UpdateInstanceSetting": {
+        post: connectOperation(
+          "connectUpdateInstanceSetting",
+          "Update an instance setting",
+        ),
+      },
+      "/memos.api.v1.InstanceService/GetInstanceStats": {
+        post: connectOperation(
+          "connectGetInstanceStats",
+          "Get instance statistics",
+        ),
+      },
+      "/memos.api.v1.InstanceService/TestInstanceEmailSetting": {
+        post: connectOperation(
+          "connectTestInstanceEmailSetting",
+          "Test instance email settings",
+        ),
+      },
+      "/memos.api.v1.IdentityProviderService/ListIdentityProviders": {
+        post: connectOperation(
+          "connectListIdentityProviders",
+          "List identity providers",
+          optionalReadSecurity,
+        ),
+      },
+      "/memos.api.v1.AIService/Transcribe": {
+        post: connectOperation("connectTranscribe", "Transcribe audio"),
       },
       "/mcp": {
         post: secured({

--- a/packages/domain/src/attachments.ts
+++ b/packages/domain/src/attachments.ts
@@ -3,7 +3,7 @@ import { attachments } from "@flaremo/db";
 import { and, desc, eq, inArray, isNull, lt, or } from "drizzle-orm";
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
 import { createResourceId, parseResourceName } from "./ids";
-import { getMemoById } from "./memos";
+import { getMemoById, getMemoByIdForViewer } from "./memos";
 
 export type CreateAttachmentMetadataInput = {
   memoId?: string | null;
@@ -106,6 +106,28 @@ export async function listMemoAttachments(
   return listAttachments(db, user, { memoId: normalizedMemoId, pageSize: 100 });
 }
 
+export async function listMemoAttachmentsForViewer(
+  db: FlareMoDb,
+  user: UserRow | null,
+  memoId: string,
+) {
+  const normalizedMemoId = parseResourceName(memoId, "memos");
+  await getMemoByIdForViewer(db, user, normalizedMemoId);
+  if (user) return listMemoAttachments(db, user, normalizedMemoId);
+  return db
+    .select()
+    .from(attachments)
+    .where(
+      and(
+        eq(attachments.memoId, normalizedMemoId),
+        isNull(attachments.deletedAt),
+        eq(attachments.state, "ready"),
+      ),
+    )
+    .orderBy(desc(attachments.createdAt))
+    .limit(100);
+}
+
 export async function listAllMemoAttachments(
   db: FlareMoDb,
   user: UserRow,
@@ -163,6 +185,27 @@ export async function listAttachmentsForMemos(
     .where(
       and(
         eq(attachments.userId, user.id),
+        inArray(attachments.memoId, memoIds),
+        isNull(attachments.deletedAt),
+        eq(attachments.state, "ready"),
+      ),
+    )
+    .orderBy(desc(attachments.createdAt));
+}
+
+export async function listAttachmentsForMemosForViewer(
+  db: FlareMoDb,
+  user: UserRow | null,
+  memoIds: string[],
+) {
+  if (user) return listAttachmentsForMemos(db, user, memoIds);
+  if (memoIds.length === 0) return [];
+
+  return db
+    .select()
+    .from(attachments)
+    .where(
+      and(
         inArray(attachments.memoId, memoIds),
         isNull(attachments.deletedAt),
         eq(attachments.state, "ready"),
@@ -284,6 +327,24 @@ export async function bindMemoAttachments(
   }
 
   return listMemoAttachments(db, user, normalizedMemoId);
+}
+
+export async function updateAttachmentMemo(
+  db: FlareMoDb,
+  user: UserRow,
+  id: string,
+  memoId: string | null,
+) {
+  const attachment = await getAttachmentById(db, user, id);
+  const normalizedMemoId = memoId ? parseResourceName(memoId, "memos") : null;
+  if (normalizedMemoId) await getMemoById(db, user, normalizedMemoId);
+  await db
+    .update(attachments)
+    .set({ memoId: normalizedMemoId, updatedAt: new Date().toISOString() })
+    .where(
+      and(eq(attachments.id, attachment.id), eq(attachments.userId, user.id)),
+    );
+  return getAttachmentById(db, user, attachment.id);
 }
 
 export async function softDeleteAttachment(

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -10,5 +10,6 @@ export * from "./memos-social";
 export * from "./memos-sse";
 export * from "./relations";
 export * from "./revisions";
+export * from "./settings";
 export * from "./shares";
 export * from "./users";

--- a/packages/domain/src/memo-filter.ts
+++ b/packages/domain/src/memo-filter.ts
@@ -10,7 +10,10 @@ const MAX_MEMO_FILTER_AST_NODES = 512;
  * the domain package so REST, Connect-shaped JSON, and MCP all evaluate the
  * same expression against the same resource context.
  */
-export type CompiledMemoFilter = (memo: MemoRow, user: UserRow) => boolean;
+export type CompiledMemoFilter = (
+  memo: MemoRow,
+  user: UserRow | null,
+) => boolean;
 
 const memoFilterEnvironment = new Environment({
   // Memos filters are user supplied. Keep the parser bounded even before the
@@ -116,7 +119,7 @@ export function compileMemoFilter(
 
 export function memoFilterContext(
   memo: MemoRow,
-  user: UserRow,
+  user: UserRow | null,
   now = new Date(),
 ) {
   const payload = isRecord(memo.payload) ? memo.payload : {};
@@ -130,8 +133,8 @@ export function memoFilterContext(
   return {
     name: memo.id,
     content: memo.content,
-    creator: user.id,
-    creator_id: memoCreatorId(user.id),
+    creator: user?.id ?? memo.userId,
+    creator_id: memoCreatorId(user?.id ?? memo.userId),
     created_ts: new Date(memo.createdAt),
     updated_ts: new Date(memo.updatedAt),
     pinned: memo.pinned,

--- a/packages/domain/src/memos-social.ts
+++ b/packages/domain/src/memos-social.ts
@@ -24,6 +24,7 @@ import { createResourceId, parseResourceName } from "./ids";
 import { compileMemoFilter } from "./memo-filter";
 import {
   getMemoById,
+  getMemoByIdForViewer,
   normalizeMemoClientId,
   normalizeMemoPayload,
   normalizeMemoTags,
@@ -271,18 +272,18 @@ export async function getMemoParent(
 
 export function listMemoComments(
   db: FlareMoDb,
-  user: UserRow,
+  user: UserRow | null,
   parentMemoId: string,
   input?: ListMemoCommentsInput,
 ): Promise<MemoCommentsResult>;
 export function listMemoComments(
   db: FlareMoDb,
-  user: UserRow,
+  user: UserRow | null,
   input: ListMemoCommentsInput & { memoName: string },
 ): Promise<MemoCommentsResult>;
 export async function listMemoComments(
   db: FlareMoDb,
-  user: UserRow,
+  user: UserRow | null,
   parentMemoOrInput: string | (ListMemoCommentsInput & { memoName: string }),
   input: ListMemoCommentsInput = {},
 ): Promise<MemoCommentsResult> {
@@ -293,7 +294,7 @@ export async function listMemoComments(
       ? parentMemoOrInput
       : parentMemoOrInput.memoName;
   const parentId = parseResourceName(parentMemoId, "memos");
-  await getMemoById(db, user, parentId);
+  await getMemoByIdForViewer(db, user, parentId);
   const order = normalizeCommentOrder(effectiveInput.orderBy);
   const pageSize = normalizePageSize(effectiveInput.pageSize);
   const cursor = effectiveInput.pageToken
@@ -309,8 +310,10 @@ export async function listMemoComments(
   const filters = [
     eq(memoRelations.relatedMemoId, parentId),
     eq(memoRelations.type, "comment"),
-    eq(memos.userId, user.id),
-    inArray(memos.status, ["normal", "archived"]),
+    ...(user ? [eq(memos.userId, user.id)] : [eq(memos.visibility, "public")]),
+    ...(user
+      ? [inArray(memos.status, ["normal", "archived"])]
+      : [eq(memos.status, "normal")]),
   ];
 
   if (cursor) {
@@ -433,18 +436,18 @@ export async function upsertMemoReaction(
 
 export function listMemoReactions(
   db: FlareMoDb,
-  user: UserRow,
+  user: UserRow | null,
   memoId: string,
   input?: ListMemoReactionsInput,
 ): Promise<MemoReactionsResult>;
 export function listMemoReactions(
   db: FlareMoDb,
-  user: UserRow,
+  user: UserRow | null,
   input: ListMemoReactionsInput & { memoName: string },
 ): Promise<MemoReactionsResult>;
 export async function listMemoReactions(
   db: FlareMoDb,
-  user: UserRow,
+  user: UserRow | null,
   memoOrInput: string | (ListMemoReactionsInput & { memoName: string }),
   input: ListMemoReactionsInput = {},
 ): Promise<MemoReactionsResult> {
@@ -452,7 +455,7 @@ export async function listMemoReactions(
   const memoId =
     typeof memoOrInput === "string" ? memoOrInput : memoOrInput.memoName;
   const contentId = parseResourceName(memoId, "memos");
-  await getMemoById(db, user, contentId);
+  await getMemoByIdForViewer(db, user, contentId);
   const pageSize = normalizePageSize(effectiveInput.pageSize);
   const order = "create_time asc";
   const cursor = effectiveInput.pageToken

--- a/packages/domain/src/memos.ts
+++ b/packages/domain/src/memos.ts
@@ -99,6 +99,19 @@ export async function listMemos(
   user: UserRow,
   query: ListMemosQuery,
 ): Promise<MemoListResult> {
+  return listMemosForViewer(db, user, query);
+}
+
+/**
+ * List memos using the same visibility boundary as the Memos API. An
+ * anonymous viewer is intentionally restricted to normal public memos; the
+ * authenticated single-user path retains the existing owner-scoped behavior.
+ */
+export async function listMemosForViewer(
+  db: FlareMoDb,
+  user: UserRow | null,
+  query: ListMemosQuery,
+): Promise<MemoListResult> {
   const search = parseMemoSearchQuery(query.q);
   const celFilter = compileMemoFilter(query.filter);
   const cursor = query.page_token
@@ -108,7 +121,9 @@ export async function listMemos(
   const orderColumn = query.order_by.startsWith("updated_at")
     ? memos.updatedAt
     : memos.createdAt;
-  const filters = [eq(memos.userId, user.id)];
+  const filters = user
+    ? [eq(memos.userId, user.id)]
+    : [eq(memos.visibility, "public"), eq(memos.status, "normal")];
 
   // The established `state` query parameter wins over a search scope so that
   // Memos-compatible clients retain their existing filtering semantics.
@@ -143,7 +158,7 @@ export async function listMemos(
       sql`EXISTS (
         SELECT 1 FROM ${attachments}
         WHERE ${attachments.memoId} = ${memos.id}
-          AND ${attachments.userId} = ${user.id}
+          ${user ? sql`AND ${attachments.userId} = ${user.id}` : sql``}
           AND ${attachments.deletedAt} IS NULL
           AND ${attachments.state} = 'ready'
       )`,
@@ -171,7 +186,7 @@ export async function listMemos(
       sql`EXISTS (
         SELECT 1 FROM ${memoTags}
         WHERE ${memoTags.memoId} = ${memos.id}
-          AND ${memoTags.userId} = ${user.id}
+          ${user ? sql`AND ${memoTags.userId} = ${user.id}` : sql``}
           AND ${memoTags.tag} = ${tag}
       )`,
     );
@@ -322,7 +337,27 @@ export async function getMemoById(
   id: string,
   options: { includeDeleted?: boolean } = {},
 ): Promise<MemoRow> {
-  const filters = [eq(memos.id, id), eq(memos.userId, user.id)];
+  return getMemoByIdForViewer(db, user, id, options);
+}
+
+/**
+ * Resolve a memo for a read-only viewer without ever substituting the owner
+ * user for an anonymous request. This prevents a public request from
+ * inheriting the owner's private timeline by accident.
+ */
+export async function getMemoByIdForViewer(
+  db: FlareMoDb,
+  user: UserRow | null,
+  id: string,
+  options: { includeDeleted?: boolean } = {},
+): Promise<MemoRow> {
+  const filters = user
+    ? [eq(memos.id, id), eq(memos.userId, user.id)]
+    : [
+        eq(memos.id, id),
+        eq(memos.visibility, "public"),
+        eq(memos.status, "normal"),
+      ];
   if (!options.includeDeleted) {
     filters.push(inArray(memos.status, ["normal", "archived", "trashed"]));
   }

--- a/packages/domain/src/relations.ts
+++ b/packages/domain/src/relations.ts
@@ -4,15 +4,15 @@ import { memoRelations, memos } from "@flaremo/db";
 import { and, eq, inArray, or } from "drizzle-orm";
 import { NotFoundError } from "./errors";
 import { parseResourceName } from "./ids";
-import { getMemoById } from "./memos";
+import { getMemoById, getMemoByIdForViewer } from "./memos";
 
 export async function listMemoRelations(
   db: FlareMoDb,
-  user: UserRow,
+  user: UserRow | null,
   memoId: string,
 ) {
   const normalizedMemoId = parseResourceName(memoId, "memos");
-  await getMemoById(db, user, normalizedMemoId);
+  await getMemoByIdForViewer(db, user, normalizedMemoId);
   return db
     .select()
     .from(memoRelations)

--- a/packages/domain/src/settings.ts
+++ b/packages/domain/src/settings.ts
@@ -1,0 +1,68 @@
+import type { FlareMoDb, UserRow } from "@flaremo/db";
+import { settings } from "@flaremo/db";
+import { and, asc, eq } from "drizzle-orm";
+
+export type StoredSetting = {
+  key: string;
+  value: unknown;
+  updatedAt: string;
+};
+
+/**
+ * Settings are deliberately kept behind a domain boundary.  The table is
+ * shared by the single-user runtime and the future multi-user runtime, so
+ * callers must always supply the owning FlareMo user instead of reaching into
+ * the table from an HTTP adapter.
+ */
+export async function getStoredSetting(
+  db: FlareMoDb,
+  user: UserRow,
+  key: string,
+): Promise<StoredSetting | undefined> {
+  const row = await db.query.settings.findFirst({
+    where: and(eq(settings.userId, user.id), eq(settings.key, key)),
+  });
+  return row
+    ? { key: row.key, value: row.value, updatedAt: row.updatedAt }
+    : undefined;
+}
+
+export async function listStoredSettings(
+  db: FlareMoDb,
+  user: UserRow,
+  prefix?: string,
+): Promise<StoredSetting[]> {
+  const rows = await db
+    .select({
+      key: settings.key,
+      value: settings.value,
+      updatedAt: settings.updatedAt,
+    })
+    .from(settings)
+    .where(eq(settings.userId, user.id))
+    .orderBy(asc(settings.key));
+  return rows
+    .filter((row) => !prefix || row.key.startsWith(prefix))
+    .map((row) => ({
+      key: row.key,
+      value: row.value,
+      updatedAt: row.updatedAt,
+    }));
+}
+
+export async function upsertStoredSetting(
+  db: FlareMoDb,
+  user: UserRow,
+  key: string,
+  value: unknown,
+): Promise<StoredSetting> {
+  const updatedAt = new Date().toISOString();
+  await db
+    .insert(settings)
+    .values({ userId: user.id, key, value, updatedAt })
+    .onConflictDoUpdate({
+      target: [settings.userId, settings.key],
+      set: { value, updatedAt },
+    });
+  return { key, value, updatedAt };
+}

--- a/packages/domain/src/users.ts
+++ b/packages/domain/src/users.ts
@@ -34,3 +34,30 @@ export async function ensureSingleUser(
   await db.insert(users).values(row).onConflictDoNothing({ target: users.id });
   return (await db.query.users.findFirst({ where: eq(users.id, id) })) ?? row;
 }
+
+export async function getFlaremoUserById(
+  db: FlareMoDb,
+  id: string,
+): Promise<UserRow | null> {
+  return (await db.query.users.findFirst({ where: eq(users.id, id) })) ?? null;
+}
+
+export async function updateFlaremoUserProfile(
+  db: FlareMoDb,
+  user: UserRow,
+  input: { name?: string; avatarUrl?: string | null },
+) {
+  const nextName = input.name?.trim();
+  if (nextName === "") throw new Error("Display name cannot be empty");
+  await db
+    .update(users)
+    .set({
+      ...(nextName !== undefined ? { name: nextName } : {}),
+      ...(input.avatarUrl !== undefined ? { avatarUrl: input.avatarUrl } : {}),
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(users.id, user.id));
+  return (
+    (await db.query.users.findFirst({ where: eq(users.id, user.id) })) ?? user
+  );
+}

--- a/packages/memos/src/current-adapter.ts
+++ b/packages/memos/src/current-adapter.ts
@@ -194,6 +194,19 @@ export function currentUserToDto(user: UserRow, authUser?: AuthUserRow | null) {
   };
 }
 
+export function publicUserToDto(user: UserRow, username?: string) {
+  return {
+    name: user.id,
+    role: user.role === "owner" ? "ADMIN" : "USER",
+    username: username ?? user.id.replace(/^users\//, ""),
+    displayName: user.name,
+    ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
+    state: "NORMAL",
+    createTime: user.createdAt,
+    updateTime: user.updatedAt,
+  };
+}
+
 export function currentMemoState(
   value: MemoRow["status"],
 ): "STATE_UNSPECIFIED" | "NORMAL" | "ARCHIVED" {


### PR DESCRIPTION
## Summary

- harden anonymous public memo/read ACLs and the public Connect credential boundary
- extend current REST and Connect/protobuf/gRPC-Web unary compatibility for attachments, users, instance settings, identity providers, and share reads
- add protobuf framing/response contracts and deterministic test-only auth golden coverage
- document the exact Memos compatibility matrix and ecosystem verification boundary

## Validation

- `pnpm verify`
- `pnpm deploy:dry-run`
- `pnpm format:check`
- `pnpm exec vitest run --config vitest.config.ts apps/worker/src/memos-protobuf.test.ts apps/worker/src/memos-transport.test.ts apps/worker/src/memos-auth-golden.test.ts`
- `pnpm exec vitest run --config vitest.config.ts apps/worker/src/memos-compatibility.test.ts`
- remote D1 migration check: no migrations to apply

## Compatibility boundary

This PR does not claim complete Memos Server parity or official/third-party client smoke compatibility. Generated client round-trips, full schema/runtime parity, native HTTP/2 gRPC, streaming/compression/trailers, full multi-user authorization, and several upstream services remain explicitly documented follow-up work.

## Deployment

Production deployment is intentionally performed after review/merge. The configured production origin is `https://flaremo.chendahuang.com`; production bootstrap is already complete and no credentials or secrets are included in this PR.