### PR TITLE
feat: extend Memos generated client compatibility

### DIFF
--- a/apps/worker/src/memos-auth-golden.test.ts
+++ b/apps/worker/src/memos-auth-golden.test.ts
@@ -19,6 +19,13 @@ const FIXTURE_ACCESS_EXPIRES_AT = 1_735_690_500;
 const FIXTURE_REFRESH_EXPIRES_AT = 1_738_281_600;
 const FIXTURE_FIRST_TOKEN_ID = "00000000-0000-4000-8000-000000000001";
 const FIXTURE_SECOND_TOKEN_ID = "00000000-0000-4000-8000-000000000002";
+const GO_ACCESS_TOKEN_SHA256 =
+  "f849ac9ef389c070d2bddabf1aedfc8e465cd769bcdd38799202c2754d282d0f";
+const GO_ACCESS_SEGMENT_SHA256 = {
+  header: "08c78c4576dba19dabf54432ec3613d12ee3bdb256a001a48d48808501d2b077",
+  payload: "fe7affb5a0910da91db2c61478c777bbb23b8e54e47a532b62a527ee5e77d57c",
+  signature: "7ee97cb1769406c81b05cafb1541e331e622456105ff9f267744f3625cc392de",
+};
 
 let runtime: Miniflare;
 let env: Env;
@@ -100,6 +107,18 @@ describe("native Memos auth deterministic golden fixture", () => {
       refreshTokenExpiresAt: new Date(FIXTURE_REFRESH_EXPIRES_AT * 1_000),
       subject: 1,
     });
+    const accessSegments = issued.accessToken.split(".");
+    expect(accessSegments).toHaveLength(3);
+    expect(await sha256Hex(issued.accessToken)).toBe(GO_ACCESS_TOKEN_SHA256);
+    expect(await sha256Hex(accessSegments[0] ?? "")).toBe(
+      GO_ACCESS_SEGMENT_SHA256.header,
+    );
+    expect(await sha256Hex(accessSegments[1] ?? "")).toBe(
+      GO_ACCESS_SEGMENT_SHA256.payload,
+    );
+    expect(await sha256Hex(accessSegments[2] ?? "")).toBe(
+      GO_ACCESS_SEGMENT_SHA256.signature,
+    );
     expect(issued.refreshCookie).toContain(
       `memos_refresh=${expectedFirstRefreshToken};`,
     );
@@ -216,9 +235,19 @@ async function createTestRuntime() {
       FLAREMO_SINGLE_USER_EMAIL: TEST_ONLY_EMAIL,
       FLAREMO_SINGLE_USER_NAME: TEST_ONLY_NAME,
       FLAREMO_PUBLIC_URL: "http://flaremo.test",
-      BETTER_AUTH_SECRET: crypto.randomUUID(),
+      BETTER_AUTH_SECRET: "cross-language-fixture-secret-2026",
     } as Env,
   };
