### PR TITLE
fix: route attachment files through worker

### DIFF
--- a/docs/agent-deploy.md
+++ b/docs/agent-deploy.md
@@ -8,7 +8,7 @@
 - `pnpm install` 已完成，或 Agent 可以执行它。
 - Wrangler 已登录目标 Cloudflare 账号。
 - `wrangler.jsonc` 里的 D1、R2 binding 指向目标资源。
-- `wrangler.jsonc` 的 Static Assets `run_worker_first` 必须覆盖 `/api/*`、`/mcp`、`/openapi.json` 和 `/memos.api.v1.*`；否则 Connect/gRPC-Web 路径会被静态资源 fallback 接管，返回 405 而不是进入 Worker。
+- `wrangler.jsonc` 的 Static Assets `run_worker_first` 必须覆盖 `/api/*`、`/file/*`、`/mcp`、`/openapi.json` 和 `/memos.api.v1.*`；否则 API、Memos Web 附件文件 URL 或 Connect/gRPC-Web 路径会被静态资源 fallback 接管，返回 SPA HTML 而不是进入 Worker。
 - `wrangler.jsonc` 的 `FLAREMO_PUBLIC_URL` 已设置为生产 canonical origin；需要时设置 `FLAREMO_TRUSTED_ORIGINS`。
 - `BETTER_AUTH_SECRET` 和 `FLAREMO_BOOTSTRAP_SECRET` 已通过 Wrangler secret 或 Cloudflare 控制台配置，且各至少 32 个字符。`FLAREMO_RECOVERY_SECRET` 只在明确批准的 break-glass recovery 窗口临时配置。Agent 不得要求用户把 secret、密码、cookie 或 PAT 粘贴到聊天中。
 - `FLAREMO_SINGLE_USER_EMAIL` 和 `FLAREMO_SINGLE_USER_NAME` 只是既有 `users/owner` domain metadata 的 legacy 公开变量；它们不是 Better Auth 登录身份、用户名、密码或 bootstrap 输入。初始认证身份以部署者在生产 `/setup` 页面提交的值为准。

--- a/docs/en/agent-deploy.md
+++ b/docs/en/agent-deploy.md
@@ -8,6 +8,7 @@ This runbook is for Codex, Claude Code, Cursor Agent, and other command-capable 
 - `pnpm install` has completed, or the agent can run it.
 - Wrangler is logged in to the target Cloudflare account.
 - `wrangler.jsonc` points to the target D1 and R2 resources.
+- `wrangler.jsonc` Static Assets `run_worker_first` covers `/api/*`, `/file/*`, `/mcp`, `/openapi.json`, and `/memos.api.v1.*`; otherwise API, Memos Web attachment URLs, or Connect/gRPC-Web requests can be handled by the SPA fallback instead of the Worker.
 - Application authentication is handled by Better Auth. Cloudflare Access is optional outer policy and does not replace a FlareMo cookie session or `memos_pat_` PAT.
 - `BETTER_AUTH_SECRET` and `FLAREMO_BOOTSTRAP_SECRET` are configured as Wrangler secrets. `FLAREMO_RECOVERY_SECRET` is optional and must only be configured for an approved break-glass recovery window, then rotated or removed.
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,7 +12,13 @@
     "directory": "./apps/web/dist",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*", "/mcp", "/openapi.json", "/memos.api.v1.*"]
+    "run_worker_first": [
+      "/api/*",
+      "/file/*",
+      "/mcp",
+      "/openapi.json",
+      "/memos.api.v1.*"
+    ]
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

- Add `/file/*` to Workers Static Assets `run_worker_first`.
- Prevent the SPA `not_found_handling` fallback from swallowing Memos Web attachment file requests before the Worker can enforce Better Auth/share-token authorization.
- Document the required route coverage in both deployment runbooks.

## Production finding

After PR #56 deployed, an unauthenticated `/file/attachments/...` request returned cached SPA HTML instead of the Worker's `401`. This patch addresses that deployment-layer routing boundary.

## Validation

- `pnpm format:check`
- `pnpm deploy:dry-run`
- `git diff --check`

No database, R2, or secret changes.