### PR TITLE
feat: harden Memos compatibility

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -28,6 +28,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "5.20260708.1",
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-web": "2.1.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0",
     "wrangler": "^4.114.0"

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -86,7 +86,18 @@ app.use(
       }
     },
     credentials: true,
-    allowHeaders: ["content-type", "authorization", "connect-protocol-version"],
+    allowHeaders: [
+      "content-type",
+      "authorization",
+      "accept",
+      "connect-protocol-version",
+      "grpc-accept-encoding",
+      "grpc-encoding",
+      "grpc-timeout",
+      "x-grpc-web",
+      "x-user-agent",
+    ],
+    exposeHeaders: ["grpc-status", "grpc-message", "grpc-status-details-bin"],
     allowMethods: ["POST", "OPTIONS"],
   }),
 );

--- a/apps/worker/src/memos-connect-client.test.ts
+++ b/apps/worker/src/memos-connect-client.test.ts
@@ -1,0 +1,159 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createClient } from "@connectrpc/connect";
+import {
+  createConnectTransport,
+  createGrpcWebTransport,
+} from "@connectrpc/connect-web";
+import { Miniflare } from "miniflare";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import app from "./index";
+import { MemoService } from "./memos-generated/api/v1/memo_service_pb";
+
+let runtime: Miniflare;
+let env: Env;
+let accessToken: string;
+
+const TEST_AUTH_SECRET =
+  "official-connect-client-test-secret-never-used-in-production";
+const TEST_BOOTSTRAP_SECRET =
+  "official-connect-client-bootstrap-never-used-in-production";
+const TEST_PASSWORD = "official-connect-client-password-never-production-123";
+
+describe("official generated Connect clients", () => {
+  beforeEach(async () => {
+    runtime = await createTestRuntime();
+    accessToken = await signIn();
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+  });
+
+  it("roundtrips the pinned MemoService through Connect binary and gRPC-Web", async () => {
+    const fetchWithAuth: typeof fetch = async (input, init) => {
+      const request = new Request(input, init);
+      request.headers.set("authorization", `Bearer ${accessToken}`);
+      return app.fetch(request, env);
+    };
+
+    const connectClient = createClient(
+      MemoService,
+      createConnectTransport({
+        baseUrl: "http://flaremo.test",
+        fetch: fetchWithAuth,
+        useBinaryFormat: true,
+      }),
+    );
+    const grpcWebClient = createClient(
+      MemoService,
+      createGrpcWebTransport({
+        baseUrl: "http://flaremo.test",
+        fetch: fetchWithAuth,
+        useBinaryFormat: true,
+      }),
+    );
+
+    const created = await connectClient.createMemo({
+      memo: { content: "official Connect client memo" },
+    });
+    expect(created.name).toMatch(/^memos\//);
+
+    const connectList = await connectClient.listMemos({ pageSize: 10 });
+    expect(connectList.memos.some((memo) => memo.name === created.name)).toBe(
+      true,
+    );
+
+    const grpcWebMemo = await grpcWebClient.getMemo({ name: created.name });
+    expect(grpcWebMemo).toMatchObject({
+      name: created.name,
+      content: "official Connect client memo",
+    });
+  });
+});
+
+async function createTestRuntime() {
+  const created = new Miniflare({
+    script: "export default { fetch() { return new Response('ok') } }",
+    modules: true,
+    compatibilityDate: "2026-07-10",
+    compatibilityFlags: ["nodejs_compat"],
+    d1Databases: { DB: `flaremo-official-client-${crypto.randomUUID()}` },
+    r2Buckets: {
+      ATTACHMENTS: `flaremo-official-client-attachments-${crypto.randomUUID()}`,
+    },
+  });
+  const db = await created.getD1Database("DB");
+  for (const filename of [
+    "0000_illegal_inhumans.sql",
+    "0001_familiar_morph.sql",
+    "0002_wooden_professor_monster.sql",
+    "0003_equal_maximus.sql",
+    "0004_complex_the_enforcers.sql",
+    "0005_confused_masque.sql",
+    "0006_silent_kylun.sql",
+    "0007_flat_phil_sheldon.sql",
+  ]) {
+    const sql = await readFile(
+      resolve(import.meta.dirname, `../../../migrations/${filename}`),
+      "utf8",
+    );
+    for (const statement of sql
+      .split("--> statement-breakpoint")
+      .map((value) => value.trim())
+      .filter(Boolean)) {
+      await db.prepare(statement).run();
+    }
+  }
+  runtime = created;
+  env = {
+    DB: db,
+    ATTACHMENTS: await created.getR2Bucket("ATTACHMENTS"),
+    ASSETS: {
+      fetch: async () => new Response("asset", { status: 200 }),
+    } as Fetcher,
+    FLAREMO_SINGLE_USER_EMAIL: "owner@example.com",
+    FLAREMO_SINGLE_USER_NAME: "Owner",
+    FLAREMO_PUBLIC_URL: "http://flaremo.test",
+    BETTER_AUTH_SECRET: TEST_AUTH_SECRET,
+    FLAREMO_BOOTSTRAP_SECRET: TEST_BOOTSTRAP_SECRET,
+  } as Env;
+  return created;
+}
+
+async function signIn() {
+  const bootstrap = await app.fetch(
+    new Request("http://flaremo.test/api/auth/flaremo/bootstrap", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+        "x-flaremo-bootstrap-secret": TEST_BOOTSTRAP_SECRET,
+      },
+      body: JSON.stringify({
+        username: "owner",
+        name: "Owner",
+        email: "owner@example.com",
+        password: TEST_PASSWORD,
+      }),
+    }),
+    env,
+  );
+  expect(bootstrap.status).toBe(201);
+
+  const response = await app.fetch(
+    new Request("http://flaremo.test/api/v1/auth/signin", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+      },
+      body: JSON.stringify({
+        passwordCredentials: { username: "owner", password: TEST_PASSWORD },
+      }),
+    }),
+    env,
+  );
+  expect(response.status).toBe(200);
+  return ((await response.json()) as { accessToken: string }).accessToken;
+}

--- a/apps/worker/src/memos-protobuf.test.ts
+++ b/apps/worker/src/memos-protobuf.test.ts
@@ -64,7 +64,13 @@ describe("Memos protobuf transport", () => {
     expect(response).toBeInstanceOf(Uint8Array);
     const bytes = response as Uint8Array;
     expect(bytes[0]).toBe(0);
-    expect(new DataView(bytes.buffer).getUint32(1)).toBe(bytes.length - 5);
+    const dataLength = new DataView(
+      bytes.buffer,
+      bytes.byteOffset,
+      bytes.byteLength,
+    ).getUint32(1);
+    expect(dataLength).toBeLessThan(bytes.length - 5);
+    expect(bytes[5 + dataLength]).toBe(0x80);
     expect(new TextDecoder().decode(bytes)).toContain("memos/one");
   });
 
@@ -204,5 +210,41 @@ describe("Memos protobuf transport", () => {
       users: [{ name: "users/owner", username: "owner" }],
       totalSize: 1,
     });
+  });
+
+  it("adds and consumes standard gRPC-Web unary trailer frames", () => {
+    const response = encodeBinaryResponse(
+      "memos.api.v1.MemoService",
+      "GetMemo",
+      { name: "memos/one", content: "hello" },
+      "grpc-web-proto",
+    ) as Uint8Array;
+    expect(response[0]).toBe(0);
+    const trailerOffset = 5 + new DataView(response.buffer).getUint32(1);
+    expect(response[trailerOffset]).toBe(0x80);
+    expect(
+      new TextDecoder().decode(response.subarray(trailerOffset + 5)),
+    ).toContain("grpc-status: 0");
+    expect(
+      decodeBinaryResponse(
+        "memos.api.v1.MemoService",
+        "GetMemo",
+        response,
+        "grpc-web-proto",
+      ),
+    ).toMatchObject({ name: "memos/one", content: "hello" });
+
+    const error = encodeBinaryError(
+      "bad input",
+      "grpc-web-proto",
+      3,
+    ) as Uint8Array;
+    expect(error[0]).toBe(0x80);
+    expect(new TextDecoder().decode(error.subarray(5))).toContain(
+      "grpc-status: 3",
+    );
+    expect(new TextDecoder().decode(error.subarray(5))).toContain(
+      "grpc-message: bad%20input",
+    );
   });
 });

