### PR TITLE
fix(web): 登录页文案清理与视觉重设计

### DIFF
--- a/apps/web/src/components/auth-page-frame.tsx
+++ b/apps/web/src/components/auth-page-frame.tsx
@@ -18,17 +18,42 @@ export function AuthPageFrame({
   title,
 }: {
   children: ReactNode;
-  description: string;
+  description?: string;
   eyebrow?: string;
   title: string;
 }) {
   const { t, toggleLocale } = useI18n();
 
   return (
-    <main className="flex min-h-svh items-center justify-center bg-[radial-gradient(circle_at_top,_var(--color-flame-100),_transparent_42%)] px-4 py-8 dark:bg-[radial-gradient(circle_at_top,_color-mix(in_oklab,var(--color-flame-400)_15%,transparent),_transparent_42%)]">
-      <div className="flex w-full max-w-md flex-col gap-4">
-        <header className="flex items-center justify-between px-1">
-          <FlareMoLogo labelClassName="text-lg" markClassName="size-7" />
+    <main className="grid min-h-svh lg:grid-cols-2">
+      <aside className="relative hidden overflow-hidden bg-flame-700 lg:flex lg:flex-col lg:justify-between lg:p-12">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0"
+        >
+          <div className="absolute -top-32 -left-32 size-112 rounded-full bg-flame-500/50 blur-3xl" />
+          <div className="absolute -right-24 -bottom-24 size-96 rounded-full bg-flame-coral/40 blur-3xl" />
+        </div>
+        <div className="relative flex items-center gap-2.5">
+          <img
+            alt=""
+            aria-hidden="true"
+            className="size-8"
+            src="/brand/flaremo-mark-dark-320.png"
+          />
+          <span className="font-heading text-lg font-semibold tracking-tight text-flame-50">
+            FlareMo
+          </span>
+        </div>
+        <p className="relative max-w-md font-heading text-4xl font-semibold leading-snug tracking-tight text-flame-50">
+          {t("auth.brandTagline")}
+        </p>
+      </aside>
+      <div className="relative flex items-center justify-center bg-[radial-gradient(circle_at_top,_var(--color-flame-100),_transparent_42%)] px-4 py-8 dark:bg-[radial-gradient(circle_at_top,_color-mix(in_oklab,var(--color-flame-400)_15%,transparent),_transparent_42%)]">
+        <header className="absolute inset-x-0 top-0 flex items-center justify-between p-4 lg:justify-end">
+          <span className="lg:hidden">
+            <FlareMoLogo labelClassName="text-lg" markClassName="size-7" />
+          </span>
           <Button
             aria-label={t("language.toggle")}
             size="sm"
@@ -40,7 +65,7 @@ export function AuthPageFrame({
             {t("language.next")}
           </Button>
         </header>
-        <Card className="shadow-lg shadow-flame-950/5">
+        <Card className="w-full max-w-md shadow-lg">
           <CardHeader className="gap-2">
             {eyebrow ? (
               <p className="text-xs font-semibold tracking-[0.16em] text-primary uppercase">
@@ -48,7 +73,9 @@ export function AuthPageFrame({
               </p>
             ) : null}
             <CardTitle className="text-xl">{title}</CardTitle>
-            <CardDescription>{description}</CardDescription>
+            {description ? (
+              <CardDescription>{description}</CardDescription>
+            ) : null}
           </CardHeader>
           <CardContent>{children}</CardContent>
         </Card>

--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -140,7 +140,8 @@ const messages = {
     "detail.revokeShare": "撤销分享",
     "toast.accessRequired": "登录状态已失效，请重新登录",
     "auth.loginTitle": "登录 FlareMo",
-    "auth.loginDescription": "使用你的 FlareMo 用户名和密码继续。",
+    "auth.brandTagline": "随时落笔，留住想法。",
+    "auth.forgotPasswordHint": "忘记密码？用部署时配置的恢复密钥重置。",
     "auth.username": "用户名",
     "auth.password": "密码",
     "auth.signIn": "登录",
@@ -384,8 +385,9 @@ const messages = {
     "detail.revokeShare": "Revoke share",
     "toast.accessRequired": "Your sign-in has expired. Please sign in again.",
     "auth.loginTitle": "Sign in to FlareMo",
-    "auth.loginDescription":
-      "Continue with your FlareMo username and password.",
+    "auth.brandTagline": "Capture every thought as it lands.",
+    "auth.forgotPasswordHint":
+      "Forgot your password? Reset it with the recovery secret from your deployment.",
     "auth.username": "Username",
     "auth.password": "Password",
     "auth.signIn": "Sign in",

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -75,10 +75,7 @@ export function LoginPage() {
   };
 
   return (
-    <AuthPageFrame
-      description={t("auth.loginDescription")}
-      title={t("auth.loginTitle")}
-    >
+    <AuthPageFrame title={t("auth.loginTitle")}>
       {bootstrapQuery.isError && (
         <p className="mb-4 rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive">
           {t("auth.statusUnavailable")}
@@ -146,6 +143,9 @@ export function LoginPage() {
         >
           {isSubmitting ? t("auth.signingIn") : t("auth.signIn")}
         </Button>
+        <p className="text-center text-xs leading-5 text-muted-foreground">
+          {t("auth.forgotPasswordHint")}
+        </p>
       </form>
     </AuthPageFrame>
   );


### PR DESCRIPTION
## 改动

- 删除零信息增量的登录页描述「使用你的 FlareMo 用户名和密码继续。」（中英），`AuthPageFrame` 的 `description` 改为可选。
- 重设计登录/初始化页：桌面端左侧火焰品牌面板（白色 logo + 品牌标语 + 光晕装饰），右侧表单卡片；移动端折叠为单列居中。
- 登录表单下方新增忘记密码提示，指向已有的 operator recovery 路径（`FLAREMO_RECOVERY_SECRET` → `POST /api/auth/flaremo/recover`）。

## 验证

- `pnpm verify`:biome（仅 main 基线 5 个 warning)、7 包 tsc、worker/web/domain 单测全过。
- `pnpm test:e2e`:21/21 通过（首次跑服务器中途崩溃导致 9 个 ECONNREFUSED，重跑全绿）。
- 截图目检：桌面亮色/暗色、英文、移动端（`.wrangler-screenshots/login/`)。

Closes #67