+}
+
+async function sha256Hex(value: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
 }
 
 async function signReferenceJwt(

--- a/apps/worker/src/memos-protobuf.test.ts
+++ b/apps/worker/src/memos-protobuf.test.ts
@@ -30,9 +30,16 @@ describe("Memos protobuf transport", () => {
 
   it("supports Connect, gRPC, gRPC-Web, and text gRPC-Web media types", () => {
     expect(detectBinaryTransport("application/proto")).toBe("connect-proto");
+    expect(detectBinaryTransport("application/grpc")).toBe("grpc-proto");
     expect(detectBinaryTransport("application/grpc+proto")).toBe("grpc-proto");
+    expect(detectBinaryTransport("application/grpc-web")).toBe(
+      "grpc-web-proto",
+    );
     expect(detectBinaryTransport("application/grpc-web+proto")).toBe(
       "grpc-web-proto",
+    );
+    expect(detectBinaryTransport("application/grpc-web-text")).toBe(
+      "grpc-web-text-proto",
     );
     expect(detectBinaryTransport("application/grpc-web-text+proto")).toBe(
       "grpc-web-text-proto",

--- a/apps/worker/src/memos-protobuf.ts
+++ b/apps/worker/src/memos-protobuf.ts
@@ -21,9 +21,25 @@ export function detectBinaryTransport(
 ): BinaryTransport | undefined {
   const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
   if (mediaType === "application/proto") return "connect-proto";
-  if (mediaType === "application/grpc+proto") return "grpc-proto";
-  if (mediaType === "application/grpc-web+proto") return "grpc-web-proto";
-  if (mediaType === "application/grpc-web-text+proto") {
+  // Native gRPC commonly uses application/grpc while gRPC-Web uses the
+  // explicit +proto subtype. Memos uses protobuf as its wire codec, so both
+  // media-type forms select the same unary protobuf framing.
+  if (
+    mediaType === "application/grpc" ||
+    mediaType === "application/grpc+proto"
+  ) {
+    return "grpc-proto";
+  }
+  if (
+    mediaType === "application/grpc-web" ||
+    mediaType === "application/grpc-web+proto"
+  ) {
+    return "grpc-web-proto";
+  }
+  if (
+    mediaType === "application/grpc-web-text" ||
+    mediaType === "application/grpc-web-text+proto"
+  ) {
     return "grpc-web-text-proto";
   }
   return undefined;

--- a/apps/worker/src/memos-transport.test.ts
+++ b/apps/worker/src/memos-transport.test.ts
@@ -570,6 +570,23 @@ describe("Memos native auth and transport boundaries", () => {
       "Connect JSON memo",
     );
 
+    const nativeGrpcList = await request(
+      "/memos.api.v1.MemoService/ListMemos",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "content-type": "application/grpc",
+        },
+        body: frameProto(encodeListMemosProto()),
+      },
+    );
+    expect(nativeGrpcList.status).toBe(200);
+    expect(nativeGrpcList.headers.get("grpc-status")).toBe("0");
+    expect(
+      new TextDecoder().decode(await nativeGrpcList.arrayBuffer()),
+    ).toContain("Connect JSON memo");
+
     const binaryGet = await request("/memos.api.v1.MemoService/GetMemo", {
       method: "POST",
       headers: {
@@ -623,6 +640,20 @@ describe("Memos native auth and transport boundaries", () => {
     expect(new TextDecoder().decode(await authBinary.arrayBuffer())).toContain(
       "users/owner",
     );
+
+    const binarySignOut = await request("/memos.api.v1.AuthService/SignOut", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        cookie: refreshCookie,
+        "content-type": "application/proto",
+        origin: "http://flaremo.test",
+      },
+      body: new Uint8Array(),
+    });
+    expect(binarySignOut.status).toBe(200);
+    expect(binarySignOut.headers.get("content-type")).toBe("application/proto");
+    expect(new Uint8Array(await binarySignOut.arrayBuffer())).toHaveLength(0);
 
     const compressed = await request("/memos.api.v1.MemoService/CreateMemo", {
       method: "POST",

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -2323,6 +2323,12 @@ async function connectAuthSignOut(
 function copyResponseHeaders(target: Headers, source: Headers) {
   for (const [name, value] of source.entries()) {
     if (name === "set-cookie") target.append(name, value);
+    // Better Auth returns a JSON representation for its sign-out/sign-in
+    // handler. The Connect adapter has already selected the protobuf
+    // representation, so copying representation headers would make a valid
+    // binary response undecodable by generated clients (especially an empty
+    // google.protobuf.Empty response).
+    else if (name === "content-type" || name === "content-length") continue;
     else target.set(name, value);
   }
 }

--- a/docs/en/memos-compatibility.md
+++ b/docs/en/memos-compatibility.md
@@ -1,6 +1,6 @@
 # Memos Compatibility Matrix
 
-FlareMo is a Cloudflare-native personal knowledge system with a Memos-compatible adapter, not a fork of the Memos Go server. The default `/api/v1` wire is a current Memos-style camelCase / protobuf-JSON subset. The previous FlareMo snake_case wire remains available through an explicit legacy header, and the root `/mcp` endpoint provides a stateless Streamable HTTP MCP subset.
+FlareMo is a Cloudflare-native personal knowledge system with a Memos-compatible adapter, not a fork of the Memos Go server. The default `/api/v1` wire is a current Memos-style camelCase / protobuf-JSON subset. The previous FlareMo snake_case wire remains available through an explicit legacy header, and the root `/mcp` endpoint provides a stateless Streamable HTTP MCP subset. The pinned official Memos generated Connect client has completed one isolated binary-unary smoke against a local Wrangler Worker; this is not complete Memos Server parity or proof that the official Web and third-party clients work in production.
 
 This is an interoperability boundary, not a claim of complete Memos Server parity. Repository contract tests prove FlareMo's own surface; they do not replace real smoke tests against Memos clients. See the [ecosystem matrix](../memos-ecosystem.md) for third-party verification status.
 
@@ -76,7 +76,9 @@ The current tool names use `memo_`, `attachment_`, `shortcut_`, and `auth_` pref
 
 ### Connect JSON and SSE
 
-The Worker also exposes the canonical `memos.api.v1.MemoService/*` HTTP unary JSON subset for memo CRUD, attachments, and relations. It accepts `application/json` only; protobuf binary, native gRPC, complete Connect metadata/trailers, and other Memos services are not implemented.
+The Worker also exposes the canonical `memos.api.v1/{Service}/{Method}` HTTP unary adapter for the documented service subset. It accepts Connect JSON plus `application/proto`, `application/grpc`, `application/grpc+proto`, `application/grpc-web`, `application/grpc-web+proto`, `application/grpc-web-text`, and `application/grpc-web-text+proto`. This is still a hand-written protobuf codec: it does not provide native HTTP/2 gRPC, complete metadata/trailers, compression, streaming, or full Memos service/schema parity.
+
+The pinned official generated-client smoke used the `Temp/memos` commit `daa71d0456d07a25ff5ea435e46577d31d030728`, `@bufbuild/protobuf@2.12.0`, `@connectrpc/connect@2.1.1`, `@connectrpc/connect-web@2.1.1`, and `useBinaryFormat: true` against `http://127.0.0.1:18787`. It successfully decoded the listed unary Auth, Memo/social, Attachment, Shortcut, User, and Instance responses. This is an isolated local E2E result, not a production-domain or official-Web smoke.
 
 `GET /api/v1/sse` provides an authenticated `text/event-stream` handshake, connection comment, heartbeat, and abort/cancel handling. It does not yet provide a cross-isolate mutation outbox, `Last-Event-ID` replay, or a complete Memos SSE event hub, so it is documented as a heartbeat/polling-compatible stream.
 
@@ -92,7 +94,7 @@ Do not describe the following as complete compatibility:
 - Complete upstream service/wire parity for comments, reactions, and shortcuts, plus notifications and admin/instance surfaces.
 - A complete SSE event hub/replay protocol and stateful MCP sessions.
 - Byte-level/version-level native Memos JWT/refresh-token parity; the current implementation only verifies FlareMo's own HS256 claims, rotation, and revocation behavior.
-- Connect protobuf binary, native gRPC/gRPC-Web, and uncovered Memos services.
+- Uncovered Memos services, native HTTP/2 gRPC, complete gRPC-Web trailer/metadata behavior, compression, and streaming.
 - Real smoke tests for the official Memos client, MemoFlow, Dynos, Raycast, browser extensions, or other third-party clients.
 - Cloudflare Access policy correctness; Access is a deployment-layer policy, not the FlareMo application protocol.
 

--- a/docs/memos-compatibility.md
+++ b/docs/memos-compatibility.md
@@ -1,8 +1,8 @@
 # Memos 兼容矩阵
 
-> 矩阵快照：2026-08-04。本页按当前工作树、当前 `git diff` 和仓库测试整理；它描述的是 FlareMo 的兼容边界，不是对任意 Memos 客户端的线上承诺。
+> 矩阵快照：2026-08-05。本页按当前工作树、当前 `git diff` 和仓库测试整理；它描述的是 FlareMo 的兼容边界，不是对任意 Memos 客户端的线上承诺。
 
-FlareMo 是运行在 Cloudflare Workers 上的个人知识系统，不是 Memos Server 的 Go fork。它的定位是“内核不同、对外协议尽量兼容”：应用层使用 Better Auth，数据由 D1/Drizzle 和 R2 承载，并提供 Memos 风格 current camelCase REST、旧 FlareMo legacy wire、canonical Connect/protobuf unary adapter、有限 SSE 和无状态 Streamable HTTP MCP。
+FlareMo 是运行在 Cloudflare Workers 上的个人知识系统，不是 Memos Server 的 Go fork。它的定位是“内核不同、对外协议尽量兼容”：应用层使用 Better Auth，数据由 D1/Drizzle 和 R2 承载，并提供 Memos 风格 current camelCase REST、旧 FlareMo legacy wire、canonical Connect/protobuf unary adapter、有限 SSE 和无状态 Streamable HTTP MCP。官方 Memos generated Connect client 已在隔离的本地 Wrangler Worker 上完成一次 binary unary smoke；这仍不是完整 Memos Server parity 或官方 Web/第三方客户端线上兼容证明。
 
 当前可以准确地说 FlareMo 已经有 Better Auth 原生鉴权、Memos 风格 access/refresh token、可撤销 `memos_pat_` PAT，以及 Memo/Auth/Shortcut 为主并扩展到 Attachment、单用户 User、Instance 和空 IdentityProvider 列表的兼容基础。不能宣称已经完成完整 Memos Server parity，也不能把仓库 contract tests 写成官方 Web 或第三方客户端已经可用。
 
@@ -28,7 +28,8 @@ FlareMo 是运行在 Cloudflare Workers 上的个人知识系统，不是 Memos 
 | protobuf / gRPC-style / gRPC-Web unary | 部分实现 | 部分已测试 | 有手写 codec 和 framing；部分请求/响应已测，未达到 generated schema/runtime parity。 |
 | SSE | 已实现 | 已测试 | D1 outbox + polling + cursor replay 的 FlareMo 实现；不是上游进程内 SSEHub parity。 |
 | Streamable HTTP MCP | 已实现 | 已测试 | 根 `/mcp` 是无状态 JSON 子集；不承诺有状态 session、SSE 或完整工具面。 |
-| 官方 Memos Web、第三方客户端 | 未验证 | 未测 | 已做源码静态审计的候选见 [memos-ecosystem.md](./memos-ecosystem.md)，没有真实客户端 smoke 记录。 |
+| 官方 Memos generated Connect client | 已验证子集 | 已测（隔离 local E2E） | 使用 pinned `Temp/memos` generated client、`useBinaryFormat: true`，已解码 Auth、Memo/social、Attachment、Shortcut、User、Instance 的列出 unary 方法；不是生产验证或完整 parity。 |
+| 官方 Memos Web、第三方客户端 | 未验证 | 未测 | 官方 Web 仍只有源码静态审计；第三方候选见 [memos-ecosystem.md](./memos-ecosystem.md)，没有真实客户端 smoke 记录。 |
 | 完整 Memos Server parity | 未实现 | 未验证 | 当前明确不能宣称完成。 |
 
 ## Wire 模式
@@ -91,20 +92,20 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 
 - `application/json`：Connect JSON message。
 - `application/proto`：Connect protobuf unary message。
-- `application/grpc+proto`：单个未压缩 gRPC-style unary frame。
-- `application/grpc-web+proto`：单个未压缩 gRPC-Web protobuf frame。
-- `application/grpc-web-text+proto`：上面 frame 的 base64 文本形式。
+- `application/grpc`、`application/grpc+proto`：单个未压缩 gRPC-style unary frame；Worker 目前把两种请求 media type 映射到同一个 protobuf codec。
+- `application/grpc-web`、`application/grpc-web+proto`：单个未压缩 gRPC-Web protobuf frame。
+- `application/grpc-web-text`、`application/grpc-web-text+proto`：单个未压缩 gRPC-Web protobuf frame 的 base64 文本形式。
 
 这里是 Worker 上的手写 `ProtoReader` / `ProtoWriter` 适配层，不是从上游 proto 生成的完整 runtime。能返回 unary frame 不等于原生 HTTP/2 gRPC server、generated Connect client 或完整 schema parity。
 
 | 上游 service | 当前已接入方法 | 代码状态 | 仓库测试状态 | 重要边界 |
 | --- | --- | --- | --- | --- |
 | `MemoService` | `CreateMemo`、`ListMemos`、`GetMemo`、`UpdateMemo`、`DeleteMemo`；附件 binding；relations；comments；reactions；shares；`GetMemoByShare`；旧 `GetSharedMemo` alias；`GetLinkMetadata`、`BatchGetLinkMetadata` | 已实现子集 | 已测试 | JSON unary 和部分 protobuf/gRPC-Web framing 有覆盖；canonical `GetMemoByShare` 已有 JSON 测试。普通 memo RPC 仍需应用凭据。 |
-| `AuthService` | `GetCurrentUser`、`SignIn`、`RefreshToken`、`SignOut` | 已实现子集 | 部分已测试 | Better Auth 是身份事实源；native JWT/refresh 是 facade，不是上游 token 的字节级 parity；REST/native auth 和 binary `SignIn` 有覆盖，但完整 generated-client RPC roundtrip 未测。 |
+| `AuthService` | `GetCurrentUser`、`SignIn`、`RefreshToken`、`SignOut` | 已实现子集 | 已测（generated binary 子集） | Better Auth 是身份事实源；native JWT/refresh 是 facade，不是上游 token 的字节级 parity；官方 generated client 已完成列出方法的 binary roundtrip。 |
 | `ShortcutService` | `ListShortcuts`、`GetShortcut`、`CreateShortcut`、`UpdateShortcut`、`DeleteShortcut` | 已实现 | 已测试 | 有 JSON、gRPC-Web framing 和 social contract 覆盖；filter 仍是有限 CEL。 |
-| `AttachmentService` | `CreateAttachment`、`ListAttachments`、`GetAttachment`、`UpdateAttachment`、`DeleteAttachment`、`BatchDeleteAttachments` | 已实现子集 | 部分已测试 | JSON `ListAttachments`、R2/D1 domain path 和 protobuf 请求字段有测试；binary 上传、binary response 的 generated-client roundtrip 未测。只允许有限 memo 字段更新；`externalLink`、客户端指定 `attachmentId` 等能力明确拒绝。 |
-| `UserService` | current user list/batch/get/update；stats；user settings；空的 linked identities/webhooks/notifications list；PAT list/create/delete | 已实现子集 | 部分已测试 | 单用户模型；JSON `ListUsers`、`ListUserSettings` 和 protobuf request field 有覆盖。完整用户生命周期、完整 stats/settings oneof、binary response 和多用户语义未完成。 |
-| `InstanceService` | `GetInstanceProfile`、`GetInstanceSetting`、`BatchGetInstanceSettings`、`UpdateInstanceSetting`、`GetInstanceStats`；`TestInstanceEmailSetting` 明确返回 `501` | 部分实现 | 部分已测试 | profile、公开 settings 和 batch settings 有 JSON contract；Storage/Tags/AI 等 setting oneof、stats binary roundtrip 和 email delivery 未完成。 |
+| `AttachmentService` | `CreateAttachment`、`ListAttachments`、`GetAttachment`、`UpdateAttachment`、`DeleteAttachment`、`BatchDeleteAttachments` | 已实现子集 | 已测（generated binary 子集） | 官方 generated client 已完成 create/list/get/delete；update/batch delete、完整字段和上传语义仍未完成。只允许有限 memo 字段更新；`externalLink`、客户端指定 `attachmentId` 等能力明确拒绝。 |
+| `UserService` | current user list/batch/get/update；stats；user settings；空的 linked identities/webhooks/notifications list；PAT list/create/delete | 已实现子集 | 已测（generated binary 子集） | 官方 generated client 已完成 list/get/stats/settings/notifications/webhooks 的列出方法；单用户生命周期、多用户语义、完整 settings oneof 和 mutation 方法仍未完成。 |
+| `InstanceService` | `GetInstanceProfile`、`GetInstanceSetting`、`BatchGetInstanceSettings`、`UpdateInstanceSetting`、`GetInstanceStats`；`TestInstanceEmailSetting` 明确返回 `501` | 部分实现 | 已测（generated binary 子集） | 官方 generated client 已完成 profile、batch settings、stats；Storage/Tags/AI 等 setting oneof、更新和 email delivery 未完成。 |
 | `IdentityProviderService` | `ListIdentityProviders` 返回空列表 | 仅有限实现 | 已测试（空列表） | 没有 OAuth2 provider CRUD 或 linked identity 流程；其余方法明确返回 `501`。 |
 | `AIService` | 无可用业务实现；transcription 请求明确返回 `501` | 未实现 | 未验证 | protobuf codec 中存在字段映射代码不代表 AI provider 已配置或可调用。 |
 | 其他 service / 未列出 method | 无 | 未实现 | 未验证 | route 对未知 service/method 返回 unimplemented，不做泛化伪成功。 |
@@ -119,9 +120,9 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 
 - `InstanceSetting` 的 Storage/Tags/AI oneof、S3/AI/transcription 配置、UserSetting 完整 oneof、notification payload、attachment `motionMedia` / `externalLink` 等字段。
 - memo create/update 的完整时间、initial attachments/relations/location、完整 update mask、pagination token，以及 comments/reactions 的完整 response schema。
-- canonical `GetMemoByShare`、Attachment create/list/update/delete、User/Instance/IdentityProvider 的全部 generated-client binary roundtrip。
+- Attachment update/batch delete、User/Instance/IdentityProvider 的未覆盖方法和完整 generated-client schema roundtrip；本次 smoke 只覆盖列出的 unary 子集。
 - 原生 gRPC HTTP/2、完整 metadata/trailer、gRPC-Web trailer frame、压缩、streaming RPC、取消和 deadline 语义。
-- Memos 官方 generated Connect client 的实际连接和解码。
+- 官方 Memos Web 的真实浏览器请求、第三方客户端连接，以及 native HTTP/2 gRPC 的真实客户端验证。
 
 ## SSE 与 MCP
 
@@ -133,7 +134,7 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 
 ## 仅静态审计与明确未实现
 
-对当前参考快照 `Temp/memos` 的 proto 和 generated Web Connect client 做过静态审计，确认上游参考面包含 Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI 八类 service，并确认官方 Web 使用 binary Connect、cookie credentials 和 bearer/refresh 生命周期。这个审计只用于列出协议面，不能证明 FlareMo 或官方 Web 已互通。
+对当前参考快照 `Temp/memos` 的 proto 和 generated Web Connect client 做过静态审计，并在 2026-08-05 使用 commit `daa71d0456d07a25ff5ea435e46577d31d030728` 生成的 client 做过一次隔离 local binary smoke。静态审计确认上游参考面包含 Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI 八类 service，并确认官方 Web 使用 binary Connect、cookie credentials 和 bearer/refresh 生命周期；local smoke 只证明列出的 generated unary 子集能解码，不证明官方 Web 或全部服务已互通。
 
 当前明确未实现或未验证的能力：
 

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -1,6 +1,6 @@
 # Memos 生态兼容记录
 
-FlareMo 的目标是复用 Memos 生态，但兼容必须被验证。本文把“代码已接入”“仓库 contract 已测试”“源码静态审计”和“真实客户端 smoke”分开记录，不把“接口长得像”当成“已经兼容”。截至本次快照，FlareMo 已有 Better Auth-backed identity、Memos 风格 HS256 access JWT/轮换 `memos_refresh` cookie、current camelCase REST 的 memo/social 子集、PAT、Connect/protobuf/gRPC-Web unary 子集、D1 outbox/cursor replay SSE 和根 `/mcp` 无状态 Streamable HTTP MCP 子集；完整 Memos Server parity 和第三方客户端实测仍未完成。
+FlareMo 的目标是复用 Memos 生态，但兼容必须被验证。本文把“代码已接入”“仓库 contract 已测试”“源码静态审计”和“真实客户端 smoke”分开记录，不把“接口长得像”当成“已经兼容”。截至本次快照，FlareMo 已有 Better Auth-backed identity、Memos 风格 HS256 access JWT/轮换 `memos_refresh` cookie、current camelCase REST 的 memo/social 子集、PAT、Connect/protobuf/gRPC-Web unary 子集、D1 outbox/cursor replay SSE 和根 `/mcp` 无状态 Streamable HTTP MCP 子集；官方 generated Connect client 已在隔离的本地 Wrangler Worker 上完成一次 binary unary smoke，但完整 Memos Server parity、官方 Web 真实指向 FlareMo 和第三方客户端实测仍未完成。
 
 ## 状态定义
 
@@ -44,23 +44,33 @@ Access Service Token 不会自动变成 FlareMo 用户 session；不能发送应
 | --- | --- | --- | --- | --- |
 | current REST script / curl | 通用 HTTP 脚本 | 已实现 | `memos-compatibility.test.ts`、`memos-social.test.ts`、`auth.test.ts` 覆盖 current DTO、memo/attachment/share、social、PAT、native auth、Origin 和标准错误；`memos-auth-golden.test.ts` 固定验证 FlareMo 自己的 JWT/refresh bytes。 | 已测试的是 FlareMo contract；没有独立客户端或线上实例 smoke，也不证明上游 token parity。 |
 | legacy REST script / curl | 兼容迁移脚本 | 已实现 | current/legacy OpenAPI 和 wire negotiation 有测试。 | 未对历史第三方脚本逐一重放。 |
-| generic Connect JSON client | HTTP unary client | 已实现子集 | `memos-transport.test.ts` 覆盖 Memo/Shortcut 及部分 Auth、Attachment/User/Instance/IdentityProvider JSON RPC。 | 尚未使用官方 generated Connect client 连接。 |
+| generic Connect JSON client | HTTP unary client | 已实现子集 | `memos-transport.test.ts` 覆盖 Memo/Shortcut 及部分 Auth、Attachment/User/Instance/IdentityProvider JSON RPC。 | 官方 generated client 的 binary smoke 已单独记录；generic JSON client 仍未逐一做第三方客户端 smoke。 |
 | generic protobuf / gRPC-style client | HTTP binary client | 已实现子集 | `memos-protobuf.test.ts`、`memos-transport.test.ts` 覆盖 media type、部分 upstream field number、unary framing、gRPC-Web/text 和 error status。 | response 多数只做 frame/字节断言；generated schema roundtrip 未测。 |
 | FlareMo current MCP endpoint | MCP client | 已实现子集 | `mcp-streamable.test.ts`、`memos-compatibility.test.ts` 覆盖 `initialize`、`notifications/initialized`、`tools/list`、`tools/call` 和工具错误 envelope。 | 根 `/mcp` 是无状态 JSON 子集；未测所有第三方 MCP client。 |
 | FlareMo legacy MCP endpoint | 旧 MCP JSON-RPC | 已实现子集 | `mcp-streamable.test.ts` 和 `auth.test.ts` 覆盖旧工具名/PAT 边界。 | 不能从旧 endpoint 推断完整 Memos MCP 兼容。 |
 | FlareMo SSE consumer | EventSource / SSE client | 已实现子集 | `memos-transport.test.ts` 覆盖 authenticated stream、connected/heartbeat、`Last-Event-ID` replay、visibility 和 cancellation。 | D1 polling 实现，未做第三方 EventSource smoke。 |
 | FlareMo Telegram Worker example | Telegram webhook adapter | 已实现示例 | `apps/telegram-bot/src/index.test.ts` 覆盖 PAT-only、可选 Access headers、secret 校验和 fail-closed。 | 不是真实 Telegram API 或生产 FlareMo smoke。 |
 | public share reader | 浏览器 / curl | 已实现 | `memos-compatibility.test.ts`、`api.test.ts` 覆盖 share token 隔离、撤销、过期/状态和附件读取。 | 仍需在实际部署域名上验证 Access bypass 规则；不绕过 FlareMo share 校验。 |
+| 官方 Memos generated Connect client | `protoc-gen-es` + `@connectrpc/connect-web` binary unary client | 已实测子集 | 隔离本地 Wrangler E2E：覆盖 Auth、Memo/social、Attachment、Shortcut、User、Instance 列出的 unary 方法，并由官方 generated decoder 解码响应。 | 只证明 pinned generated client 的 local binary roundtrip；不是生产域名、官方 Web 全量行为或完整 Memos Server parity。 |
 
-## 官方 Memos Web：仅静态审计
+## 官方 Memos generated Connect client：已完成隔离本地 smoke
 
-当前本地参考快照 `Temp/memos` 的 Web 代码和 generated proto client 已被用于协议面静态审计，不能作为真实互通证据。审计得到的关键事实是：
+2026-08-05 对当前本地工作树做过一次隔离 local E2E。测试使用本地参考快照 `Temp/memos` 的 commit `daa71d0456d07a25ff5ea435e46577d31d030728` 生成的 TypeScript client，并使用 `@bufbuild/protobuf@2.12.0`、`@connectrpc/connect@2.1.1`、`@connectrpc/connect-web@2.1.1` 和 `useBinaryFormat: true`，连接本地 Wrangler Worker `http://127.0.0.1:18787`。
 
-- 官方 Web 使用 8 类 generated Connect client：Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI。
-- `connect.ts` 选择 binary format，并使用 `credentials: include`；认证生命周期包含 bearer access token、refresh cookie、Unauthenticated 后 refresh/retry。
-- 因此仅有 Connect JSON 或“HTTP 返回 200”不够；必须把 Attachment/User/Instance 等 response 交给同一 generated client 解码，并真实验证 refresh、signout、memo CRUD 和附件路径。
+已由官方 generated client 成功完成并解码：
 
-当前结论：`仅静态审计`，没有官方 Web 指向 FlareMo 的真实请求、客户端版本记录或 smoke 结果。FlareMo 的手写 protobuf codec 仍有字段和 transport 边界，不能宣称官方 Web 已兼容。
+- `InstanceService`：`GetInstanceProfile`、`BatchGetInstanceSettings`、`GetInstanceStats`。
+- `AuthService`：`SignIn`、`GetCurrentUser`、`RefreshToken`、`SignOut`；signout 后 refresh token reuse 被拒绝。
+- `MemoService`：memo CRUD、comments、reactions、shares 和 share read。
+- `AttachmentService`：create/list/get/delete。
+- `ShortcutService`：create/list/update/delete。
+- `UserService`：list/get/stats/settings/notifications/webhooks。
+
+这条证据只说明 pinned generated client 能把列出的 Connect binary unary 请求发到 FlareMo，并把响应交给同一 generated schema 解码。它不是生产域名验证，也不是官方 Memos Web 全量 smoke：官方 Web 的 cookie credentials、refresh/retry、未覆盖的 IdentityProvider/AI 方法、streaming/metadata 等仍需单独验证；第三方客户端仍保持未测。
+
+## 官方 Memos Web：仍仅静态审计
+
+当前本地参考快照的官方 Web 代码仍只做过协议面静态审计。审计确认官方 Web 使用 8 类 generated Connect client：Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI；`connect.ts` 选择 binary format，并使用 `credentials: include`，认证生命周期包含 bearer access token、refresh cookie、Unauthenticated 后 refresh/retry。没有把官方 Web 本身配置到 FlareMo 的真实浏览器请求，因此不能把上面的 generated client smoke 扩大成“官方 Web 已兼容”。
 
 ## 第三方客户端矩阵
 
@@ -84,7 +94,7 @@ Access Service Token 不会自动变成 FlareMo 用户 session；不能发送应
 
 - 不是完整 Memos Server parity；不能把 current REST、Connect JSON、手写 protobuf 或 `/mcp` 子集合并成“完整兼容”。
 - `AIService/Transcribe`、Instance email test、OAuth2/IdentityProvider CRUD、User create/delete、linked identity CRUD、webhook CRUD、notification update/delete 当前明确未实现或返回 `501`。
-- User/Instance/Attachment 的部分方法虽然已经接入 route，但没有完整 generated-client binary roundtrip；不能把“JSON handler 存在”写成 binary 客户端可用。
+- User/Instance/Attachment 的已列出方法已经有一次 pinned generated-client binary roundtrip，但这不覆盖全部字段、全部方法、生产域名或官方 Web；不能把它写成完整 binary parity。
 - public memo read 已接入 current REST 和 Connect 的明确 viewer policy：匿名只读 `PUBLIC + NORMAL`，private/protected/archived/trashed/deleted 不可见；comments、relations、attachments、reactions 会先检查 parent/read visibility。公开 share 仍是独立 token 入口，不等于普通 memo public ACL。
 - 没有完整 CEL、复杂分页/排序、全部 protobuf 字段、metadata/trailer、压缩、streaming、gRPC-Web trailer frame 或原生 HTTP/2 gRPC parity。
 - SSE 是 D1 outbox/polling/replay，不是上游 SSEHub；没有完整事件集、retention/pruning 和第三方 EventSource 实测。

--- a/packages/contracts/src/openapi-current.ts
+++ b/packages/contracts/src/openapi-current.ts
@@ -13,8 +13,11 @@ const binaryMessage = {
 const connectContent = (schema: JsonSchema) => ({
   ...json(schema),
   "application/proto": binaryMessage,
+  "application/grpc": binaryMessage,
   "application/grpc+proto": binaryMessage,
+  "application/grpc-web": binaryMessage,
   "application/grpc-web+proto": binaryMessage,
+  "application/grpc-web-text": binaryMessage,
   "application/grpc-web-text+proto": binaryMessage,
 });
 

--- a/packages/domain/src/memo-filter.test.ts
+++ b/packages/domain/src/memo-filter.test.ts
@@ -53,6 +53,53 @@ describe("Memos CEL filter", () => {
     expect(caseSensitive?.(memo, user)).toBe(false);
   });
 
+  it("keeps tag aliases atomic across boolean expressions and supports hierarchy", () => {
+    const hierarchical = {
+      ...memo,
+      pinned: false,
+      payload: { tags: ["book/fiction"], property: {} },
+    } as MemoRow;
+    expect(compileMemoFilter('tag in ["book"]')?.(hierarchical, user)).toBe(
+      true,
+    );
+
+    const pinnedWithoutTags = {
+      ...memo,
+      pinned: true,
+      payload: { tags: [], property: {} },
+    } as MemoRow;
+    expect(
+      compileMemoFilter('tag in ["book"] || pinned')?.(pinnedWithoutTags, user),
+    ).toBe(true);
+    expect(
+      compileMemoFilter('tag in ["book"] && pinned')?.(pinnedWithoutTags, user),
+    ).toBe(false);
+    expect(
+      compileMemoFilter('!(tag in ["book"])')?.(pinnedWithoutTags, user),
+    ).toBe(true);
+  });
+
+  it("uses case-insensitive string matching and validates regexes once", () => {
+    expect(compileMemoFilter('content.contains("ROADMAP")')?.(memo, user)).toBe(
+      true,
+    );
+    expect(compileMemoFilter('content.startsWith("ROAD")')?.(memo, user)).toBe(
+      true,
+    );
+    expect(compileMemoFilter('content.endsWith("LAUNCH")')?.(memo, user)).toBe(
+      true,
+    );
+    expect(
+      compileMemoFilter('content.matches("road.*launch")')?.(memo, user),
+    ).toBe(true);
+    expect(() => compileMemoFilter('content.matches("[")')).toThrow(
+      "Invalid Memos CEL filter",
+    );
+    expect(() => compileMemoFilter('content.matches("(?=road)")')).toThrow(
+      "Invalid Memos CEL filter",
+    );
+  });
+
   it("supports the upstream set helpers and non-vacuous tags.all", () => {
     expect(
       compileMemoFilter(
@@ -89,5 +136,53 @@ describe("Memos CEL filter", () => {
     expect(() => compileMemoFilter("x".repeat(4_097))).toThrow(
       "Memos filter is too long",
     );
+    expect(() => compileMemoFilter("1")).toThrow(
+      "filter must evaluate to a boolean",
+    );
+    expect(() => compileMemoFilter('timestamp("garbage") < now')).toThrow(
+      "Invalid Memos CEL filter",
+    );
+    expect(() =>
+      compileMemoFilter('duration("garbage") > duration("1s")'),
+    ).toThrow("Invalid Memos CEL filter");
+    expect(() => compileMemoFilter('visibility < "PUBLIC"')).toThrow(
+      "Invalid Memos CEL filter",
+    );
+    expect(() => compileMemoFilter('tag == "urgent"')).toThrow(
+      "Invalid Memos CEL filter",
+    );
+    expect(() => compileMemoFilter("tags.map(t, t)")).toThrow(
+      "Invalid Memos CEL filter",
+    );
+    expect(() =>
+      compileMemoFilter('content.substring(0, 2) == "road"'),
+    ).toThrow("Invalid Memos CEL filter");
+    expect(() => compileMemoFilter('created_ts.getHours("UTC") > 0')).toThrow(
+      "Invalid Memos CEL filter",
+    );
+  });
+
+  it("normalizes only code and preserves string literals", () => {
+    expect(
+      compileMemoFilter('sets . contains ( tags, ["urgent"] )')?.(memo, user),
+    ).toBe(true);
+    const singleTagMemo = {
+      ...memo,
+      payload: { tags: ["urgent"], property: {} },
+    } as MemoRow;
+    expect(
+      compileMemoFilter('tags . all (t, t.startsWith("URGENT"))')?.(
+        singleTagMemo,
+        user,
+      ),
+    ).toBe(true);
+
+    const literalMemo = { ...memo, content: "sets.contains(" } as MemoRow;
+    expect(
+      compileMemoFilter('content.contains("sets.contains(")')?.(
+        literalMemo,
+        user,
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/domain/src/memo-filter.ts
+++ b/packages/domain/src/memo-filter.ts
@@ -4,6 +4,15 @@ import { ValidationError } from "./errors";
 
 const MAX_MEMO_FILTER_LENGTH = 4_096;
 const MAX_MEMO_FILTER_AST_NODES = 512;
+const MAX_MEMO_FILTER_REGEX_LENGTH = 1_024;
+const MAX_MEMO_FILTER_REGEX_CACHE_ENTRIES = 256;
+
+const memoFilterRegexCache = new Map<string, RegExp>();
+
+type MemoFilterAst = {
+  op: string;
+  args: unknown;
+};
 
 /**
  * A compiled Memos CEL filter.  The parser/evaluator is deliberately kept in
@@ -62,6 +71,37 @@ const memoFilterEnvironment = new Environment({
         leftSet.every((value) => rightSet.includes(value))
       );
     },
+  )
+  .registerFunction(
+    "flaremo_tag_in(list<string>, list<string>): bool",
+    (tags: string[], candidates: string[]) =>
+      candidates.some((candidate) =>
+        tags.some(
+          (tag) => tag === candidate || tag.startsWith(`${candidate}/`),
+        ),
+      ),
+  )
+  .registerFunction(
+    "string.flaremo_contains(string): bool",
+    (left: string, right: string) =>
+      left.toLowerCase().includes(right.toLowerCase()),
+  )
+  .registerFunction(
+    "string.flaremo_startsWith(string): bool",
+    (left: string, right: string) =>
+      left.toLowerCase().startsWith(right.toLowerCase()),
+  )
+  .registerFunction(
+    "string.flaremo_endsWith(string): bool",
+    (left: string, right: string) =>
+      left.toLowerCase().endsWith(right.toLowerCase()),
+  )
+  .registerFunction(
+    "string.flaremo_matches(string): bool",
+    (left: string, pattern: string) => {
+      const regex = getMemoFilterRegex(pattern);
+      return regex.test(left);
+    },
   );
 
 export function compileMemoFilter(
@@ -72,6 +112,7 @@ export function compileMemoFilter(
   if (value.length > MAX_MEMO_FILTER_LENGTH) {
     throw new ValidationError("Memos filter is too long");
   }
+  rejectReservedImplementationNames(value);
 
   let compiled: ParseResult;
   try {
@@ -92,22 +133,19 @@ export function compileMemoFilter(
       `Invalid Memos CEL filter: ${safeError(checked.error)}`,
     );
   }
+  if (checked.type !== "bool") {
+    throw new ValidationError(
+      "Invalid Memos CEL filter: filter must evaluate to a boolean",
+    );
+  }
+
+  validateMemoFilterSurface(compiled.ast);
 
   const frozenNow = new Date();
-  const usesTagAlias = astContainsIdentifier(compiled.ast, "tag");
 
   return (memo, user) => {
     const context = memoFilterContext(memo, user, frozenNow);
     try {
-      // Memos' `tag` is a virtual alias for membership in `tags`, not one
-      // arbitrary scalar stored on a memo. Evaluating once per tag preserves
-      // the existential semantics of the upstream `tag in [...]` form while
-      // keeping CEL-JS' regular type checker in place.
-      if (usesTagAlias) {
-        return context.tags.some(
-          (tag) => compiled({ ...context, tag }) === true,
-        );
-      }
       return compiled(context) === true;
     } catch (error) {
       throw new ValidationError(
@@ -155,106 +193,576 @@ export function memoFilterContext(
 }
 
 function normalizeMemoFilterExpression(expression: string) {
-  let normalized = expression
-    .replaceAll("sets.contains(", "flaremo_sets_contains(")
-    .replaceAll("sets.intersects(", "flaremo_sets_intersects(")
-    .replaceAll("sets.equivalent(", "flaremo_sets_equivalent(");
+  let normalized = rewriteOutsideStringLiterals(expression, (code) =>
+    code
+      .replace(
+        /\bsets\s*\.\s*(contains|intersects|equivalent)\s*\(/g,
+        (_, name: string) => `flaremo_sets_${name}(`,
+      )
+      .replace(
+        /\.\s*(contains|startsWith|endsWith|matches)\s*(?=\()/g,
+        (_, name: string) => `.flaremo_${name}`,
+      ),
+  );
 
   normalized = rewriteTagsAll(normalized);
+  normalized = rewriteTagAliasIn(normalized);
   return normalized;
 }
 
 function rewriteTagsAll(expression: string) {
-  const target = "tags.all(";
   let output = "";
   let cursor = 0;
   while (cursor < expression.length) {
-    const match = findOutsideString(expression, target, cursor);
-    if (match < 0) {
+    const match = findQualifiedCall(expression, "tags", "all", cursor);
+    if (!match) {
       output += expression.slice(cursor);
       break;
     }
 
-    output += expression.slice(cursor, match);
-    const end = findClosingParenthesis(expression, match + target.length - 1);
+    const end = findClosingDelimiter(expression, match.opening);
     if (end < 0) {
-      output += expression.slice(match);
+      output += expression.slice(cursor);
       break;
     }
 
-    const call = expression.slice(match, end + 1);
+    output += expression.slice(cursor, match.start);
+    const call = expression.slice(match.start, end + 1);
     output += `(size(tags) > 0 && ${call})`;
     cursor = end + 1;
   }
   return output;
 }
 
-function findOutsideString(input: string, needle: string, from: number) {
-  let quote: string | undefined;
-  let escaped = false;
-  for (let index = from; index <= input.length - needle.length; index += 1) {
-    const character = input[index];
-    if (quote) {
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (character === quote) quote = undefined;
-      continue;
+function rewriteTagAliasIn(expression: string) {
+  let output = "";
+  let cursor = 0;
+  while (cursor < expression.length) {
+    const match = findTagInList(expression, cursor);
+    if (!match) {
+      output += expression.slice(cursor);
+      break;
     }
-    if (character === '"' || character === "'" || character === "`") {
-      quote = character;
-      continue;
-    }
-    if (input.startsWith(needle, index)) return index;
+
+    output += expression.slice(cursor, match.start);
+    output += `flaremo_tag_in(tags,${expression.slice(match.listStart, match.end + 1)})`;
+    cursor = match.end + 1;
   }
-  return -1;
+  return output;
 }
 
-function findClosingParenthesis(input: string, opening: number) {
-  let depth = 0;
-  let quote: string | undefined;
-  let escaped = false;
+function rewriteOutsideStringLiterals(
+  input: string,
+  rewrite: (code: string) => string,
+) {
+  let output = "";
+  let segmentStart = 0;
+  let index = 0;
+
+  while (index < input.length) {
+    if (!isStringDelimiter(input[index])) {
+      index += 1;
+      continue;
+    }
+
+    output += rewrite(input.slice(segmentStart, index));
+    const end = findStringLiteralEnd(input, index);
+    if (end < 0) {
+      output += input.slice(index);
+      return output;
+    }
+    output += input.slice(index, end);
+    index = end;
+    segmentStart = end;
+  }
+
+  return output + rewrite(input.slice(segmentStart));
+}
+
+function findQualifiedCall(
+  input: string,
+  receiver: string,
+  method: string,
+  from: number,
+) {
+  for (let index = from; index < input.length; index += 1) {
+    if (isStringDelimiter(input[index])) {
+      const end = findStringLiteralEnd(input, index);
+      if (end < 0) return undefined;
+      index = end - 1;
+      continue;
+    }
+    if (!input.startsWith(receiver, index)) continue;
+    if (
+      isIdentifierCharacter(input[index - 1]) ||
+      isIdentifierCharacter(input[index + receiver.length])
+    ) {
+      continue;
+    }
+
+    let cursor = skipWhitespace(input, index + receiver.length);
+    if (input[cursor] !== ".") continue;
+    cursor = skipWhitespace(input, cursor + 1);
+    if (!input.startsWith(method, cursor)) continue;
+    if (
+      isIdentifierCharacter(input[cursor - 1]) ||
+      isIdentifierCharacter(input[cursor + method.length])
+    ) {
+      continue;
+    }
+    cursor = skipWhitespace(input, cursor + method.length);
+    if (input[cursor] !== "(") continue;
+    return { start: index, opening: cursor };
+  }
+  return undefined;
+}
+
+function findTagInList(input: string, from: number) {
+  for (let index = from; index < input.length; index += 1) {
+    if (isStringDelimiter(input[index])) {
+      const end = findStringLiteralEnd(input, index);
+      if (end < 0) return undefined;
+      index = end - 1;
+      continue;
+    }
+    if (!input.startsWith("tag", index)) continue;
+    if (
+      isIdentifierCharacter(input[index - 1]) ||
+      isIdentifierCharacter(input[index + 3])
+    ) {
+      continue;
+    }
+
+    let cursor = skipWhitespace(input, index + 3);
+    if (!input.startsWith("in", cursor)) continue;
+    if (
+      isIdentifierCharacter(input[cursor - 1]) ||
+      isIdentifierCharacter(input[cursor + 2])
+    ) {
+      continue;
+    }
+    cursor = skipWhitespace(input, cursor + 2);
+    if (input[cursor] !== "[") continue;
+    const end = findClosingDelimiter(input, cursor);
+    if (end < 0) return undefined;
+    return { start: index, listStart: cursor, end };
+  }
+  return undefined;
+}
+
+function findClosingDelimiter(input: string, opening: number) {
+  const expected = new Map([
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
+  ]);
+  const closing = new Set(expected.values());
+  const stack: string[] = [];
+
   for (let index = opening; index < input.length; index += 1) {
     const character = input[index];
-    if (quote) {
-      if (escaped) escaped = false;
-      else if (character === "\\") escaped = true;
-      else if (character === quote) quote = undefined;
+    if (character === undefined) continue;
+    if (isStringDelimiter(character)) {
+      const end = findStringLiteralEnd(input, index);
+      if (end < 0) return -1;
+      index = end - 1;
       continue;
     }
-    if (character === '"' || character === "'" || character === "`") {
-      quote = character;
+    if (expected.has(character)) {
+      stack.push(expected.get(character) as string);
       continue;
     }
-    if (character === "(") depth += 1;
-    else if (character === ")") {
-      depth -= 1;
-      if (depth === 0) return index;
+    if (!closing.has(character)) continue;
+    if (stack.pop() !== character) return -1;
+    if (stack.length === 0) return index;
+  }
+  return -1;
+}
+
+function findStringLiteralEnd(input: string, start: number) {
+  const delimiter = input[start];
+  if (delimiter === undefined) return -1;
+  const triple = input.startsWith(delimiter.repeat(3), start);
+  const width = triple ? 3 : 1;
+
+  for (let index = start + width; index < input.length; index += 1) {
+    if (input[index] === "\\") {
+      index += 1;
+      continue;
+    }
+    if (
+      triple
+        ? input.startsWith(delimiter.repeat(3), index)
+        : input[index] === delimiter
+    ) {
+      return index + width;
     }
   }
   return -1;
 }
 
-function astContainsIdentifier(
-  node: { op: string; args: unknown },
-  name: string,
-): boolean {
-  if (node.op === "id") return node.args === name;
-  const children = Array.isArray(node.args)
-    ? node.args
-    : node.args && typeof node.args === "object"
-      ? Object.values(node.args)
-      : [];
-  return children.some((child) => {
-    if (isAstNode(child)) return astContainsIdentifier(child, name);
-    if (Array.isArray(child)) {
-      return child.some((nested) =>
-        isAstNode(nested) ? astContainsIdentifier(nested, name) : false,
-      );
-    }
-    return false;
-  });
+function isStringDelimiter(value: string | undefined) {
+  return value === '"' || value === "'" || value === "`";
 }
 
+function isIdentifierCharacter(value: string | undefined) {
+  return value !== undefined && /[A-Za-z0-9_]/.test(value);
+}
+
+function skipWhitespace(input: string, from: number) {
+  let index = from;
+  while (/\s/.test(input[index] ?? "")) index += 1;
+  return index;
+}
+
+const memoFilterBooleanFields = new Set([
+  "pinned",
+  "has_link",
+  "has_task_list",
+  "has_code",
+  "has_incomplete_tasks",
+]);
+const memoFilterStringFields = new Set([
+  "content",
+  "creator",
+  "visibility",
+  "state",
+]);
+const memoFilterAllowedIds = new Set([
+  ...memoFilterBooleanFields,
+  ...memoFilterStringFields,
+  "creator_id",
+  "created_ts",
+  "updated_ts",
+  "tags",
+  "now",
+]);
+
+function rejectUnsupported(message: string): never {
+  throw new ValidationError(`Invalid Memos CEL filter: ${message}`);
+}
+
+function rejectReservedImplementationNames(expression: string) {
+  let found = false;
+  rewriteOutsideStringLiterals(expression, (code) => {
+    if (
+      /\bflaremo_(?:sets_(?:contains|intersects|equivalent)|tag_in|(?:contains|startsWith|endsWith|matches))\b/.test(
+        code,
+      )
+    ) {
+      found = true;
+    }
+    return code;
+  });
+  if (found) {
+    rejectUnsupported("reserved implementation helper is not public");
+  }
+}
+
+function validateMemoFilterSurface(node: MemoFilterAst) {
+  visitMemoFilterAst(node, new Set<string>());
+}
+
+function visitMemoFilterAst(node: MemoFilterAst, boundIds: Set<string>) {
+  switch (node.op) {
+    case "id": {
+      const name = identifierName(node);
+      if (!name || (!memoFilterAllowedIds.has(name) && !boundIds.has(name))) {
+        rejectUnsupported("identifier is not supported");
+      }
+      return;
+    }
+    case "value":
+      return;
+    case "list":
+      for (const item of requireAstArray(node.args, "list")) {
+        visitMemoFilterAst(item, boundIds);
+      }
+      return;
+    case "&&":
+    case "||":
+    case "==":
+    case "!=":
+    case "<":
+    case "<=":
+    case ">":
+    case ">=": {
+      const args = binaryAstArgs(node);
+      if (!args) rejectUnsupported(`${node.op} requires two operands`);
+      if (
+        ["<", "<=", ">", ">="].includes(node.op) &&
+        isStringOrderingOperand(args[0])
+      ) {
+        rejectUnsupported("string ordering is not supported");
+      }
+      visitMemoFilterAst(args[0], boundIds);
+      visitMemoFilterAst(args[1], boundIds);
+      return;
+    }
+    case "!_":
+      if (!isAstNode(node.args))
+        rejectUnsupported("NOT requires one condition");
+      visitMemoFilterAst(node.args, boundIds);
+      return;
+    case "call":
+      validateCallSurface(node, boundIds);
+      return;
+    case "rcall":
+      validateReceiverCallSurface(node, boundIds);
+      return;
+    default:
+      rejectUnsupported(`operator ${node.op} is not supported`);
+  }
+}
+
+function validateCallSurface(node: MemoFilterAst, boundIds: Set<string>) {
+  const parts = callParts(node);
+  if (!parts) rejectUnsupported("malformed function call");
+
+  if (
+    parts.name === "flaremo_tag_in" ||
+    parts.name === "flaremo_sets_contains" ||
+    parts.name === "flaremo_sets_intersects" ||
+    parts.name === "flaremo_sets_equivalent"
+  ) {
+    if (parts.args.length !== 2) {
+      rejectUnsupported(`${parts.name} requires tags and a string list`);
+    }
+    const receiver = requireAstArg(parts.args, 0, parts.name);
+    const candidates = requireAstArg(parts.args, 1, parts.name);
+    if (identifierName(receiver) !== "tags" || !isStringList(candidates)) {
+      rejectUnsupported(`${parts.name} requires tags and a string list`);
+    }
+    visitMemoFilterAst(receiver, boundIds);
+    return;
+  }
+
+  if (parts.name === "size") {
+    if (parts.args.length !== 1) {
+      rejectUnsupported("size is only supported for tags");
+    }
+    const receiver = requireAstArg(parts.args, 0, "size");
+    if (identifierName(receiver) !== "tags") {
+      rejectUnsupported("size is only supported for tags");
+    }
+    visitMemoFilterAst(receiver, boundIds);
+    return;
+  }
+
+  if (parts.name === "timestamp" || parts.name === "duration") {
+    if (parts.args.length !== 1) {
+      rejectUnsupported(`${parts.name} requires one literal`);
+    }
+    const literal = stringLiteral(requireAstArg(parts.args, 0, parts.name));
+    if (literal === undefined) {
+      rejectUnsupported(`${parts.name} requires a literal string`);
+    }
+    if (parts.name === "timestamp") validateTimestampLiteral(literal);
+    else validateDurationLiteral(literal);
+    return;
+  }
+
+  rejectUnsupported(`function ${parts.name} is not supported`);
+}
+
+function validateReceiverCallSurface(
+  node: MemoFilterAst,
+  boundIds: Set<string>,
+) {
+  const parts = receiverCallParts(node);
+  if (!parts) rejectUnsupported("malformed receiver call");
+
+  if (
+    parts.name === "exists" ||
+    parts.name === "all" ||
+    parts.name === "exists_one"
+  ) {
+    if (parts.args.length !== 2) {
+      rejectUnsupported(`${parts.name} is only supported for tags`);
+    }
+    const iteratorArg = requireAstArg(parts.args, 0, parts.name);
+    const predicate = requireAstArg(parts.args, 1, parts.name);
+    if (
+      identifierName(parts.receiver) !== "tags" ||
+      identifierName(iteratorArg) === undefined
+    ) {
+      rejectUnsupported(`${parts.name} is only supported for tags`);
+    }
+    const iterator = identifierName(iteratorArg);
+    if (!iterator || iterator === "tag") {
+      rejectUnsupported("tag comprehension iterator is not valid");
+    }
+    visitMemoFilterAst(parts.receiver, boundIds);
+    const nestedIds = new Set(boundIds);
+    nestedIds.add(iterator);
+    visitMemoFilterAst(predicate, nestedIds);
+    return;
+  }
+
+  if (
+    parts.name !== "flaremo_contains" &&
+    parts.name !== "flaremo_startsWith" &&
+    parts.name !== "flaremo_endsWith" &&
+    parts.name !== "flaremo_matches"
+  ) {
+    rejectUnsupported(`method ${parts.name} is not supported`);
+  }
+  const receiverName = identifierName(parts.receiver);
+  if (receiverName !== "content" && !boundIds.has(receiverName ?? "")) {
+    rejectUnsupported("text methods only support content and tag iterators");
+  }
+  if (parts.args.length !== 1) {
+    rejectUnsupported(`${parts.name} requires one string literal`);
+  }
+  const literal = stringLiteral(requireAstArg(parts.args, 0, parts.name));
+  if (literal === undefined) {
+    rejectUnsupported(`${parts.name} requires a literal string`);
+  }
+  if (parts.name === "flaremo_matches") validateRegexPattern(literal);
+  visitMemoFilterAst(parts.receiver, boundIds);
+}
+
+function requireAstArray(value: unknown, label: string): MemoFilterAst[] {
+  if (!Array.isArray(value) || !value.every(isAstNode)) {
+    rejectUnsupported(`${label} arguments are not valid`);
+  }
+  return value;
+}
+
+function requireAstArg(
+  args: MemoFilterAst[],
+  index: number,
+  label: string,
+): MemoFilterAst {
+  const arg = args[index];
+  if (!arg) rejectUnsupported(`${label} arguments are not valid`);
+  return arg;
+}
+
+function binaryAstArgs(
+  node: MemoFilterAst,
+): [MemoFilterAst, MemoFilterAst] | undefined {
+  if (
+    !Array.isArray(node.args) ||
+    node.args.length !== 2 ||
+    !isAstNode(node.args[0]) ||
+    !isAstNode(node.args[1])
+  ) {
+    return undefined;
+  }
+  return [node.args[0], node.args[1]];
+}
+
+function callParts(
+  node: MemoFilterAst,
+): { name: string; args: MemoFilterAst[] } | undefined {
+  if (node.op !== "call" || !Array.isArray(node.args)) return undefined;
+  const [name, args] = node.args;
+  if (
+    typeof name !== "string" ||
+    !Array.isArray(args) ||
+    !args.every(isAstNode)
+  ) {
+    return undefined;
+  }
+  return { name, args };
+}
+
+function receiverCallParts(
+  node: MemoFilterAst,
+):
+  | { name: string; receiver: MemoFilterAst; args: MemoFilterAst[] }
+  | undefined {
+  if (node.op !== "rcall" || !Array.isArray(node.args)) return undefined;
+  const [name, receiver, args] = node.args;
+  if (
+    typeof name !== "string" ||
+    !isAstNode(receiver) ||
+    !Array.isArray(args) ||
+    !args.every(isAstNode)
+  ) {
+    return undefined;
+  }
+  return { name, receiver, args };
+}
+
+function isStringOrderingOperand(node: MemoFilterAst) {
+  return node.op === "id" && memoFilterStringFields.has(String(node.args));
+}
+
+function stringLiteral(node: MemoFilterAst) {
+  return node.op === "value" && typeof node.args === "string"
+    ? node.args
+    : undefined;
+}
+
+function identifierName(node: unknown) {
+  return isAstNode(node) && node.op === "id" && typeof node.args === "string"
+    ? node.args
+    : undefined;
+}
+
+function isStringList(node: MemoFilterAst) {
+  return (
+    node.op === "list" &&
+    Array.isArray(node.args) &&
+    node.args.every((item) => isAstNode(item) && typeof item.args === "string")
+  );
+}
+
+function validateTimestampLiteral(value: string) {
+  if (
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/.test(
+      value,
+    ) ||
+    Number.isNaN(Date.parse(value))
+  ) {
+    rejectUnsupported("timestamp requires a valid RFC3339 literal");
+  }
+}
+
+function validateDurationLiteral(value: string) {
+  if (
+    !/^[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:ns|us|µs|ms|s|m|h)(?:(?:\d+(?:\.\d+)?|\.\d+)(?:ns|us|µs|ms|s|m|h))*$/.test(
+      value,
+    )
+  ) {
+    rejectUnsupported("duration requires a valid literal");
+  }
+}
+
+function validateRegexPattern(pattern: string) {
+  if (pattern.length > MAX_MEMO_FILTER_REGEX_LENGTH) {
+    rejectUnsupported("regex literal is too long");
+  }
+  if (/\\(?:[1-9]\d*|k<)|\(\?/.test(pattern)) {
+    rejectUnsupported("regex uses an unsupported construct");
+  }
+  if (/\((?:[^()\\]|\\.)*[+*{](?:[^()\\]|\\.)*\)[+*{]/.test(pattern)) {
+    rejectUnsupported("regex contains nested quantifiers");
+  }
+  if (memoFilterRegexCache.has(pattern)) return;
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern);
+  } catch {
+    rejectUnsupported("regex is invalid");
+  }
+  if (memoFilterRegexCache.size >= MAX_MEMO_FILTER_REGEX_CACHE_ENTRIES) {
+    const oldest = memoFilterRegexCache.keys().next().value;
+    if (oldest !== undefined) memoFilterRegexCache.delete(oldest);
+  }
+  memoFilterRegexCache.set(pattern, regex);
+}
+
+function getMemoFilterRegex(pattern: string) {
+  const cached = memoFilterRegexCache.get(pattern);
+  if (cached) return cached;
+  validateRegexPattern(pattern);
+  const compiled = memoFilterRegexCache.get(pattern);
+  if (!compiled) throw new Error("Memos filter regex was not compiled");
+  return compiled;
+}
 function memoCreatorId(userId: string) {
   if (userId === "users/owner") return 1n;
   const numericId = /^users\/([1-9][0-9]*)$/.exec(userId)?.[1];
@@ -293,7 +801,7 @@ function countAstNodes(node: { op: string; args: unknown }): number {
   return count;
 }
 
-function isAstNode(value: unknown): value is { op: string; args: unknown } {
+function isAstNode(value: unknown): value is MemoFilterAst {
   return Boolean(
     value && typeof value === "object" && "op" in value && "args" in value,
   );

--- a/tests/fixtures/memos-auth/v0.29.1-daa71d0.access.json
+++ b/tests/fixtures/memos-auth/v0.29.1-daa71d0.access.json
@@ -1,0 +1,28 @@
+{
+  "reference": {
+    "memosCommit": "daa71d0456d07a25ff5ea435e46577d31d030728",
+    "releaseContext": "0.29.1-era",
+    "go": "1.26.2",
+    "jwt": "github.com/golang-jwt/jwt/v5@v5.3.1"
+  },
+  "input": {
+    "issuedAt": 1735689600,
+    "expiresAt": 1735690500,
+    "subject": "1",
+    "username": "owner",
+    "role": "ADMIN",
+    "status": "NORMAL",
+    "secret": "cross-language-fixture-secret-2026"
+  },
+  "serialization": {
+    "headerJson": "{\"alg\":\"HS256\",\"kid\":\"v1\",\"typ\":\"JWT\"}",
+    "payloadJson": "{\"type\":\"access\",\"role\":\"ADMIN\",\"status\":\"NORMAL\",\"username\":\"owner\",\"iss\":\"memos\",\"sub\":\"1\",\"aud\":[\"user.access-token\"],\"exp\":1735690500,\"iat\":1735689600}",
+    "encodedSegmentSha256": {
+      "header": "08c78c4576dba19dabf54432ec3613d12ee3bdb256a001a48d48808501d2b077",
+      "payload": "fe7affb5a0910da91db2c61478c777bbb23b8e54e47a532b62a527ee5e77d57c",
+      "signature": "7ee97cb1769406c81b05cafb1541e331e622456105ff9f267744f3625cc392de"
+    },
+    "tokenSha256": "f849ac9ef389c070d2bddabf1aedfc8e465cd769bcdd38799202c2754d282d0f",
+    "segmentLengths": [51, 207, 43]
+  }
+}


### PR DESCRIPTION
## Summary
- harden the restricted Memos CEL filter surface and add regression coverage
- accept Connect, gRPC-style, and gRPC-Web protobuf media types without corrupting binary Auth responses
- add a pinned Memos access-JWT golden fixture and document the isolated official generated-client binary smoke boundary

## Verification
- pnpm verify
- pnpm deploy:dry-run
- pnpm format:check
- pnpm check
- official pinned generated Connect client local binary-unary smoke against Wrangler Worker

## Scope
This PR is a compatibility-hardening follow-up on the current Memos adapter foundation. It does not claim complete Memos Server parity, native HTTP/2 gRPC, full streaming/metadata/compression parity, official Web compatibility, or third-party client compatibility. No issue was provided; this is the focused follow-up for the current compatibility work.