--- a/apps/worker/src/memos-protobuf.ts
+++ b/apps/worker/src/memos-protobuf.ts
@@ -135,7 +135,10 @@ export function encodeBinaryResponse(
 ): Uint8Array | string {
   const payload = encodeResponseMessage(service, method, value);
   if (transport === "connect-proto") return payload;
-  const framed = encodeGrpcUnaryFrame(payload);
+  const framed =
+    transport === "grpc-web-proto" || transport === "grpc-web-text-proto"
+      ? encodeGrpcWebResponse(payload, 0)
+      : encodeGrpcUnaryFrame(payload);
   return transport === "grpc-web-text-proto" ? encodeBase64(framed) : framed;
 }
 
@@ -150,7 +153,13 @@ export function encodeBinaryError(
   // INVALID_ARGUMENT.
   const status = new ProtoWriter().int32(1, code).string(2, message).finish();
   if (transport === "connect-proto") return status;
-  const framed = encodeGrpcUnaryFrame(status);
+  // gRPC-Web application errors are carried in a trailers-only frame. A
+  // protobuf google.rpc.Status data frame would be interpreted as a normal
+  // response message by generated browser clients.
+  const framed =
+    transport === "grpc-web-proto" || transport === "grpc-web-text-proto"
+      ? encodeGrpcWebTrailerFrame(code, message)
+      : encodeGrpcUnaryFrame(status);
   return transport === "grpc-web-text-proto" ? encodeBase64(framed) : framed;
 }
 
@@ -170,9 +179,11 @@ export function decodeBinaryResponse(
   const payload =
     transport === "connect-proto"
       ? input
-      : decodeGrpcUnaryFrame(
-          transport === "grpc-web-text-proto" ? decodeBase64(input) : input,
-        );
+      : transport === "grpc-web-proto" || transport === "grpc-web-text-proto"
+        ? decodeGrpcWebUnaryResponse(
+            transport === "grpc-web-text-proto" ? decodeBase64(input) : input,
+          )
+        : decodeGrpcUnaryFrame(input);
   return decodeResponseMessage(service, method, payload);
 }
 
