### PR TITLE
feat: bridge Memos attachment file URLs

### DIFF
--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -549,6 +549,44 @@ describe("FlareMo Worker API", () => {
     );
     expect(await blob.text()).toBe("hello attachment");
 
+    const unauthenticatedFile = await fetchApp(
+      `http://flaremo.test/file/${attachment.name}/hello.txt`,
+      undefined,
+      { authenticated: false },
+    );
+    expect(unauthenticatedFile.status).toBe(401);
+
+    const fileUrl = `http://flaremo.test/file/${attachment.name}/hello.txt`;
+    const file = await fetchApp(fileUrl, {
+      headers: { cookie: sessionCookie },
+    });
+    expect(file.status).toBe(200);
+    expect(file.headers.get("content-type")).toContain("text/plain");
+    expect(file.headers.get("content-disposition")).toContain(
+      'filename="hello.txt"',
+    );
+    expect(await file.text()).toBe("hello attachment");
+
+    const fileWithUntrustedName = await fetchApp(
+      `http://flaremo.test/file/${attachment.name}/not-the-real-file.txt`,
+      { headers: { cookie: sessionCookie } },
+    );
+    expect(fileWithUntrustedName.status).toBe(200);
+    expect(await fileWithUntrustedName.text()).toBe("hello attachment");
+
+    const partialFile = await fetchApp(fileUrl, {
+      headers: { cookie: sessionCookie, range: "bytes=0-4" },
+    });
+    expect(partialFile.status).toBe(206);
+    expect(await partialFile.text()).toBe("hello");
+
+    const etag = file.headers.get("etag");
+    expect(etag).toBeTruthy();
+    const notModified = await fetchApp(fileUrl, {
+      headers: { cookie: sessionCookie, "if-none-match": etag ?? "" },
+    });
+    expect(notModified.status).toBe(304);
+
     const deleted = await json(
       await fetchApp(`http://flaremo.test/api/v1/${attachment.name}`, {
         method: "DELETE",
@@ -731,7 +769,7 @@ describe("FlareMo Worker API", () => {
       "file",
       new File(["shared attachment"], "shared.txt", { type: "text/plain" }),
     );
-    await json(
+    const sharedAttachment = await json<{ name: string }>(
       await fetchApp("http://flaremo.test/api/v1/attachments", {
         method: "POST",
         body: formData,
@@ -761,6 +799,22 @@ describe("FlareMo Worker API", () => {
     expect(blob.ok).toBe(true);
     expect(await blob.text()).toBe("shared attachment");
 
+    const memosWebShareFile = await fetchApp(
+      `http://flaremo.test/file/${sharedAttachment.name}/shared.txt?share_token=${encodeURIComponent(share.token)}`,
+      undefined,
+      { authenticated: false },
+    );
+    expect(memosWebShareFile.status).toBe(200);
+    expect(memosWebShareFile.headers.get("cache-control")).toContain("public");
+    expect(await memosWebShareFile.text()).toBe("shared attachment");
+
+    const invalidShareFile = await fetchApp(
+      `http://flaremo.test/file/${sharedAttachment.name}/shared.txt?share_token=invalid-token`,
+      undefined,
+      { authenticated: false },
+    );
+    expect(invalidShareFile.status).toBe(404);
+
     const otherMemo = await createMemo("not shared");
     const otherFormData = new FormData();
     otherFormData.set("memo", otherMemo.name);
@@ -778,6 +832,13 @@ describe("FlareMo Worker API", () => {
       `http://flaremo.test/api/public/shares/${share.token}/attachments/${otherAttachment.id}/blob`,
     );
     expect(forbiddenBlob.status).toBe(404);
+
+    const forbiddenMemosWebFile = await fetchApp(
+      `http://flaremo.test/file/${otherAttachment.name}/private.txt?share_token=${encodeURIComponent(share.token)}`,
+      undefined,
+      { authenticated: false },
+    );
+    expect(forbiddenMemosWebFile.status).toBe(404);
 
     await json(
       await fetchApp(`http://flaremo.test/api/v1/${memo.name}`, {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -27,6 +27,7 @@ import {
   isLegacyWireRequest,
   memosCurrentApi,
 } from "./routes/memos-current-api";
+import { memosFileApi } from "./routes/memos-file-api";
 import { memosSocialApi } from "./routes/memos-social-api";
 import { memosSseApi } from "./routes/memos-sse";
 import { publicApi } from "./routes/public-api";
@@ -108,6 +109,7 @@ app.all("/api/auth/*", (c) => createFlareMoAuth(c.env).handler(c.req.raw));
 app.route("/api/app/account", accountApi);
 app.route("/api/app", appApi);
 app.route("/api/public", publicApi);
+app.route("/file", memosFileApi);
 app.route("/mcp", mcpStreamableApi);
 app.route("/", memosConnectApi);
 app.route("/", memosSseApi);

--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -490,6 +490,7 @@ describe("Memos-compatible API contract", () => {
       paths: {
         "/api/v1/auth/signin": expect.any(Object),
         "/api/v1/memos": expect.any(Object),
+        "/file/attachments/{attachment}/{filename}": expect.any(Object),
         "/memos.api.v1.MemoService/GetMemoByShare": expect.any(Object),
         "/memos.api.v1.AttachmentService/ListAttachments": expect.any(Object),
         "/memos.api.v1.InstanceService/GetInstanceProfile": expect.any(Object),

--- a/apps/worker/src/memos-transport.test.ts
+++ b/apps/worker/src/memos-transport.test.ts
@@ -364,6 +364,76 @@ describe("Memos native auth and transport boundaries", () => {
       expect.objectContaining({ name: attachmentBody.name }),
     ]);
 
+    const secondAttachment = await request("/api/v1/attachments", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        attachment: {
+          filename: "second-connect.txt",
+          content: "c2Vjb25k",
+          type: "text/plain",
+          memo: created.name,
+        },
+      }),
+    });
+    expect(secondAttachment.status).toBe(200);
+    const secondAttachmentBody = (await secondAttachment.json()) as {
+      name: string;
+    };
+
+    const firstAttachmentPage = await connectService(
+      "AttachmentService",
+      "ListAttachments",
+      { pageSize: 1, orderBy: "filename asc" },
+    );
+    expect(firstAttachmentPage.attachments).toHaveLength(1);
+    expect(firstAttachmentPage.totalSize).toBeGreaterThanOrEqual(2);
+    expect(firstAttachmentPage.nextPageToken).toEqual(expect.any(String));
+
+    const secondAttachmentPage = await connectService(
+      "AttachmentService",
+      "ListAttachments",
+      {
+        pageSize: 1,
+        orderBy: "filename asc",
+        pageToken: firstAttachmentPage.nextPageToken,
+      },
+    );
+    expect(secondAttachmentPage.attachments).toHaveLength(1);
+    expect(secondAttachmentPage.nextPageToken).toBeUndefined();
+    expect(secondAttachmentPage.attachments[0]?.name).toBe(
+      secondAttachmentBody.name,
+    );
+
+    const mismatchedAttachmentToken = await request(
+      "/memos.api.v1.AttachmentService/ListAttachments",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          pageSize: 1,
+          orderBy: "create_time desc",
+          pageToken: firstAttachmentPage.nextPageToken,
+        }),
+      },
+    );
+    expect(mismatchedAttachmentToken.status).toBe(400);
+
+    const filteredAttachments = await connectService(
+      "AttachmentService",
+      "ListAttachments",
+      { filter: 'filename.contains("second-connect")' },
+    );
+    expect(filteredAttachments.attachments).toEqual([
+      expect.objectContaining({ name: secondAttachmentBody.name }),
+    ]);
+
     const comment = await connect("CreateMemoComment", {
       name: created.name,
       comment: { content: "Connect comment" },

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -24,7 +24,7 @@ import {
   getShortcut,
   getStoredSetting,
   hardDeleteMemo,
-  listAttachments,
+  listAttachmentsPage,
   listMemoAttachments,
   listMemoAttachmentsForViewer,
   listMemoComments,
@@ -185,7 +185,7 @@ memosConnectApi.post("/:service/:method", async (c) => {
       ].includes(method)
     ) {
       const optionalContext = await getOptionalRequestContext(c);
-      return connectInstanceMethod(
+      return await connectInstanceMethod(
         c,
         optionalContext.user
           ? (optionalContext as ConnectRequestContext)
@@ -208,16 +208,28 @@ memosConnectApi.post("/:service/:method", async (c) => {
       return connectAuthSignOut(c, context, binaryTransport);
     }
     if (service === "memos.api.v1.AttachmentService") {
-      return connectAttachmentMethod(c, context, method, body, binaryTransport);
+      return await connectAttachmentMethod(
+        c,
+        context,
+        method,
+        body,
+        binaryTransport,
+      );
     }
     if (service === "memos.api.v1.UserService") {
-      return connectUserMethod(c, context, method, body, binaryTransport);
+      return await connectUserMethod(c, context, method, body, binaryTransport);
     }
     if (service === "memos.api.v1.InstanceService") {
-      return connectInstanceMethod(c, context, method, body, binaryTransport);
+      return await connectInstanceMethod(
+        c,
+        context,
+        method,
+        body,
+        binaryTransport,
+      );
     }
     if (service === "memos.api.v1.IdentityProviderService") {
-      return connectIdentityProviderMethod(
+      return await connectIdentityProviderMethod(
         c,
         context,
         method,
@@ -235,7 +247,13 @@ memosConnectApi.post("/:service/:method", async (c) => {
       );
     }
     if (service === "memos.api.v1.ShortcutService") {
-      return connectShortcutMethod(c, context, method, body, binaryTransport);
+      return await connectShortcutMethod(
+        c,
+        context,
+        method,
+        body,
+        binaryTransport,
+      );
     }
     if (service !== memoService) {
       return connectErrorForTransport(
@@ -436,16 +454,18 @@ async function connectAttachmentMethod(
       return connectValue(c, currentAttachmentToDto(attachment), transport);
     }
     case "ListAttachments": {
-      const filter = optionalString(body.filter);
-      const memoId = filter ? parseAttachmentMemoFilter(filter) : undefined;
-      const attachments = await listAttachments(context.db, context.user, {
-        memoId,
+      const filter = parseAttachmentFilter(optionalString(body.filter));
+      const result = await listAttachmentsPage(context.db, context.user, {
         pageSize: pageSize(body.pageSize),
+        pageToken: optionalString(body.pageToken),
+        orderBy: optionalString(body.orderBy),
+        filter,
       });
       return connectValue(
         c,
-        currentAttachmentsToListResponse(attachments, {
-          totalSize: attachments.length,
+        currentAttachmentsToListResponse(result.attachments, {
+          nextPageToken: result.nextPageToken,
+          totalSize: result.totalSize,
         }),
         transport,
       );
@@ -1811,14 +1831,34 @@ function attachmentBytes(value: unknown) {
   return new Uint8Array();
 }
 
-function parseAttachmentMemoFilter(value: string) {
-  const match = /^memo\s*(?:==|=)\s*["']([^"']+)["']$/i.exec(value.trim());
-  if (!match?.[1]) {
+function parseAttachmentFilter(value: string | undefined) {
+  if (!value?.trim()) return undefined;
+  const trimmed = value.trim();
+  const contains = /^filename\.contains\(\s*["']([^"']*)["']\s*\)$/i.exec(
+    trimmed,
+  );
+  if (contains?.[1] !== undefined) {
+    return { filenameContains: contains[1] };
+  }
+  const equality = /^([a-z_]+)\s*(?:==|=)\s*["']([^"']*)["']$/i.exec(trimmed);
+  if (!equality?.[1] || equality[2] === undefined) {
     throw new ConnectInputError(
-      'Attachment filter only supports memo == "memos/{id}"',
+      'Attachment filter supports memo == "memos/{id}", filename == "...", filename.contains("..."), or mime_type == "..."',
     );
   }
-  return match[1];
+  const [, field, valuePart] = equality;
+  switch (field.toLowerCase()) {
+    case "memo":
+      return { memoId: valuePart };
+    case "filename":
+      return { filenameEquals: valuePart };
+    case "mime_type":
+      return { contentType: valuePart };
+    default:
+      throw new ConnectInputError(
+        "Attachment filter field is not supported by FlareMo",
+      );
+  }
 }
 
 function fieldMaskPaths(value: unknown) {

--- a/apps/worker/src/routes/memos-file-api.ts
+++ b/apps/worker/src/routes/memos-file-api.ts
@@ -1,0 +1,73 @@
+import { createDb } from "@flaremo/db";
+import { getAttachmentById, getPublicShareByToken } from "@flaremo/domain";
+import { type Context, Hono } from "hono";
+import { attachmentObjectResponse } from "../attachment-http";
+import { getRequestContext, type HonoBindings } from "../context";
+import { jsonError } from "../http";
+
+/**
+ * Memos Web's attachment URL is not an API resource URL. The official Web
+ * client builds `/file/{attachment.name}/{attachment.filename}` directly,
+ * so keep this small compatibility bridge separate from `/api/v1`.
+ *
+ * The filename is only a URL-shape compatibility parameter. Object lookup is
+ * always by the resource name and the authenticated/share-scoped owner; a
+ * caller can never select an R2 key by supplying a path fragment.
+ */
+export const memosFileApi = new Hono<HonoBindings>();
+
+memosFileApi.get("/attachments/:attachment/:filename", async (c) => {
+  try {
+    const attachmentName = normalizeAttachmentName(c.req.param("attachment"));
+    const shareToken = c.req.query("share_token");
+
+    if (shareToken) {
+      const db = createDb(c.env.DB);
+      const share = await getPublicShareByToken(db, shareToken);
+      const attachment = await getAttachmentById(
+        db,
+        share.user,
+        attachmentName,
+      );
+      if (attachment.memoId !== share.memo.id) {
+        return c.json({ error: { message: "Attachment not found" } }, 404);
+      }
+      return serveAttachment(c, attachment, "public, max-age=3600");
+    }
+
+    const context = await getRequestContext(c);
+    const attachment = await getAttachmentById(
+      context.db,
+      context.user,
+      attachmentName,
+    );
+    return serveAttachment(c, attachment, "private, max-age=3600");
+  } catch (error) {
+    return jsonError(c, error);
+  }
+});
+
+async function serveAttachment(
+  c: Context<HonoBindings>,
+  attachment: Awaited<ReturnType<typeof getAttachmentById>>,
+  cacheControl: string,
+) {
+  const response = await attachmentObjectResponse({
+    attachment,
+    bucket: c.env.ATTACHMENTS,
+    cacheControl,
+    inlineRequested:
+      c.req.query("thumbnail") === "true" ||
+      c.req.query("preview") === "1" ||
+      c.req.query("disposition") === "inline",
+    request: c.req.raw,
+  });
+  if (!response) {
+    return c.json({ error: { message: "Attachment object not found" } }, 404);
+  }
+  return response;
+}
+
+function normalizeAttachmentName(value: string) {
+  return value.startsWith("attachments/") ? value : `attachments/${value}`;
+}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -277,6 +277,7 @@ curl "$FLAREMO_URL/mcp" \
 
 - `/share/*`
 - `/api/public/shares/*`
+- `/file/*`（只为带 `share_token` 的公开附件 URL 提供外层 bypass；无 token 时仍由 FlareMo 应用层认证）
 - `/assets/*`
 
 建议做法：
@@ -285,9 +286,10 @@ curl "$FLAREMO_URL/mcp" \
 | --- | --- | --- |
 | `/share/*` | `Bypass` | `Everyone` |
 | `/api/public/shares/*` | `Bypass` | `Everyone` |
+| `/file/*` | `Bypass` | `Everyone` |
 | `/assets/*` | `Bypass` | `Everyone` |
 
-只 bypass 这些公开路径，不要 bypass `/api/auth/*`、`/api/app/*`、`/api/v1/*`、`/openapi.json` 或根路径。`Bypass` 会跳过 Access 强制认证，但不会跳过 Better Auth、PAT 或 share token 校验；需要认证和审计的机器请求应使用 `Service Auth`，不要用 `Bypass`。
+只 bypass 这些公开路径，不要 bypass `/api/auth/*`、`/api/app/*`、`/api/v1/*`、`/openapi.json` 或根路径。`/file/*` 同时承载 Memos Web 的私有附件 URL 和带 `share_token` 的公开 URL；如果对它做 Bypass，Worker 仍必须在无 token 分支要求 Better Auth cookie/session bearer、native access JWT 或 PAT，在带 token 分支严格校验 share token、过期时间、撤销状态、memo 状态和附件归属。`Bypass` 会跳过 Access 强制认证，但不会跳过这些 FlareMo 应用层校验；需要认证和审计的机器请求应使用 `Service Auth`，不要用 `Bypass`。
 
 Bypass 只跳过 Cloudflare Access，不跳过 FlareMo 的 share token、过期时间和 memo 状态校验。归档、回收站、删除或过期的分享仍应由 FlareMo 返回不可访问。
 
@@ -322,7 +324,7 @@ curl -I "$FLAREMO_URL/api/public/shares/not-a-real-token"
 - 已完成一次性 owner bootstrap，成功登录，并创建至少一个需要的 PAT。
 - 脚本、MCP 和 Memos-compatible 客户端使用 `Service Auth` policy、Access Service Token 和 FlareMo PAT。
 - `Client Secret` 没有写入仓库、issue、PR 或公开日志。
-- `/share/*`、`/api/public/shares/*`、`/assets/*` 有明确 `Bypass` policy。
+- `/share/*`、`/api/public/shares/*`、`/file/*`、`/assets/*` 有明确 `Bypass` policy；`/file/*` 的应用层 private/share 分支仍然 fail-closed。
 - 没有 bypass 根路径、`/api/auth/*`、`/api/app/*`、`/api/v1/*` 或 `/openapi.json`。
 - 关闭 Access 前，已在隔离环境验证 native cookie session、PAT、revoke、公开分享和无凭据 `401`。
 

--- a/docs/en/deploy.md
+++ b/docs/en/deploy.md
@@ -139,6 +139,7 @@ Public shares need unauthenticated access to the share page and shared attachmen
 
 - `/share/*`
 - `/api/public/shares/*`
+- `/file/*` (for public attachment URLs carrying a valid `share_token`; private requests remain protected by FlareMo)
 - `/assets/*`
 
 Recommended policies:
@@ -147,9 +148,10 @@ Recommended policies:
 | --- | --- | --- |
 | `/share/*` | `Bypass` | `Everyone` |
 | `/api/public/shares/*` | `Bypass` | `Everyone` |
+| `/file/*` | `Bypass` | `Everyone` |
 | `/assets/*` | `Bypass` | `Everyone` |
 
-Only bypass these public paths. Do not bypass `/api/v1/*`, `/openapi.json`, or the root application. `Bypass` disables Access enforcement and Access logging for matching requests; machine clients that need authentication and auditability should use `Service Auth`.
+Only bypass these public paths. Do not bypass `/api/v1/*`, `/openapi.json`, or the root application. `/file/*` carries both Memos Web private attachment URLs and public URLs with a `share_token`; when Access is bypassed, the Worker still requires a Better Auth cookie/session bearer, native access JWT, or PAT for the private branch and validates the share token, expiry, revocation, memo state, and attachment ownership for the public branch. `Bypass` disables Access enforcement and Access logging for matching requests; machine clients that need authentication and auditability should use `Service Auth`.
 
 The bypass only skips Cloudflare Access. FlareMo still validates share token, expiration time, and memo state. Archived, trashed, deleted, or expired shares must remain inaccessible.
 
@@ -182,7 +184,7 @@ curl -I "$FLAREMO_URL/api/public/shares/not-a-real-token"
 - Human access uses an `Allow` policy scoped to allowed users only.
 - Scripts, MCP, and Memos-compatible clients use a FlareMo `memos_pat_` token, plus a `Service Auth` policy and Access Service Token when Access remains enabled.
 - The `Client Secret` is not committed to the repository, issues, PRs, or public logs.
-- `/share/*`, `/api/public/shares/*`, and `/assets/*` have explicit `Bypass` policies.
+- `/share/*`, `/api/public/shares/*`, `/file/*`, and `/assets/*` have explicit `Bypass` policies; `/file/*` remains fail-closed at the FlareMo application layer.
 - The root application, `/api/v1/*`, and `/openapi.json` are not bypassed.
 - Access is not treated as FlareMo application identity; private API requests still use a Better Auth cookie/session bearer or `memos_pat_` PAT.
 

--- a/docs/en/memos-compatibility.md
+++ b/docs/en/memos-compatibility.md
@@ -44,8 +44,8 @@ Better Auth is the application authentication source of truth. Cloudflare Access
 | Shortcuts | Implemented subset | `GET/POST /api/v1/users/{user}/shortcuts` and `GET/PATCH/DELETE /api/v1/users/{user}/shortcuts/{shortcut}`; supports CEL validation, `validateOnly`, and `updateMask`. |
 | Memo shares | Implemented subset | `GET/POST /api/v1/memos/{memo}/shares` and `DELETE /api/v1/memos/{memo}/shares/{share}`; current share names use `memos/{id}/shares/{token}`. |
 | Anonymous share read | Implemented | `GET /api/v1/shares/{share_id}`, still guarded by share token, expiry, and memo state. |
-| Attachment resources | Implemented subset | `GET/POST /api/v1/attachments` and `GET/PATCH/DELETE /api/v1/attachments/{attachment}`; supports the current `{ attachment: {...} }` wrapper and explicitly rejects `attachmentId`. |
-| Attachment list | Implemented subset | Returns `attachments` and an optional `nextPageToken`; protobuf JSON `size` is emitted as a decimal string. |
+| Attachment resources | Implemented subset | `GET/POST /api/v1/attachments` and `GET/PATCH/DELETE /api/v1/attachments/{attachment}`; supports the current `{ attachment: {...} }` wrapper and explicitly rejects `attachmentId`. The official Memos Web `/file/attachments/{id}/{filename}` private/share read bridge is also implemented; arbitrary `externalLink` persistence, thumbnails, and motion conversion are not. |
+| Attachment list | Implemented subset | Connect `ListAttachments` returns `attachments`, `totalSize`, and an optional `nextPageToken`; it supports bounded `create_time`/`filename` ordering and filename/mime/memo filters. Protobuf JSON `size` is emitted as a decimal string. |
 | PAT resources | Implemented foundation | `GET/POST /api/v1/users/{user}/personalAccessTokens` and `DELETE /api/v1/users/{user}/personalAccessTokens/{token}`. |
 | Standard errors | Implemented | Current errors use `{ code, message, details }` rather than exposing internal FlareMo exceptions. |
 | Current OpenAPI | Implemented | `GET /openapi.json`, and authenticated `GET /api/v1/openapi.json`, describe current/legacy negotiation, native JWT/refresh cookie, social routes, SSE, the Connect JSON subset, and `/mcp`. |
@@ -89,7 +89,8 @@ The endpoint is currently stateless JSON. SSE, MCP session state, the complete m
 Do not describe the following as complete compatibility:
 
 - Complete Memos Server parity or complete Connect/gRPC parity.
-- Full CEL, complex pagination/ordering, or complete attachment filter/order/page-token semantics.
+- Full CEL, complex pagination/ordering, or complete attachment filter/order/page-token semantics; attachment list support is a bounded subset.
+- The Memos Web `/file/attachments/{id}/{filename}` bridge supports private Better Auth/PAT/native-JWT reads and `share_token`-scoped public reads. `thumbnail=true` currently returns the original object; motion-media conversion and arbitrary `externalLink` persistence are not implemented.
 - Current attachment batch delete or Attachment updates beyond the memo-binding subset.
 - Complete upstream service/wire parity for comments, reactions, and shortcuts, plus notifications and admin/instance surfaces.
 - A complete SSE event hub/replay protocol and stateful MCP sessions.

--- a/docs/memos-compatibility.md
+++ b/docs/memos-compatibility.md
@@ -63,7 +63,7 @@ Better Auth 是应用层认证事实源，Cloudflare Access 只能作为可选�
 | memo 创建、列表、详情、更新、删除 | 已实现 | 已测试 | `POST/GET /api/v1/memos`、`GET/PATCH/DELETE /api/v1/memos/{memo}`；支持 current `{ memo: {...} }` wrapper、有限 `pageSize`、`pageToken`、`orderBy`、filter 和 `updateMask`。 |
 | memo 字段、状态、可见性、tags、property、location | 已实现 | 已测试 | 已做 DTO/枚举映射；FlareMo 的 trash/deleted 与 current Memos 状态模型并非完全相同。 |
 | memo 附件、relations、comments、reactions | 已实现 | 已测试 | `memos/{memo}/attachments`、`relations`、`comments`、`reactions` 的 current 子集；完整上游资源语义仍未证明。 |
-| attachment 资源 | 已实现 | 已测试 | `GET/POST /api/v1/attachments`、`GET/PATCH/DELETE /api/v1/attachments/{attachment}`；支持 current wrapper、R2 blob 和 memo 绑定，客户端指定 `attachmentId` 仍明确拒绝。 |
+| attachment 资源 | 已实现子集 | 已测试 | `GET/POST /api/v1/attachments`、`GET/PATCH/DELETE /api/v1/attachments/{attachment}`；支持 current wrapper、R2 blob 和 memo 绑定，客户端指定 `attachmentId` 仍明确拒绝。官方 Memos Web 预期的 `/file/attachments/{id}/{filename}` 私有/分享读取也已接入；任意 `externalLink` 持久化、缩略图和 motion 转换仍未实现。 |
 | shortcuts | 已实现 | 已测试 | `GET/POST /api/v1/users/{user}/shortcuts` 及单项 CRUD；覆盖有限 CEL 校验、`validateOnly` 和 `updateMask`。 |
 | memo shares | 已实现 | 已测试 | `GET/POST /api/v1/memos/{memo}/shares`、`DELETE`；匿名读取仍由 share token、过期时间和 memo 状态控制。 |
 | current PAT 资源 | 已实现 | 已测试 | `/api/v1/users/{user}/personalAccessTokens` 的 list/create/revoke；PAT 不能反过来管理 PAT。 |
@@ -103,7 +103,7 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 | `MemoService` | `CreateMemo`、`ListMemos`、`GetMemo`、`UpdateMemo`、`DeleteMemo`；附件 binding；relations；comments；reactions；shares；`GetMemoByShare`；旧 `GetSharedMemo` alias；`GetLinkMetadata`、`BatchGetLinkMetadata` | 已实现子集 | 已测试 | JSON unary 和 generated protobuf/gRPC-Web framing 有覆盖；canonical `GetMemoByShare` 已有 JSON 测试。普通 memo RPC 仍需应用凭据。 |
 | `AuthService` | `GetCurrentUser`、`SignIn`、`RefreshToken`、`SignOut` | 已实现子集 | 已测（generated binary 子集） | Better Auth 是身份事实源；native JWT/refresh 是 facade，不是上游 token 的字节级 parity；官方 generated client 已完成列出方法的 binary roundtrip。 |
 | `ShortcutService` | `ListShortcuts`、`GetShortcut`、`CreateShortcut`、`UpdateShortcut`、`DeleteShortcut` | 已实现 | 已测试 | 有 JSON、gRPC-Web framing 和 social contract 覆盖；filter 仍是有限 CEL。 |
-| `AttachmentService` | `CreateAttachment`、`ListAttachments`、`GetAttachment`、`UpdateAttachment`、`DeleteAttachment`、`BatchDeleteAttachments` | 已实现子集 | 已测（generated binary 子集） | 官方 generated client 已完成 create/list/get/delete；update/batch delete、完整字段和上传语义仍未完成。只允许有限 memo 字段更新；外链、客户端指定 `attachmentId` 等能力明确拒绝。 |
+| `AttachmentService` | `CreateAttachment`、`ListAttachments`、`GetAttachment`、`UpdateAttachment`、`DeleteAttachment`、`BatchDeleteAttachments` | 已实现子集 | 已测（generated binary 子集） | 官方 generated client 已完成 create/list/get/delete；`ListAttachments` 支持有限 `pageToken`、`orderBy` 和 filename/mime/memo 过滤；update/batch delete、完整字段和上传语义仍未完成。只允许有限 memo 字段更新；外链、客户端指定 `attachmentId` 等能力明确拒绝。 |
 | `UserService` | current user list/batch/get/update；stats；user settings；空的 linked identities/webhooks/notifications list；PAT list/create/delete | 已实现子集 | 已测（generated binary 子集） | 官方 generated client 已完成 list/get/stats/settings/notifications/webhooks 的列出方法；单用户生命周期、多用户语义、完整 settings oneof 和 mutation 方法仍未完成。 |
 | `InstanceService` | `GetInstanceProfile`、`GetInstanceSetting`、`BatchGetInstanceSettings`、`UpdateInstanceSetting`、`GetInstanceStats`；`TestInstanceEmailSetting` 明确返回 `501` | 部分实现 | 已测（generated binary 子集） | 官方 generated client 已完成 profile、batch settings、stats；Storage/Tags/AI 等 setting oneof、更新和 email delivery 未完成。 |
 | `IdentityProviderService` | `ListIdentityProviders` 返回空列表 | 仅有限实现 | 已测试（空列表） | 没有 OAuth2 provider CRUD 或 linked identity 流程；其余方法明确返回 `501`。 |
@@ -120,7 +120,8 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 
 - Worker generated codec 已对 `InstanceSetting`/`UserSetting` oneof、notification payload、attachment `motionMedia` / `externalLink` 等字段做 focused roundtrip；这些字段对应的完整业务持久化和 handler 语义仍未完成。
 - memo create/update 的完整时间、initial attachments/relations/location、完整 update mask、pagination token，以及 comments/reactions 的完整 response schema。
-- Attachment update/batch delete、User/Instance/IdentityProvider 的未覆盖方法和完整 generated-client schema roundtrip；本次 smoke 只覆盖列出的 unary 子集。
+- Attachment update/batch delete、User/Instance/IdentityProvider 的未覆盖方法和完整 generated-client schema roundtrip；本次 smoke 只覆盖列出的 unary 子集。Attachment 列表的分页/排序/过滤是 FlareMo 的有限子集，不是完整 CEL parity。
+- 官方 Memos Web 的 `/file/attachments/{id}/{filename}` 文件 URL bridge 已实现，支持 Better Auth/PAT/native access JWT 私有读取和 `share_token` 绑定的公开读取；`thumbnail=true` 目前返回原始对象，motion media 转换和任意 `externalLink` 持久化仍未完成。
 - 原生 gRPC HTTP/2、完整 metadata/trailer、gRPC-Web trailer frame、压缩、streaming RPC、取消和 deadline 语义。
 - 官方 Memos Web 的真实浏览器请求、第三方客户端连接，以及 native HTTP/2 gRPC 的真实客户端验证。
 

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -51,6 +51,7 @@ Access Service Token 不会自动变成 FlareMo 用户 session；不能发送应
 | FlareMo SSE consumer | EventSource / SSE client | 已实现子集 | `memos-transport.test.ts` 覆盖 authenticated stream、connected/heartbeat、`Last-Event-ID` replay、visibility 和 cancellation。 | D1 polling 实现，未做第三方 EventSource smoke。 |
 | FlareMo Telegram Worker example | Telegram webhook adapter | 已实现示例 | `apps/telegram-bot/src/index.test.ts` 覆盖 PAT-only、可选 Access headers、secret 校验和 fail-closed。 | 不是真实 Telegram API 或生产 FlareMo smoke。 |
 | public share reader | 浏览器 / curl | 已实现 | `memos-compatibility.test.ts`、`api.test.ts` 覆盖 share token 隔离、撤销、过期/状态和附件读取。 | 仍需在实际部署域名上验证 Access bypass 规则；不绕过 FlareMo share 校验。 |
+| Memos Web attachment file URL bridge | Memos Web `/file/attachments/{id}/{filename}` | 已实现子集 | `api.test.ts` 覆盖私有 cookie、Range/ETag、错误 filename 不改变对象定位，以及带 `share_token` 的公共读取和跨 memo 隔离。 | 只证明 FlareMo 的文件 URL contract；thumbnail 原图 fallback、motion media、官方 Web 全量行为和生产 Access path policy 仍未实测。 |
 | 官方 Memos generated Connect client | `protoc-gen-es` + `@connectrpc/connect-web` binary unary client | 已实测子集 | 隔离本地 Wrangler E2E：覆盖 Auth、Memo/social、Attachment、Shortcut、User、Instance 列出的 unary 方法，并由官方 generated decoder 解码响应；同一 client 对生产域名匿名 `MemoService/ListMemos` 也成功解码。 | 生产只覆盖一个匿名 unary 方法；不是官方 Web 全量行为或完整 Memos Server parity。 |
 
 ## 官方 Memos generated Connect client：local 与 production anonymous smoke
@@ -70,7 +71,7 @@ local 证据说明 pinned generated client 能把列出的 Connect binary unary 
 
 ## 官方 Memos Web：仍仅静态审计
 
-当前本地参考快照的官方 Web 代码仍只做过协议面静态审计。审计确认官方 Web 使用 8 类 generated Connect client：Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI；`connect.ts` 选择 binary format，并使用 `credentials: include`，认证生命周期包含 bearer access token、refresh cookie、Unauthenticated 后 refresh/retry。没有把官方 Web 本身配置到 FlareMo 的真实浏览器请求，因此不能把上面的 generated client smoke 扩大成“官方 Web 已兼容”。
+当前本地参考快照的官方 Web 代码仍只做过协议面静态审计。审计确认官方 Web 使用 8 类 generated Connect client：Auth、Memo、Shortcut、Attachment、User、Instance、IdentityProvider、AI；`connect.ts` 选择 binary format，并使用 `credentials: include`，认证生命周期包含 bearer access token、refresh cookie、Unauthenticated 后 refresh/retry。FlareMo 现在已经提供官方 Web 预期的 `/file/attachments/{id}/{filename}` 私有文件 URL 和 `share_token` 公共文件 URL bridge，但没有把官方 Web 本身配置到 FlareMo 的真实浏览器请求，因此不能把 generated client 或文件 bridge 扩大成“官方 Web 已兼容”。
 
 ## 第三方客户端矩阵
 
@@ -96,7 +97,7 @@ local 证据说明 pinned generated client 能把列出的 Connect binary unary 
 - `AIService/Transcribe`、Instance email test、OAuth2/IdentityProvider CRUD、User create/delete、linked identity CRUD、webhook CRUD、notification update/delete 当前明确未实现或返回 `501`。
 - User/Instance/Attachment 的已列出方法已经有一次 pinned generated-client binary roundtrip，但这不覆盖全部字段、全部方法、生产域名或官方 Web；不能把它写成完整 binary parity。
 - public memo read 已接入 current REST 和 Connect 的明确 viewer policy：匿名只读 `PUBLIC + NORMAL`，private/protected/archived/trashed/deleted 不可见；comments、relations、attachments、reactions 会先检查 parent/read visibility。公开 share 仍是独立 token 入口，不等于普通 memo public ACL。
-- 没有完整 CEL、复杂分页/排序、全部 protobuf 字段、metadata/trailer、压缩、streaming、gRPC-Web trailer frame 或原生 HTTP/2 gRPC parity。
+- 没有完整 CEL、复杂分页/排序、全部 protobuf 字段、metadata/trailer、压缩、streaming、gRPC-Web trailer frame 或原生 HTTP/2 gRPC parity。Attachment list 的 page token/order/filter 只是有限子集；`thumbnail=true` 暂时返回原始对象，motion media 和任意 `externalLink` 持久化仍未完成。
 - SSE 是 D1 outbox/polling/replay，不是上游 SSEHub；没有完整事件集、retention/pruning 和第三方 EventSource 实测。
 - 根 `/mcp` 没有有状态 MCP session，不承诺 SSE transport 或所有 MCP client 的 method surface。
 

--- a/packages/contracts/src/openapi-current.ts
+++ b/packages/contracts/src/openapi-current.ts
@@ -51,6 +51,15 @@ const attachmentName = {
   description: "An attachment resource name or attachment id.",
 };
 
+const attachmentFilename = {
+  name: "filename",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+  description:
+    "The filename segment used by the official Memos Web URL; object lookup uses the attachment resource name.",
+};
+
 const userName = {
   name: "user",
   in: "path",
@@ -850,6 +859,48 @@ export function createCurrentOpenApiDocument() {
           tags: ["Attachments"],
           parameters: [attachmentName],
           responses: { "200": emptyResponse("Deleted.") },
+        }),
+      },
+      "/file/attachments/{attachment}/{filename}": {
+        get: secured({
+          operationId: "getMemosAttachmentFile",
+          summary: "Serve a Memos Web-compatible attachment file URL",
+          description:
+            "Private requests require Better Auth/PAT/native access authentication. An unauthenticated request is allowed only when share_token identifies a valid, unexpired share for the attachment's memo. The filename is a compatibility path segment and is not used to select an R2 object.",
+          tags: ["Attachments"],
+          security: optionalReadSecurity,
+          parameters: [
+            attachmentName,
+            attachmentFilename,
+            {
+              name: "share_token",
+              in: "query",
+              schema: { type: "string" },
+              description:
+                "Optional public-share token used by the Memos Web share view.",
+            },
+            {
+              name: "thumbnail",
+              in: "query",
+              schema: { type: "boolean" },
+              description:
+                "Currently returns the original object; image thumbnail generation is not implemented.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Attachment bytes.",
+              content: { "application/octet-stream": binaryMessage },
+            },
+            "206": {
+              description:
+                "Partial attachment bytes for a valid Range request.",
+              content: { "application/octet-stream": binaryMessage },
+            },
+            "304": emptyResponse("Attachment has not changed."),
+            "401": response("Authentication required.", error),
+            "404": response("Attachment or share not found.", error),
+          },
         }),
       },
       "/api/v1/users": {

--- a/packages/domain/src/attachments.ts
+++ b/packages/domain/src/attachments.ts
@@ -1,6 +1,18 @@
 import type { AttachmentRow, FlareMoDb, UserRow } from "@flaremo/db";
 import { attachments } from "@flaremo/db";
-import { and, desc, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
 import { createResourceId, parseResourceName } from "./ids";
 import { getMemoById, getMemoByIdForViewer } from "./memos";
@@ -20,6 +32,32 @@ export type CreateAttachmentMetadataInput = {
 export type ListAttachmentsInput = {
   memoId?: string;
   pageSize?: number;
+};
+
+export type AttachmentListFilter = {
+  memoId?: string;
+  filenameEquals?: string;
+  filenameContains?: string;
+  contentType?: string;
+};
+
+export type ListAttachmentsPageInput = ListAttachmentsInput & {
+  pageToken?: string;
+  filter?: AttachmentListFilter;
+  orderBy?: string;
+};
+
+export type AttachmentListResult = {
+  attachments: AttachmentRow[];
+  nextPageToken?: string;
+  totalSize: number;
+};
+
+type AttachmentCursor = {
+  id: string;
+  sortValue: string;
+  orderBy: string;
+  scopeKey: string;
 };
 
 export async function createAttachmentMetadata(
@@ -94,6 +132,116 @@ export async function listAttachments(
     .where(and(...filters))
     .orderBy(desc(attachments.createdAt))
     .limit(input.pageSize ?? 50);
+}
+
+/**
+ * List attachments using the upstream AttachmentService cursor contract.
+ *
+ * The current Memos service accepts rich CEL filters, but accepting arbitrary
+ * expressions in a Worker would make both cost and authorization behavior
+ * difficult to bound. The route parses a deliberately small filter subset
+ * into this typed input, while this domain function owns the user/deleted/R2
+ * visibility boundary and the stable cursor semantics.
+ */
+export async function listAttachmentsPage(
+  db: FlareMoDb,
+  user: UserRow,
+  input: ListAttachmentsPageInput = {},
+): Promise<AttachmentListResult> {
+  const pageSize = normalizeAttachmentPageSize(input.pageSize);
+  const orderBy = normalizeAttachmentOrderBy(input.orderBy);
+  const memoId = input.memoId
+    ? parseResourceName(input.memoId, "memos")
+    : undefined;
+  const filterMemoId = input.filter?.memoId
+    ? parseResourceName(input.filter.memoId, "memos")
+    : undefined;
+  if (memoId && filterMemoId && memoId !== filterMemoId) {
+    throw new ValidationError("Attachment memo filters must match");
+  }
+  const scopeKey = JSON.stringify({
+    memoId: memoId ?? filterMemoId ?? null,
+    filter: input.filter ?? null,
+  });
+  const cursor = input.pageToken
+    ? decodeAttachmentPageToken(input.pageToken, orderBy, scopeKey)
+    : undefined;
+  const filters = [
+    eq(attachments.userId, user.id),
+    isNull(attachments.deletedAt),
+    eq(attachments.state, "ready"),
+  ];
+  const scopedMemoId = memoId ?? filterMemoId;
+  if (scopedMemoId) filters.push(eq(attachments.memoId, scopedMemoId));
+  if (input.filter?.filenameEquals !== undefined) {
+    filters.push(eq(attachments.filename, input.filter.filenameEquals));
+  }
+  if (input.filter?.filenameContains !== undefined) {
+    filters.push(
+      sql`${attachments.filename} LIKE ${`%${escapeAttachmentLike(input.filter.filenameContains)}%`} ESCAPE '\\'`,
+    );
+  }
+  if (input.filter?.contentType !== undefined) {
+    filters.push(eq(attachments.contentType, input.filter.contentType));
+  }
+
+  const sortColumn = orderBy.startsWith("filename")
+    ? attachments.filename
+    : attachments.createdAt;
+  const direction = orderBy.endsWith(" asc") ? "asc" : "desc";
+  const baseWhere = and(...filters);
+  if (cursor) {
+    const cursorFilter =
+      direction === "asc"
+        ? or(
+            gt(sortColumn, cursor.sortValue),
+            and(
+              eq(sortColumn, cursor.sortValue),
+              gt(attachments.id, cursor.id),
+            ),
+          )
+        : or(
+            lt(sortColumn, cursor.sortValue),
+            and(
+              eq(sortColumn, cursor.sortValue),
+              lt(attachments.id, cursor.id),
+            ),
+          );
+    if (cursorFilter) filters.push(cursorFilter);
+  }
+
+  const [rows, total] = await Promise.all([
+    db
+      .select()
+      .from(attachments)
+      .where(and(...filters))
+      .orderBy(
+        direction === "asc" ? asc(sortColumn) : desc(sortColumn),
+        direction === "asc" ? asc(attachments.id) : desc(attachments.id),
+      )
+      .limit(pageSize + 1),
+    db
+      .select({ count: count(attachments.id) })
+      .from(attachments)
+      .where(baseWhere)
+      .get(),
+  ]);
+  const page = rows.slice(0, pageSize);
+  const next = rows.length > pageSize ? page.at(-1) : undefined;
+  return {
+    attachments: page,
+    totalSize: Number(total?.count ?? 0),
+    nextPageToken: next
+      ? encodeAttachmentPageToken({
+          id: next.id,
+          sortValue: orderBy.startsWith("filename")
+            ? next.filename
+            : next.createdAt,
+          orderBy,
+          scopeKey,
+        })
+      : undefined,
+  };
 }
 
 export async function listMemoAttachments(
@@ -424,4 +572,62 @@ export async function finalizeAttachmentCleanup(db: FlareMoDb, id: string) {
     .update(attachments)
     .set({ deletedAt: now, updatedAt: now, memoId: null, state: "deleting" })
     .where(eq(attachments.id, parseResourceName(id, "attachments")));
+}
+
+function normalizeAttachmentPageSize(value: number | undefined) {
+  if (value === undefined) return 50;
+  if (!Number.isInteger(value) || value < 1) {
+    throw new ValidationError(
+      "Attachment page size must be a positive integer",
+    );
+  }
+  return Math.min(value, 1_000);
+}
+
+function normalizeAttachmentOrderBy(value: string | undefined) {
+  const normalized = (
+    value?.trim().toLowerCase() || "create_time desc"
+  ).replace("createtime", "create_time");
+  const [field = "create_time", direction = "desc"] = normalized.split(/\s+/);
+  if (
+    !["create_time", "filename"].includes(field) ||
+    !["asc", "desc"].includes(direction)
+  ) {
+    throw new ValidationError(
+      "Attachment order_by only supports create_time or filename asc/desc",
+    );
+  }
+  return `${field} ${direction}`;
+}
+
+function encodeAttachmentPageToken(cursor: AttachmentCursor) {
+  return btoa(JSON.stringify(cursor));
+}
+
+function decodeAttachmentPageToken(
+  token: string,
+  orderBy: string,
+  scopeKey: string,
+): AttachmentCursor {
+  try {
+    const cursor = JSON.parse(atob(token)) as Partial<AttachmentCursor>;
+    if (
+      typeof cursor.id === "string" &&
+      typeof cursor.sortValue === "string" &&
+      cursor.orderBy === orderBy &&
+      cursor.scopeKey === scopeKey
+    ) {
+      return cursor as AttachmentCursor;
+    }
+  } catch {
+    // Fall through to one stable validation error.
+  }
+  throw new ValidationError("Invalid attachment page token");
+}
+
+function escapeAttachmentLike(value: string) {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
 }


### PR DESCRIPTION
## Summary

- Add the official Memos Web-compatible `/file/attachments/{attachment}/{filename}` bridge for private Better Auth/PAT/native-JWT reads and share-token-scoped public reads.
- Extend Connect `AttachmentService/ListAttachments` with bounded page tokens, total size, ordering, and filename/mime/memo filters.
- Keep R2 lookup server-owned, document the Cloudflare Access `/file/*` boundary, and add contract coverage.

## Compatibility boundary

This advances FlareMo's Memos-compatible surface; it does not claim complete Memos Server parity, arbitrary CEL, thumbnail generation, external-link persistence, or official Web/third-party client full-stack validation.

## Validation

- `pnpm verify`
- `pnpm deploy:dry-run`
- `git diff --cached --check`

No database migration or production data write is included.