@@ -2505,6 +2516,71 @@ function encodeGrpcUnaryFrame(payload: Uint8Array) {
   new DataView(frame.buffer).setUint32(1, payload.length);
   frame.set(payload, 5);
   return frame;
+}
+
+function decodeGrpcWebUnaryResponse(input: Uint8Array) {
+  let offset = 0;
+  let data: Uint8Array | undefined;
+  while (offset < input.length) {
+    if (input.length - offset < 5) {
+      throw new ProtoCodecError("Truncated gRPC-Web frame");
+    }
+    const flags = input[offset] ?? 255;
+    const length = new DataView(
+      input.buffer,
+      input.byteOffset + offset,
+      input.byteLength - offset,
+    ).getUint32(1);
+    offset += 5;
+    if (length > input.length - offset) {
+      throw new ProtoCodecError("Truncated gRPC-Web frame payload");
+    }
+    const payload = input.subarray(offset, offset + length);
+    offset += length;
+
+    if (flags === 0) {
+      if (data) throw new ProtoCodecError("Expected one gRPC-Web data frame");
+      data = payload;
+      continue;
+    }
+    if ((flags & 0x80) !== 0) continue;
+    throw new ProtoCodecError("Unsupported gRPC-Web frame flags");
+  }
+  return data ?? new Uint8Array();
+}
+
+function encodeGrpcWebResponse(payload: Uint8Array, code: number) {
+  return concatBytes(
+    encodeGrpcWebFrame(0, payload),
+    encodeGrpcWebTrailerFrame(code),
+  );
+}
+
+function encodeGrpcWebTrailerFrame(code: number, message?: string) {
+  const lines = [`grpc-status: ${code}`];
+  if (message) lines.push(`grpc-message: ${encodeURIComponent(message)}`);
+  const payload = new TextEncoder().encode(`${lines.join("\r\n")}\r\n`);
+  return encodeGrpcWebFrame(0x80, payload);
+}
+
+function encodeGrpcWebFrame(flags: number, payload: Uint8Array) {
+  const frame = new Uint8Array(payload.length + 5);
+  frame[0] = flags;
+  new DataView(frame.buffer).setUint32(1, payload.length);
+  frame.set(payload, 5);
+  return frame;
+}
+
+function concatBytes(...values: Uint8Array[]) {
+  const output = new Uint8Array(
+    values.reduce((length, value) => length + value.length, 0),
+  );
+  let offset = 0;
+  for (const value of values) {
+    output.set(value, offset);
+    offset += value.length;
+  }
+  return output;
 }
 
 function decodeBase64(input: Uint8Array) {

--- a/apps/worker/src/memos-social.test.ts
+++ b/apps/worker/src/memos-social.test.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { createDb, memosSseEvents } from "@flaremo/db";
 import { Miniflare } from "miniflare";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import app from "./index";
@@ -72,6 +73,18 @@ describe("Memos social REST compatibility", () => {
     expect(
       new Set([first.name, second.name]).has(secondPage.memos[0].name),
     ).toBe(true);
+
+    const commentEvent = (
+      await createDb(env.DB).select().from(memosSseEvents).all()
+    ).find((event) => event.type === "memo.comment.created");
+    expect(commentEvent).toMatchObject({
+      // The pinned Memos server identifies the parent memo for this event;
+      // the comment itself is available through the comments collection.
+      name: parent.name,
+      parent: null,
+      visibility: "private",
+      creatorId: "users/owner",
+    });
   });
 
   it("upserts, lists, and deletes memo reactions", async () => {
@@ -210,6 +223,21 @@ describe("Memos social REST compatibility", () => {
     );
     expect(deleted.status).toBe(200);
     expect((await json(await fetchSocial(shortcutPath))).shortcuts).toEqual([]);
+  });
+
+  it("rejects shortcuts without an upstream-compatible filter", async () => {
+    const response = await fetchSocial(
+      "http://flaremo.test/api/v1/users/owner/shortcuts",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Missing filter" }),
+      },
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      code: 3,
+    });
   });
 
   it("uses the current JSON error envelope and exact Origin boundary", async () => {

--- a/apps/worker/src/memos-transport.test.ts
+++ b/apps/worker/src/memos-transport.test.ts
@@ -336,6 +336,17 @@ describe("Memos native auth and transport boundaries", () => {
     expect(relationList.relations[0]?.relatedMemo.name).toBe(related.name);
     expect(relationList.relations[0]?.type).toBe("REFERENCE");
 
+    const incomingRelationList = await connect("ListMemoRelations", {
+      name: related.name,
+    });
+    expect(incomingRelationList.relations).toEqual([
+      expect.objectContaining({
+        memo: { name: created.name, snippet: expect.any(String) },
+        relatedMemo: { name: related.name, snippet: expect.any(String) },
+        type: "REFERENCE",
+      }),
+    ]);
+
     const attachment = await request("/api/v1/attachments", {
       method: "POST",
       headers: {

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -29,7 +29,7 @@ import {
   listMemoAttachmentsForViewer,
   listMemoComments,
   listMemoReactions,
-  listMemoRelations,
+  listMemoRelationsForViewer,
   listMemoShares,
   listMemos,
   listMemosForViewer,
@@ -409,11 +409,15 @@ async function connectShortcutMethod(
     }
     case "UpdateShortcut": {
       const shortcut = record(body.shortcut);
+      const updateMask = optionalString(body.updateMask);
+      if (!updateMask?.trim()) {
+        throw new ConnectInputError("updateMask is required");
+      }
       const updated = await updateShortcut(context.db, context.user, {
         name: requiredString(shortcut.name, "shortcut.name"),
         title: optionalString(shortcut.title),
         filter: optionalString(shortcut.filter),
-        updateMask: optionalString(body.updateMask),
+        updateMask,
       });
       return connectValue(c, currentShortcutToDto(updated), transport);
     }
@@ -1276,17 +1280,24 @@ async function connectPublicMemoRead(
     }
     case "ListMemoRelations": {
       const memoId = normalizeMemoName(requiredString(body.name, "name"));
-      const memo = await getMemoByIdForViewer(context.db, context.user, memoId);
-      const rows = await listMemoRelations(context.db, context.user, memoId);
+      await getMemoByIdForViewer(context.db, context.user, memoId);
+      const rows = await listMemoRelationsForViewer(
+        context.db,
+        context.user,
+        memoId,
+      );
       const relations = await Promise.all(
         rows.map(async (relation) => {
           try {
-            const relatedMemo = await getMemoByIdForViewer(
-              context.db,
-              context.user,
-              relation.relatedMemoId,
-            );
-            return currentRelationToDto(relation, memo, relatedMemo);
+            const [relationMemo, relatedMemo] = await Promise.all([
+              getMemoByIdForViewer(context.db, context.user, relation.memoId),
+              getMemoByIdForViewer(
+                context.db,
+                context.user,
+                relation.relatedMemoId,
+              ),
+            ]);
+            return currentRelationToDto(relation, relationMemo, relatedMemo);
           } catch {
             return null;
           }
@@ -1323,17 +1334,20 @@ async function connectPublicMemoWithDetails(
   const [attachments, reactions, relationRows] = await Promise.all([
     listMemoAttachmentsForViewer(context.db, context.user, memo.id),
     listMemoReactions(context.db, context.user, memo.id, { pageSize: 1_000 }),
-    listMemoRelations(context.db, context.user, memo.id),
+    listMemoRelationsForViewer(context.db, context.user, memo.id),
   ]);
   const relations = await Promise.all(
     relationRows.map(async (relation) => {
       try {
-        const relatedMemo = await getMemoByIdForViewer(
-          context.db,
-          context.user,
-          relation.relatedMemoId,
-        );
-        return currentRelationToDto(relation, memo, relatedMemo);
+        const [relationMemo, relatedMemo] = await Promise.all([
+          getMemoByIdForViewer(context.db, context.user, relation.memoId),
+          getMemoByIdForViewer(
+            context.db,
+            context.user,
+            relation.relatedMemoId,
+          ),
+        ]);
+        return currentRelationToDto(relation, relationMemo, relatedMemo);
       } catch {
         return null;
       }
@@ -1596,16 +1610,22 @@ async function listConnectRelations(
   const memo = await getMemoById(context.db, context.user, memoId, {
     includeDeleted: true,
   });
-  const rows = await listMemoRelations(context.db, context.user, memo.id);
+  const rows = await listMemoRelationsForViewer(
+    context.db,
+    context.user,
+    memo.id,
+  );
   const relations = await Promise.all(
     rows.map(async (row) => {
-      const relatedMemo = await getMemoById(
-        context.db,
-        context.user,
-        row.relatedMemoId,
-        { includeDeleted: true },
-      );
-      return currentRelationToDto(row, memo, relatedMemo);
+      const [relationMemo, relatedMemo] = await Promise.all([
+        getMemoById(context.db, context.user, row.memoId, {
+          includeDeleted: true,
+        }),
+        getMemoById(context.db, context.user, row.relatedMemoId, {
+          includeDeleted: true,
+        }),
+      ]);
+      return currentRelationToDto(row, relationMemo, relatedMemo);
     }),
   );
   return { relations };
@@ -1622,7 +1642,7 @@ async function connectMemoWithDetails(
   );
   const [attachments, rows, reactionPage, parent] = await Promise.all([
     listMemoAttachments(context.db, context.user, memo.id),
-    listMemoRelations(context.db, context.user, memo.id),
+    listMemoRelationsForViewer(context.db, context.user, memo.id),
     listMemoReactions(context.db, context.user, {
       memoName: memo.id,
       pageSize: 1_000,
@@ -1631,13 +1651,15 @@ async function connectMemoWithDetails(
   ]);
   const relations = await Promise.all(
     rows.map(async (row) => {
-      const related = await getMemoById(
-        context.db,
-        context.user,
-        row.relatedMemoId,
-        { includeDeleted: true },
-      );
-      return currentRelationToDto(row, memo, related);
+      const [relationMemo, relatedMemo] = await Promise.all([
+        getMemoById(context.db, context.user, row.memoId, {
+          includeDeleted: true,
+        }),
+        getMemoById(context.db, context.user, row.relatedMemoId, {
+          includeDeleted: true,
+        }),
+      ]);
+      return currentRelationToDto(row, relationMemo, relatedMemo);
     }),
   );
   return currentMemoToDto(memo, context.user, {

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -18,7 +18,7 @@ import {
   listAttachments,
   listAttachmentsForMemosForViewer,
   listMemoAttachmentsForViewer,
-  listMemoRelations,
+  listMemoRelationsForViewer,
   listMemoShares,
   listMemosForViewer,
   listMemosPersonalAccessTokens,
@@ -898,19 +898,28 @@ async function currentRelations(
   context: Awaited<ReturnType<typeof getOptionalRequestContext>>,
   memoId: string,
 ) {
-  const memo = await getMemoByIdForViewer(context.db, context.user, memoId, {
+  await getMemoByIdForViewer(context.db, context.user, memoId, {
     includeDeleted: true,
   });
-  const rows = await listMemoRelations(context.db, context.user, memoId);
+  const rows = await listMemoRelationsForViewer(
+    context.db,
+    context.user,
+    memoId,
+  );
   const related = await Promise.all(
     rows.map(async (relation) => {
       try {
-        const relatedMemo = await getMemoByIdForViewer(
-          context.db,
-          context.user,
-          relation.relatedMemoId,
-          { includeDeleted: true },
-        );
+        const [memo, relatedMemo] = await Promise.all([
+          getMemoByIdForViewer(context.db, context.user, relation.memoId, {
+            includeDeleted: true,
+          }),
+          getMemoByIdForViewer(
+            context.db,
+            context.user,
+            relation.relatedMemoId,
+            { includeDeleted: true },
+          ),
+        ]);
         return currentRelationToDto(relation, memo, relatedMemo);
       } catch {
         return null;
@@ -921,7 +930,6 @@ async function currentRelations(
     (value): value is NonNullable<typeof value> => value !== null,
   );
 }
-
 async function currentMemoCreator(
   context: Awaited<ReturnType<typeof getOptionalRequestContext>>,
   memo: Awaited<ReturnType<typeof getMemoById>>,

--- a/apps/worker/src/routes/memos-social-api.ts
+++ b/apps/worker/src/routes/memos-social-api.ts
@@ -11,7 +11,7 @@ import {
   listMemoAttachmentsForViewer,
   listMemoComments,
   listMemoReactions,
-  listMemoRelations,
+  listMemoRelationsForViewer,
   listShortcuts,
   updateShortcut,
   upsertMemoReaction,
@@ -353,19 +353,24 @@ async function memoToCurrentDto(
   );
   const [attachments, relationRows, reactionPage] = await Promise.all([
     listMemoAttachmentsForViewer(context.db, context.user, memo.id),
-    listMemoRelations(context.db, context.user, memo.id),
+    listMemoRelationsForViewer(context.db, context.user, memo.id),
     reactionPagePromise,
   ]);
   const relations = await Promise.all(
     relationRows.map(async (relation) => {
       try {
-        const relatedMemo = await getMemoByIdForViewer(
-          context.db,
-          context.user,
-          relation.relatedMemoId,
-          { includeDeleted: true },
-        );
-        return currentRelationToDto(relation, memo, relatedMemo);
+        const [relationMemo, relatedMemo] = await Promise.all([
+          getMemoByIdForViewer(context.db, context.user, relation.memoId, {
+            includeDeleted: true,
+          }),
+          getMemoByIdForViewer(
+            context.db,
+            context.user,
+            relation.relatedMemoId,
+            { includeDeleted: true },
+          ),
+        ]);
+        return currentRelationToDto(relation, relationMemo, relatedMemo);
       } catch {
         return null;
       }

--- a/docs/en/memos-compatibility.md
+++ b/docs/en/memos-compatibility.md
@@ -59,9 +59,13 @@ content.contains("...")
 tags.exists(t, t == "...")
 pinned == true
 visibility == "PUBLIC"
+size(content) > 100
+created_ts.getFullYear() == 2026
+created_ts >= timestamp(1704067200)
+updated_ts < now - duration("1h")
 ```
 
-`orderBy` currently accepts only a single `create_time` or `update_time` field with `asc` or `desc`. Unsupported filters and orderings return a current standard error instead of silently changing the query semantics.
+The tested surface also includes `size(content)`, `size(tags)`, the pinned upstream timestamp accessors without timezone arguments, integer Unix timestamps, and `now`/`duration` arithmetic. `orderBy` currently accepts only a single `create_time` or `update_time` field with `asc` or `desc`. Unsupported filters and orderings return a current standard error instead of silently changing the query semantics.
 
 ### Root `/mcp`
 
@@ -76,26 +80,26 @@ The current tool names use `memo_`, `attachment_`, `shortcut_`, and `auth_` pref
 
 ### Connect JSON and SSE
 
-The Worker also exposes the canonical `memos.api.v1/{Service}/{Method}` HTTP unary adapter for the documented service subset. It accepts Connect JSON plus `application/proto`, `application/grpc`, `application/grpc+proto`, `application/grpc-web`, `application/grpc-web+proto`, `application/grpc-web-text`, and `application/grpc-web-text+proto`. Ordinary upstream methods use the pinned generated descriptors in `apps/worker/src/memos-generated/` and `@bufbuild/protobuf`; the hand-written codec remains only for the historical `GetSharedMemo` alias and error/status framing. This still does not provide native HTTP/2 gRPC, complete metadata/trailers, compression, streaming, or full Memos service/schema parity.
+The Worker also exposes the canonical `memos.api.v1/{Service}/{Method}` HTTP unary adapter for the documented service subset. It accepts Connect JSON plus `application/proto`, `application/grpc`, `application/grpc+proto`, `application/grpc-web`, `application/grpc-web+proto`, `application/grpc-web-text`, and `application/grpc-web-text+proto`. Ordinary upstream methods use the pinned generated descriptors in `apps/worker/src/memos-generated/` and `@bufbuild/protobuf`; the hand-written codec remains only for the historical `GetSharedMemo` alias and error/status framing. gRPC-Web unary responses now include a standard data frame followed by a trailer frame, and gRPC-Web application errors use a trailers-only frame. This still does not provide native HTTP/2 gRPC, complete metadata/trailers, compression, streaming, or full Memos service/schema parity.
 
 The pinned official generated-client smoke used the `Temp/memos` commit `daa71d0456d07a25ff5ea435e46577d31d030728`, `@bufbuild/protobuf@2.12.0`, `@connectrpc/connect@2.1.1`, `@connectrpc/connect-web@2.1.1`, and `useBinaryFormat: true` against `http://127.0.0.1:18787`. It successfully decoded the listed unary Auth, Memo/social, Attachment, Shortcut, User, and Instance responses. A separate production smoke used the same generated client for anonymous `MemoService/ListMemos` only. Neither result is an official-Web full smoke or complete Memos Server parity evidence.
 
-`GET /api/v1/sse` provides an authenticated `text/event-stream` handshake, connection comment, heartbeat, and abort/cancel handling. It does not yet provide a cross-isolate mutation outbox, `Last-Event-ID` replay, or a complete Memos SSE event hub, so it is documented as a heartbeat/polling-compatible stream.
+`GET /api/v1/sse` provides an authenticated `text/event-stream` handshake, a D1-backed mutation outbox, five-second polling, numeric `Last-Event-ID` replay, connection comments, a 30-second heartbeat, visibility filtering, and abort/cancel handling. Comment-created events identify the parent memo in `name`, matching the pinned upstream Memos behavior; relation and attachment-binding mutations atomically append `memo.updated` outbox events. It does not provide the upstream in-process SSEHub, complete event retention/stream semantics, or a third-party EventSource smoke.
 
-The endpoint is currently stateless JSON. SSE, MCP session state, the complete method surface, and every third-party MCP client's behavior are not promised. The older `POST /api/v1/mcp` JSON-RPC tool names remain available for existing FlareMo clients.
+The root MCP endpoint remains a stateless JSON Streamable HTTP subset. MCP session state, SSE MCP transport, the complete method surface, and every third-party MCP client's behavior are not promised. The older `POST /api/v1/mcp` JSON-RPC tool names remain available for existing FlareMo clients.
 
 ## Not complete or not verified
 
 Do not describe the following as complete compatibility:
 
 - Complete Memos Server parity or complete Connect/gRPC parity.
-- Full CEL, complex pagination/ordering, or complete attachment filter/order/page-token semantics; attachment list support is a bounded subset.
+- Full CEL/SQL-rendering parity, complex pagination/ordering, or complete attachment filter/order/page-token semantics; the current CEL implementation is a bounded Worker-side evaluator and attachment list support is a bounded subset.
 - The Memos Web `/file/attachments/{id}/{filename}` bridge supports private Better Auth/PAT/native-JWT reads and `share_token`-scoped public reads. `thumbnail=true` currently returns the original object; motion-media conversion and arbitrary `externalLink` persistence are not implemented.
 - Current attachment batch delete or Attachment updates beyond the memo-binding subset.
 - Complete upstream service/wire parity for comments, reactions, and shortcuts, plus notifications and admin/instance surfaces.
 - A complete SSE event hub/replay protocol and stateful MCP sessions.
 - Byte-level/version-level native Memos JWT/refresh-token parity; the current implementation only verifies FlareMo's own HS256 claims, rotation, and revocation behavior.
-- Uncovered Memos services, native HTTP/2 gRPC, complete gRPC-Web trailer/metadata behavior, compression, and streaming.
+- Uncovered Memos services, native HTTP/2 gRPC, complete gRPC-Web metadata behavior, compression, and streaming. The unary gRPC-Web data/trailer frame contract is covered locally, but not yet by an official browser transport or third-party client smoke.
 - Real smoke tests for the official Memos client, MemoFlow, Dynos, Raycast, browser extensions, or other third-party clients.
 - Cloudflare Access policy correctness; Access is a deployment-layer policy, not the FlareMo application protocol.
 
@@ -113,5 +117,6 @@ Every expanded compatibility promise needs tests for:
 - Better Auth cookie, session bearer, PAT bearer, PAT revocation, and public-share boundaries.
 - `/mcp` initialize, tools/list, tools/call, and tool-error envelopes.
 - Native JWT headers/claims, refresh-cookie attributes and reuse rejection, Connect JSON transport, and SSE handshake/cancel behavior.
+- Unary gRPC-Web data/trailer framing and trailers-only application errors.
 
 These tests prove FlareMo's own contract, not third-party client compatibility. Untested clients stay untested until a real connection, version, date, and result are recorded in the [ecosystem matrix](../memos-ecosystem.md).

--- a/docs/memos-compatibility.md
+++ b/docs/memos-compatibility.md
@@ -80,9 +80,13 @@ content.contains("...")
 tags.exists(t, t == "...")
 pinned == true
 visibility == "PUBLIC"
+size(content) > 100
+created_ts.getFullYear() == 2026
+created_ts >= timestamp(1704067200)
+updated_ts < now - duration("1h")
 ```
 
-`orderBy` 当前只支持单字段的 `create_time` / `update_time` asc/desc 子集。未支持的 filter 或排序会返回 current 标准错误，而不是静默改变语义。大小写、层级 tag、RE2 与 JavaScript regex、`name` 变量、复杂宏、完整分页和大数据量 bounded execution 仍未完成上游对照。
+当前还支持 `size(content)`、`size(tags)`、上游 timestamp accessor（不接受 timezone 参数）、epoch integer timestamp，以及 `now`/`duration` 的时间算术。`orderBy` 当前只支持单字段的 `create_time` / `update_time` asc/desc 子集。未支持的 filter 或排序会返回 current 标准错误，而不是静默改变语义。大小写、层级 tag、RE2 与 JavaScript regex、`name` 变量、复杂宏、完整分页和大数据量 bounded execution 仍未完成上游对照。
 
 普通 `GetMemo`、`ListMemos`、comments、reactions、memo relations 和 memo attachments 已经有独立的 optional viewer：匿名只读 `PUBLIC + NORMAL`，认证用户继续使用 Better Auth/PAT 的 owner-scoped 读取；创建、更新、删除和 share/social mutation 仍需认证。User profile/stats 的完整 public projection 尚未实现，不能把这一段扩大成完整 Memos ACL parity。
 
@@ -122,12 +126,12 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 - memo create/update 的完整时间、initial attachments/relations/location、完整 update mask、pagination token，以及 comments/reactions 的完整 response schema。
 - Attachment update/batch delete、User/Instance/IdentityProvider 的未覆盖方法和完整 generated-client schema roundtrip；本次 smoke 只覆盖列出的 unary 子集。Attachment 列表的分页/排序/过滤是 FlareMo 的有限子集，不是完整 CEL parity。
 - 官方 Memos Web 的 `/file/attachments/{id}/{filename}` 文件 URL bridge 已实现，支持 Better Auth/PAT/native access JWT 私有读取和 `share_token` 绑定的公开读取；`thumbnail=true` 目前返回原始对象，motion media 转换和任意 `externalLink` 持久化仍未完成。
-- 原生 gRPC HTTP/2、完整 metadata/trailer、gRPC-Web trailer frame、压缩、streaming RPC、取消和 deadline 语义。
+- 原生 gRPC HTTP/2、完整 metadata/trailer、压缩、streaming RPC、取消和 deadline 语义；gRPC-Web unary 已有标准 data+trailer frame，但还没有官方浏览器 transport 的端到端证明。
 - 官方 Memos Web 的真实浏览器请求、第三方客户端连接，以及 native HTTP/2 gRPC 的真实客户端验证。
 
 ## SSE 与 MCP
 
-`GET /api/v1/sse` 是 authenticated `text/event-stream`。当前实现使用 D1 `memos_sse_events` outbox、5 秒 polling、`Last-Event-ID` cursor replay、连接注释和 30 秒 heartbeat；当前事件包括 memo create/update/delete、comment create、reaction upsert/delete。仓库测试覆盖 authenticated handshake、replay、visibility filtering 和 cancellation。
+`GET /api/v1/sse` 是 authenticated `text/event-stream`。当前实现使用 D1 `memos_sse_events` outbox、5 秒 polling、`Last-Event-ID` cursor replay、连接注释和 30 秒 heartbeat；当前事件包括 memo create/update/delete、comment create、reaction upsert/delete。comment-created 事件按 pinned 上游语义把父 memo 放在 `name`，不额外写 `parent`；关系和附件绑定变更会与 `memo.updated` outbox 写入同一 D1 batch。仓库测试覆盖 authenticated handshake、replay、visibility filtering 和 cancellation。
 
 这不是上游进程内 SSEHub parity：当前没有 Durable Object broadcaster、retention/pruning、关系/附件/shortcut/share/user/notification 的完整事件集，也没有第三方 EventSource smoke。
 
@@ -143,8 +147,8 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 - 单用户以外的用户创建、删除、权限、协作和完整用户资源语义。
 - SSO/OAuth2 provider、linked identity、webhook、notification 的完整 CRUD/投递。
 - AI transcription、instance email testing/delivery、完整 instance setting provider 配置。
-- 普通 public memo 的完整匿名 ACL、完整 CEL filter、复杂排序/分页和所有上游错误细节。
-- generated client 端到端 binary roundtrip、原生 gRPC metadata/trailer/streaming/compression。
+- 普通 public memo 的完整匿名 ACL、完整 CEL filter、复杂排序/分页和所有上游错误细节；当前 CEL 仍是受限 evaluator，且 filter 会在 Worker 侧执行而不是完全下推到 SQL。
+- generated client 全量端到端 binary roundtrip、原生 gRPC metadata/trailer/streaming/compression，以及官方浏览器 gRPC-Web transport 全量验证。
 - 完整 SSE event hub、事件保留策略和第三方 EventSource/MCP/client smoke。
 - Memos native JWT/refresh token 的版本级、字节级 parity。
 
@@ -157,7 +161,8 @@ Worker 提供 canonical `memos.api.v1/{Service}/{Method}` 的 HTTP unary adapter
 - `apps/worker/src/memos-compatibility.test.ts`：current/legacy REST、memo/attachment/share、PAT、native auth facade、OpenAPI、MCP contract。
 - `apps/worker/src/memos-social.test.ts`：comments、reactions、shortcuts 和错误/Origin 边界。
 - `apps/worker/src/memos-transport.test.ts`：native JWT、refresh cookie、Connect JSON、部分新增 service、protobuf/gRPC-Web framing、SSE 和 canonical share RPC。
-- `apps/worker/src/memos-protobuf.test.ts`：media type、请求 field number、部分 response serialization 和 binary error status。
+- `apps/worker/src/memos-protobuf.test.ts`：media type、请求 field number、部分 response serialization、gRPC-Web unary data/trailer frame 和 binary error status。
+- `apps/worker/src/memos-connect-client.test.ts`：使用官方 generated `MemoService` 和 `@connectrpc/connect-web`，对 Connect binary 与 gRPC-Web binary 做有限的 schema-decoded unary smoke；不代表完整官方 Web 或第三方客户端兼容。
 - `apps/worker/src/mcp-streamable.test.ts`：无状态 Streamable HTTP MCP 的初始化、工具列表、调用错误和 legacy route。
 - `apps/worker/src/memos-link-metadata.test.ts`、`packages/memos/src/adapter.test.ts`、`packages/memos/src/current-adapter.test.ts`：link metadata 输入限制、resource name 和 DTO 映射。
 - `apps/telegram-bot/src/index.test.ts`：项目自带 Telegram Worker 示例的 PAT、可选 Access headers 和 webhook fail-closed contract；不是对真实 Telegram 或生产 FlareMo 的 smoke。

--- a/docs/memos-ecosystem.md
+++ b/docs/memos-ecosystem.md
@@ -45,14 +45,14 @@ Access Service Token 不会自动变成 FlareMo 用户 session；不能发送应
 | current REST script / curl | 通用 HTTP 脚本 | 已实现 | `memos-compatibility.test.ts`、`memos-social.test.ts`、`auth.test.ts` 覆盖 current DTO、memo/attachment/share、social、PAT、native auth、Origin 和标准错误；`memos-auth-golden.test.ts` 固定验证 FlareMo 自己的 JWT/refresh bytes。 | 已测试的是 FlareMo contract；没有独立客户端或线上实例 smoke，也不证明上游 token parity。 |
 | legacy REST script / curl | 兼容迁移脚本 | 已实现 | current/legacy OpenAPI 和 wire negotiation 有测试。 | 未对历史第三方脚本逐一重放。 |
 | generic Connect JSON client | HTTP unary client | 已实现子集 | `memos-transport.test.ts` 覆盖 Memo/Shortcut 及部分 Auth、Attachment/User/Instance/IdentityProvider JSON RPC。 | 官方 generated client 的 binary smoke 已单独记录；generic JSON client 仍未逐一做第三方客户端 smoke。 |
-| generic protobuf / gRPC-style client | HTTP binary client | 已实现子集 | `memos-protobuf.test.ts`、`memos-transport.test.ts` 覆盖 media type、部分 upstream field number、unary framing、gRPC-Web/text 和 error status。 | response 多数只做 frame/字节断言；generated schema roundtrip 未测。 |
+| generic protobuf / gRPC-style client | HTTP binary client | 已实现子集 | `memos-protobuf.test.ts`、`memos-transport.test.ts` 覆盖 media type、部分 upstream field number、unary framing、gRPC-Web/text、data/trailer frame 和 error status。 | response 多数只做 frame/字节断言；generated schema roundtrip 只由下方官方 client smoke 覆盖有限 MemoService 方法。 |
 | FlareMo current MCP endpoint | MCP client | 已实现子集 | `mcp-streamable.test.ts`、`memos-compatibility.test.ts` 覆盖 `initialize`、`notifications/initialized`、`tools/list`、`tools/call` 和工具错误 envelope。 | 根 `/mcp` 是无状态 JSON 子集；未测所有第三方 MCP client。 |
 | FlareMo legacy MCP endpoint | 旧 MCP JSON-RPC | 已实现子集 | `mcp-streamable.test.ts` 和 `auth.test.ts` 覆盖旧工具名/PAT 边界。 | 不能从旧 endpoint 推断完整 Memos MCP 兼容。 |
 | FlareMo SSE consumer | EventSource / SSE client | 已实现子集 | `memos-transport.test.ts` 覆盖 authenticated stream、connected/heartbeat、`Last-Event-ID` replay、visibility 和 cancellation。 | D1 polling 实现，未做第三方 EventSource smoke。 |
 | FlareMo Telegram Worker example | Telegram webhook adapter | 已实现示例 | `apps/telegram-bot/src/index.test.ts` 覆盖 PAT-only、可选 Access headers、secret 校验和 fail-closed。 | 不是真实 Telegram API 或生产 FlareMo smoke。 |
 | public share reader | 浏览器 / curl | 已实现 | `memos-compatibility.test.ts`、`api.test.ts` 覆盖 share token 隔离、撤销、过期/状态和附件读取。 | 仍需在实际部署域名上验证 Access bypass 规则；不绕过 FlareMo share 校验。 |
 | Memos Web attachment file URL bridge | Memos Web `/file/attachments/{id}/{filename}` | 已实现子集 | `api.test.ts` 覆盖私有 cookie、Range/ETag、错误 filename 不改变对象定位，以及带 `share_token` 的公共读取和跨 memo 隔离。 | 只证明 FlareMo 的文件 URL contract；thumbnail 原图 fallback、motion media、官方 Web 全量行为和生产 Access path policy 仍未实测。 |
-| 官方 Memos generated Connect client | `protoc-gen-es` + `@connectrpc/connect-web` binary unary client | 已实测子集 | 隔离本地 Wrangler E2E：覆盖 Auth、Memo/social、Attachment、Shortcut、User、Instance 列出的 unary 方法，并由官方 generated decoder 解码响应；同一 client 对生产域名匿名 `MemoService/ListMemos` 也成功解码。 | 生产只覆盖一个匿名 unary 方法；不是官方 Web 全量行为或完整 Memos Server parity。 |
+| 官方 Memos generated Connect client | `protoc-gen-es` + `@connectrpc/connect-web` binary unary client | 已实测子集 | `apps/worker/src/memos-connect-client.test.ts` 使用官方 generated `MemoService`：Connect binary 覆盖 `CreateMemo` / `ListMemos`，gRPC-Web binary 覆盖 `GetMemo`，并由 generated decoder 解码；另有下方记录的本地方法集 smoke 和生产域名匿名 `ListMemos` smoke。 | 生产只覆盖一个匿名 unary 方法；不是官方 Web 全量行为或完整 Memos Server parity。 |
 
 ## 官方 Memos generated Connect client：local 与 production anonymous smoke
 
@@ -97,7 +97,7 @@ local 证据说明 pinned generated client 能把列出的 Connect binary unary 
 - `AIService/Transcribe`、Instance email test、OAuth2/IdentityProvider CRUD、User create/delete、linked identity CRUD、webhook CRUD、notification update/delete 当前明确未实现或返回 `501`。
 - User/Instance/Attachment 的已列出方法已经有一次 pinned generated-client binary roundtrip，但这不覆盖全部字段、全部方法、生产域名或官方 Web；不能把它写成完整 binary parity。
 - public memo read 已接入 current REST 和 Connect 的明确 viewer policy：匿名只读 `PUBLIC + NORMAL`，private/protected/archived/trashed/deleted 不可见；comments、relations、attachments、reactions 会先检查 parent/read visibility。公开 share 仍是独立 token 入口，不等于普通 memo public ACL。
-- 没有完整 CEL、复杂分页/排序、全部 protobuf 字段、metadata/trailer、压缩、streaming、gRPC-Web trailer frame 或原生 HTTP/2 gRPC parity。Attachment list 的 page token/order/filter 只是有限子集；`thumbnail=true` 暂时返回原始对象，motion media 和任意 `externalLink` 持久化仍未完成。
+- 没有完整 CEL、复杂分页/排序、全部 protobuf 字段、完整 metadata/trailer、压缩、streaming 或原生 HTTP/2 gRPC parity。gRPC-Web unary 的 data/trailer frame 已有本地 codec 与 generated-client 覆盖，但仍没有官方 Web 全量或第三方客户端 smoke。Attachment list 的 page token/order/filter 只是有限子集；`thumbnail=true` 暂时返回原始对象，motion media 和任意 `externalLink` 持久化仍未完成。
 - SSE 是 D1 outbox/polling/replay，不是上游 SSEHub；没有完整事件集、retention/pruning 和第三方 EventSource 实测。
 - 根 `/mcp` 没有有状态 MCP session，不承诺 SSE transport 或所有 MCP client 的 method surface。
 

--- a/packages/domain/src/attachments.ts
+++ b/packages/domain/src/attachments.ts
@@ -16,6 +16,7 @@ import {
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
 import { createResourceId, parseResourceName } from "./ids";
 import { getMemoById, getMemoByIdForViewer } from "./memos";
+import { insertMemosSseEvent } from "./memos-sse";
 
 export type CreateAttachmentMetadataInput = {
   memoId?: string | null;
@@ -430,7 +431,7 @@ export async function bindMemoAttachments(
   attachmentNames: string[],
 ) {
   const normalizedMemoId = parseResourceName(memoId, "memos");
-  await getMemoById(db, user, normalizedMemoId);
+  const memo = await getMemoById(db, user, normalizedMemoId);
   const ids = attachmentNames.map((name) =>
     parseResourceName(name, "attachments"),
   );
@@ -455,7 +456,7 @@ export async function bindMemoAttachments(
     }
   }
 
-  await db
+  const clearExisting = db
     .update(attachments)
     .set({ memoId: null, updatedAt: now })
     .where(
@@ -466,12 +467,36 @@ export async function bindMemoAttachments(
     );
 
   if (ids.length > 0) {
-    await db
-      .update(attachments)
-      .set({ memoId: normalizedMemoId, updatedAt: now })
-      .where(
-        and(eq(attachments.userId, user.id), inArray(attachments.id, ids)),
-      );
+    // Attachment binding is a memo mutation in upstream Memos. Keep the
+    // durable outbox write in the same D1 batch so reconnecting SSE clients do
+    // not observe a successful update without its refresh event.
+    await db.batch([
+      clearExisting,
+      db
+        .update(attachments)
+        .set({ memoId: normalizedMemoId, updatedAt: now })
+        .where(
+          and(eq(attachments.userId, user.id), inArray(attachments.id, ids)),
+        ),
+      insertMemosSseEvent(db, {
+        type: "memo.updated",
+        name: memo.id,
+        visibility: memo.visibility,
+        creatorId: memo.userId,
+        createdAt: now,
+      }),
+    ]);
+  } else {
+    await db.batch([
+      clearExisting,
+      insertMemosSseEvent(db, {
+        type: "memo.updated",
+        name: memo.id,
+        visibility: memo.visibility,
+        creatorId: memo.userId,
+        createdAt: now,
+      }),
+    ]);
   }
 
   return listMemoAttachments(db, user, normalizedMemoId);

--- a/packages/domain/src/memo-filter.test.ts
+++ b/packages/domain/src/memo-filter.test.ts
@@ -35,9 +35,27 @@ describe("Memos CEL filter", () => {
   it("supports timestamp and now/duration expressions", () => {
     expect(
       compileMemoFilter(
-        'created_ts > timestamp("2020-01-01T00:00:00Z") && updated_ts <= now',
+        'created_ts > timestamp(1704067200) && updated_ts <= now - duration("1h")',
       )?.(memo, user),
     ).toBe(true);
+  });
+
+  it("supports upstream size and timestamp accessor functions", () => {
+    expect(compileMemoFilter("size(content) == 25")?.(memo, user)).toBe(true);
+    expect(compileMemoFilter("content.size() > 20")?.(memo, user)).toBe(true);
+    expect(compileMemoFilter("size(tags) == 2")?.(memo, user)).toBe(true);
+    expect(
+      compileMemoFilter("created_ts.getFullYear() == 2026")?.(memo, user),
+    ).toBe(true);
+    expect(compileMemoFilter("created_ts.getMonth() == 7")?.(memo, user)).toBe(
+      true,
+    );
+    expect(() => compileMemoFilter('created_ts.getMonth("UTC") == 7')).toThrow(
+      /timezone argument/,
+    );
+    expect(() => compileMemoFilter("now.getFullYear() == 2026")).toThrow(
+      /timestamp fields/,
+    );
   });
 
   it("matches Memos creator identity, numeric id, and virtual tag membership", () => {
@@ -157,7 +175,10 @@ describe("Memos CEL filter", () => {
     expect(() =>
       compileMemoFilter('content.substring(0, 2) == "road"'),
     ).toThrow("Invalid Memos CEL filter");
-    expect(() => compileMemoFilter('created_ts.getHours("UTC") > 0')).toThrow(
+    expect(() => compileMemoFilter('created_ts.getHours("UTC") >= 0')).toThrow(
+      "timezone argument",
+    );
+    expect(() => compileMemoFilter("size(pinned)")).toThrow(
       "Invalid Memos CEL filter",
     );
   });

--- a/packages/domain/src/memo-filter.ts
+++ b/packages/domain/src/memo-filter.ts
@@ -499,6 +499,17 @@ function visitMemoFilterAst(node: MemoFilterAst, boundIds: Set<string>) {
       visitMemoFilterAst(args[1], boundIds);
       return;
     }
+    case "+":
+    case "-":
+    case "*":
+    case "/":
+    case "%": {
+      const args = binaryAstArgs(node);
+      if (!args) rejectUnsupported(`${node.op} requires two operands`);
+      visitMemoFilterAst(args[0], boundIds);
+      visitMemoFilterAst(args[1], boundIds);
+      return;
+    }
     case "!_":
       if (!isAstNode(node.args))
         rejectUnsupported("NOT requires one condition");
@@ -539,11 +550,11 @@ function validateCallSurface(node: MemoFilterAst, boundIds: Set<string>) {
 
   if (parts.name === "size") {
     if (parts.args.length !== 1) {
-      rejectUnsupported("size is only supported for tags");
+      rejectUnsupported("size requires one argument");
     }
     const receiver = requireAstArg(parts.args, 0, "size");
-    if (identifierName(receiver) !== "tags") {
-      rejectUnsupported("size is only supported for tags");
+    if (!new Set(["content", "tags"]).has(identifierName(receiver) ?? "")) {
+      rejectUnsupported("size is only supported for content and tags");
     }
     visitMemoFilterAst(receiver, boundIds);
     return;
@@ -553,12 +564,23 @@ function validateCallSurface(node: MemoFilterAst, boundIds: Set<string>) {
     if (parts.args.length !== 1) {
       rejectUnsupported(`${parts.name} requires one literal`);
     }
-    const literal = stringLiteral(requireAstArg(parts.args, 0, parts.name));
-    if (literal === undefined) {
-      rejectUnsupported(`${parts.name} requires a literal string`);
+    const literal = requireAstArg(parts.args, 0, parts.name);
+    if (parts.name === "timestamp") {
+      const stringValue = stringLiteral(literal);
+      if (stringValue !== undefined) {
+        validateTimestampLiteral(stringValue);
+      } else if (!isIntegerLiteral(literal)) {
+        rejectUnsupported(
+          "timestamp requires an RFC3339 string or epoch integer",
+        );
+      }
+    } else {
+      const stringValue = stringLiteral(literal);
+      if (stringValue === undefined) {
+        rejectUnsupported("duration requires a literal string");
+      }
+      validateDurationLiteral(stringValue);
     }
-    if (parts.name === "timestamp") validateTimestampLiteral(literal);
-    else validateDurationLiteral(literal);
     return;
   }
 
@@ -599,6 +621,29 @@ function validateReceiverCallSurface(
     return;
   }
 
+  const receiverName = identifierName(parts.receiver);
+  if (parts.name === "size") {
+    if (parts.args.length !== 0) {
+      rejectUnsupported("size requires no arguments when used as a method");
+    }
+    if (receiverName !== "content" && receiverName !== "tags") {
+      rejectUnsupported("size is only supported for content and tags");
+    }
+    visitMemoFilterAst(parts.receiver, boundIds);
+    return;
+  }
+
+  if (memoFilterTimestampMethods.has(parts.name)) {
+    if (receiverName !== "created_ts" && receiverName !== "updated_ts") {
+      rejectUnsupported(`${parts.name} is only supported for timestamp fields`);
+    }
+    if (parts.args.length !== 0) {
+      rejectUnsupported(`${parts.name} does not accept a timezone argument`);
+    }
+    visitMemoFilterAst(parts.receiver, boundIds);
+    return;
+  }
+
   if (
     parts.name !== "flaremo_contains" &&
     parts.name !== "flaremo_startsWith" &&
@@ -607,7 +652,6 @@ function validateReceiverCallSurface(
   ) {
     rejectUnsupported(`method ${parts.name} is not supported`);
   }
-  const receiverName = identifierName(parts.receiver);
   if (receiverName !== "content" && !boundIds.has(receiverName ?? "")) {
     rejectUnsupported("text methods only support content and tag iterators");
   }
@@ -621,6 +665,18 @@ function validateReceiverCallSurface(
   if (parts.name === "flaremo_matches") validateRegexPattern(literal);
   visitMemoFilterAst(parts.receiver, boundIds);
 }
+
+const memoFilterTimestampMethods = new Set([
+  "getDate",
+  "getDayOfMonth",
+  "getDayOfWeek",
+  "getDayOfYear",
+  "getFullYear",
+  "getHours",
+  "getMinutes",
+  "getMonth",
+  "getSeconds",
+]);
 
 function requireAstArray(value: unknown, label: string): MemoFilterAst[] {
   if (!Array.isArray(value) || !value.every(isAstNode)) {
@@ -694,6 +750,14 @@ function stringLiteral(node: MemoFilterAst) {
   return node.op === "value" && typeof node.args === "string"
     ? node.args
     : undefined;
+}
+
+function isIntegerLiteral(node: MemoFilterAst) {
+  return (
+    node.op === "value" &&
+    ((typeof node.args === "number" && Number.isSafeInteger(node.args)) ||
+      typeof node.args === "bigint")
+  );
 }
 
 function identifierName(node: unknown) {

--- a/packages/domain/src/memos-social.ts
+++ b/packages/domain/src/memos-social.ts
@@ -207,6 +207,8 @@ export async function createMemoComment(
   };
   const eventStatement = insertMemosSseEvent(db, {
     type: "memo.comment.created",
+    // The pinned Memos server broadcasts the parent memo so subscribers
+    // refresh the comment collection attached to that resource.
     name: parentId,
     visibility: parent.visibility,
     creatorId: parent.userId,
@@ -864,6 +866,7 @@ function validateShortcut(title: string, filter: string) {
   if (!title) throw new ValidationError("Shortcut title is required");
   if (title.length > 256)
     throw new ValidationError("Shortcut title is too long");
+  if (!filter) throw new ValidationError("Shortcut filter is required");
   if (filter.length > 4_096)
     throw new ValidationError("Shortcut filter is too long");
   if (filter) compileMemoFilter(filter);

--- a/packages/domain/src/relations.ts
+++ b/packages/domain/src/relations.ts
@@ -1,10 +1,11 @@
 import type { PatchMemoRelationsInput } from "@flaremo/contracts";
 import type { FlareMoDb, UserRow } from "@flaremo/db";
 import { memoRelations, memos } from "@flaremo/db";
-import { and, eq, inArray, or } from "drizzle-orm";
+import { and, asc, eq, inArray, or } from "drizzle-orm";
 import { NotFoundError } from "./errors";
 import { parseResourceName } from "./ids";
 import { getMemoById, getMemoByIdForViewer } from "./memos";
+import { insertMemosSseEvent } from "./memos-sse";
 
 export async function listMemoRelations(
   db: FlareMoDb,
@@ -19,6 +20,31 @@ export async function listMemoRelations(
     .where(eq(memoRelations.memoId, normalizedMemoId));
 }
 
+/**
+ * List the complete relation set for a memo, including links where the memo
+ * is the related target. Memos' ListMemoRelations RPC exposes both directions
+ * while the legacy FlareMo relation helper historically returned only the
+ * rows owned by `memoId`; keep the two contracts explicit.
+ */
+export async function listMemoRelationsForViewer(
+  db: FlareMoDb,
+  user: UserRow | null,
+  memoId: string,
+) {
+  const normalizedMemoId = parseResourceName(memoId, "memos");
+  await getMemoByIdForViewer(db, user, normalizedMemoId);
+  return db
+    .select()
+    .from(memoRelations)
+    .where(
+      or(
+        eq(memoRelations.memoId, normalizedMemoId),
+        eq(memoRelations.relatedMemoId, normalizedMemoId),
+      ),
+    )
+    .orderBy(asc(memoRelations.createdAt), asc(memoRelations.memoId));
+}
+
 export async function replaceMemoRelations(
   db: FlareMoDb,
   user: UserRow,
@@ -26,7 +52,7 @@ export async function replaceMemoRelations(
   input: PatchMemoRelationsInput,
 ) {
   const normalizedMemoId = parseResourceName(memoId, "memos");
-  await getMemoById(db, user, normalizedMemoId);
+  const memo = await getMemoById(db, user, normalizedMemoId);
 
   const rows: Array<{
     memoId: string;
@@ -66,10 +92,21 @@ export async function replaceMemoRelations(
   const deleteStatement = db
     .delete(memoRelations)
     .where(eq(memoRelations.memoId, normalizedMemoId));
+  const eventStatement = insertMemosSseEvent(db, {
+    type: "memo.updated",
+    name: memo.id,
+    visibility: memo.visibility,
+    creatorId: memo.userId,
+    createdAt: now,
+  });
   if (rows.length > 0) {
-    await db.batch([deleteStatement, db.insert(memoRelations).values(rows)]);
+    await db.batch([
+      deleteStatement,
+      db.insert(memoRelations).values(rows),
+      eventStatement,
+    ]);
   } else {
-    await deleteStatement;
+    await db.batch([deleteStatement, eventStatement]);
   }
 
   return listMemoRelations(db, user, normalizedMemoId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: 5.20260708.1
         version: 5.20260708.1
+      '@connectrpc/connect':
+        specifier: 2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)
+      '@connectrpc/connect-web':
+        specifier: 2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -595,6 +601,17 @@ packages:
 
   '@cloudflare/workers-types@5.20260708.1':
     resolution: {integrity: sha512-FSRyCsxALKmmNnk/2HMkTiX9Iz9yqTiTWX/BJZdffGznMSunXmQgb3mKy9wGBX2BCTLOuRYWL36uh7/3Gm05Eg==}
+
+  '@connectrpc/connect-web@2.1.1':
+    resolution: {integrity: sha512-J8317Q2MaFRCT1jzVR1o06bZhDIBmU0UAzWx6xOIXzOq8+k71/+k7MUF7AwcBUX+34WIvbm5syRgC5HXQA8fOg==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.1
+
+  '@connectrpc/connect@2.1.1':
+    resolution: {integrity: sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4927,6 +4944,15 @@ snapshots:
     optional: true
 
   '@cloudflare/workers-types@5.20260708.1': {}
+
+  '@connectrpc/connect-web@2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.12.0)
+
+  '@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
## Summary

- Harden the Memos-compatible relation, attachment, comment, shortcut, CEL, SSE, and unary gRPC-Web boundaries.
- Add standard gRPC-Web unary data/trailer and trailers-only error framing, including the required CORS request/exposed headers.
- Add an official generated `@connectrpc/connect` / `@connectrpc/connect-web` binary smoke for the pinned `MemoService` descriptor.
- Record the verified scope and remaining non-parity boundaries in the Chinese and English compatibility documentation and ecosystem matrix.

## Verification

- `pnpm verify`
- `pnpm deploy:dry-run`
- `pnpm exec vitest run apps/worker/src/memos-connect-client.test.ts --reporter=dot`

The full verification passed with 11 Worker test files / 65 tests and 21 Playwright E2E tests. The official generated-client test covers Connect binary `CreateMemo` / `ListMemos` and gRPC-Web binary `GetMemo`, with responses decoded by the pinned generated schema.

## Compatibility boundary

This PR does not claim complete Memos Server parity, native HTTP/2 gRPC, full CEL/SQL parity, complete SSEHub semantics, full gRPC-Web metadata/compression/streaming, official Memos Web compatibility, or third-party client compatibility. Those remain explicitly documented as partial or unverified.
