### PR TITLE
feat(memory): add memory domain schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 test-results/
 playwright-report/
 backups/
+.zcode/

--- a/migrations/0011_daffy_ultron.sql
+++ b/migrations/0011_daffy_ultron.sql
@@ -1,0 +1,97 @@
+CREATE TABLE `memory_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`content` text NOT NULL,
+	`type` text DEFAULT 'semantic' NOT NULL,
+	`kind` text DEFAULT 'fact' NOT NULL,
+	`scope_type` text DEFAULT 'global' NOT NULL,
+	`scope_key` text,
+	`tier` text DEFAULT 'normal' NOT NULL,
+	`verification` text DEFAULT 'observed' NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`importance` integer DEFAULT 50 NOT NULL,
+	`confidence` integer DEFAULT 50 NOT NULL,
+	`needs_review` integer DEFAULT false NOT NULL,
+	`review_reason` text,
+	`created_by_type` text DEFAULT 'agent' NOT NULL,
+	`source_agent` text,
+	`source_session` text,
+	`source_ref` text,
+	`valid_from` text,
+	`valid_to` text,
+	`fingerprint` text NOT NULL,
+	`access_count` integer DEFAULT 0 NOT NULL,
+	`last_accessed_at` text,
+	`embedding_status` text DEFAULT 'not_indexed' NOT NULL,
+	`embedding_version` text,
+	`embedded_at` text,
+	`embedding_error` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	`deleted_at` text,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `memory_items_user_scope_status_idx` ON `memory_items` (`user_id`,`scope_type`,`scope_key`,`status`);--> statement-breakpoint
+CREATE INDEX `memory_items_user_type_kind_idx` ON `memory_items` (`user_id`,`type`,`kind`);--> statement-breakpoint
+CREATE INDEX `memory_items_user_tier_idx` ON `memory_items` (`user_id`,`tier`);--> statement-breakpoint
+CREATE UNIQUE INDEX `memory_items_user_fingerprint_idx` ON `memory_items` (`user_id`,`fingerprint`);--> statement-breakpoint
+CREATE TABLE `memory_relations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`memory_id` text NOT NULL,
+	`related_memory_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`type` text DEFAULT 'related_to' NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`memory_id`) REFERENCES `memory_items`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`related_memory_id`) REFERENCES `memory_items`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `memory_relations_memory_related_type_idx` ON `memory_relations` (`memory_id`,`related_memory_id`,`type`);--> statement-breakpoint
+CREATE INDEX `memory_relations_related_idx` ON `memory_relations` (`related_memory_id`,`type`);--> statement-breakpoint
+CREATE TABLE `memory_resource_links` (
+	`id` text PRIMARY KEY NOT NULL,
+	`memory_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`resource_type` text NOT NULL,
+	`resource_ref` text NOT NULL,
+	`relation_type` text DEFAULT 'derived_from' NOT NULL,
+	`metadata` text DEFAULT '{}' NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`memory_id`) REFERENCES `memory_items`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `memory_resource_links_memory_idx` ON `memory_resource_links` (`memory_id`);--> statement-breakpoint
+CREATE INDEX `memory_resource_links_resource_idx` ON `memory_resource_links` (`resource_type`,`resource_ref`);--> statement-breakpoint
+CREATE TABLE `memory_revisions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`memory_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`content` text NOT NULL,
+	`metadata_snapshot` text DEFAULT '{}' NOT NULL,
+	`created_by_type` text NOT NULL,
+	`created_by_agent` text,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`memory_id`) REFERENCES `memory_items`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `memory_revisions_memory_created_idx` ON `memory_revisions` (`memory_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `memory_revisions_user_created_idx` ON `memory_revisions` (`user_id`,`created_at`);--> statement-breakpoint
+CREATE VIRTUAL TABLE `memory_fts` USING fts5(
+	`memory_id` UNINDEXED,
+	`content`,
+	tokenize = 'trigram'
+);--> statement-breakpoint
+CREATE TRIGGER `memory_fts_insert` AFTER INSERT ON `memory_items` BEGIN
+	INSERT INTO `memory_fts` (`memory_id`, `content`) VALUES (new.`id`, new.`content`);
+END;--> statement-breakpoint
+CREATE TRIGGER `memory_fts_update` AFTER UPDATE OF `content` ON `memory_items` BEGIN
+	DELETE FROM `memory_fts` WHERE `memory_id` = old.`id`;
+	INSERT INTO `memory_fts` (`memory_id`, `content`) VALUES (new.`id`, new.`content`);
+END;--> statement-breakpoint
+CREATE TRIGGER `memory_fts_delete` AFTER DELETE ON `memory_items` BEGIN
+	DELETE FROM `memory_fts` WHERE `memory_id` = old.`id`;
+END;

--- a/migrations/meta/0011_snapshot.json
+++ b/migrations/meta/0011_snapshot.json
@@ -1,0 +1,3095 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "852b1ec7-bbac-46a7-853b-b540409c2882",
+  "prevId": "ffb12a65-5c0c-4e2a-b83c-c1400f65e319",
+  "tables": {
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo_id": {
+          "name": "memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attachments_user_created_idx": {
+          "name": "attachments_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "attachments_memo_idx": {
+          "name": "attachments_memo_idx",
+          "columns": [
+            "memo_id"
+          ],
+          "isUnique": false
+        },
+        "attachments_user_client_id_idx": {
+          "name": "attachments_user_client_id_idx",
+          "columns": [
+            "user_id",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "attachments_user_state_created_idx": {
+          "name": "attachments_user_state_created_idx",
+          "columns": [
+            "user_id",
+            "state",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attachments_user_id_users_id_fk": {
+          "name": "attachments_user_id_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachments_memo_id_memos_id_fk": {
+          "name": "attachments_memo_id_memos_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_accounts": {
+      "name": "auth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_accounts_provider_account_idx": {
+          "name": "auth_accounts_provider_account_idx",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        },
+        "auth_accounts_user_id_idx": {
+          "name": "auth_accounts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_auth_users_id_fk": {
+          "name": "auth_accounts_user_id_auth_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_apikeys": {
+      "name": "auth_apikeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'memos'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_apikeys_key_idx": {
+          "name": "auth_apikeys_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "auth_apikeys_reference_config_idx": {
+          "name": "auth_apikeys_reference_config_idx",
+          "columns": [
+            "reference_id",
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "auth_apikeys_expires_at_idx": {
+          "name": "auth_apikeys_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_apikeys_reference_id_auth_users_id_fk": {
+          "name": "auth_apikeys_reference_id_auth_users_id_fk",
+          "tableFrom": "auth_apikeys",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_bootstrap": {
+      "name": "auth_bootstrap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flaremo_user_id": {
+          "name": "flaremo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_bootstrap_auth_user_id_auth_users_id_fk": {
+          "name": "auth_bootstrap_auth_user_id_auth_users_id_fk",
+          "tableFrom": "auth_bootstrap",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "auth_bootstrap_flaremo_user_id_users_id_fk": {
+          "name": "auth_bootstrap_flaremo_user_id_users_id_fk",
+          "tableFrom": "auth_bootstrap",
+          "tableTo": "users",
+          "columnsFrom": [
+            "flaremo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_sessions": {
+      "name": "auth_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_idx": {
+          "name": "auth_sessions_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_auth_users_id_fk": {
+          "name": "auth_sessions_user_id_auth_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_user_links": {
+      "name": "auth_user_links",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flaremo_user_id": {
+          "name": "flaremo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_user_links_flaremo_user_id_idx": {
+          "name": "auth_user_links_flaremo_user_id_idx",
+          "columns": [
+            "flaremo_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auth_user_links_auth_user_id_auth_users_id_fk": {
+          "name": "auth_user_links_auth_user_id_auth_users_id_fk",
+          "tableFrom": "auth_user_links",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_user_links_flaremo_user_id_users_id_fk": {
+          "name": "auth_user_links_flaremo_user_id_users_id_fk",
+          "tableFrom": "auth_user_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "flaremo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_users": {
+      "name": "auth_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_users_email_idx": {
+          "name": "auth_users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "auth_users_username_idx": {
+          "name": "auth_users_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_verifications": {
+      "name": "auth_verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "data_tasks": {
+      "name": "data_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'created'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "manifest_key": {
+          "name": "manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_done": {
+          "name": "progress_done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress_total": {
+          "name": "progress_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "data_tasks_user_created_idx": {
+          "name": "data_tasks_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "data_tasks_status_lease_idx": {
+          "name": "data_tasks_status_lease_idx",
+          "columns": [
+            "status",
+            "lease_until"
+          ],
+          "isUnique": false
+        },
+        "data_tasks_expires_idx": {
+          "name": "data_tasks_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "data_tasks_user_id_users_id_fk": {
+          "name": "data_tasks_user_id_users_id_fk",
+          "tableFrom": "data_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memo_relations": {
+      "name": "memo_relations",
+      "columns": {
+        "memo_id": {
+          "name": "memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_memo_id": {
+          "name": "related_memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'reference'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memo_relations_related_type_memo_idx": {
+          "name": "memo_relations_related_type_memo_idx",
+          "columns": [
+            "related_memo_id",
+            "type",
+            "memo_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memo_relations_memo_id_memos_id_fk": {
+          "name": "memo_relations_memo_id_memos_id_fk",
+          "tableFrom": "memo_relations",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memo_relations_related_memo_id_memos_id_fk": {
+          "name": "memo_relations_related_memo_id_memos_id_fk",
+          "tableFrom": "memo_relations",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "related_memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memo_relations_memo_id_related_memo_id_type_pk": {
+          "columns": [
+            "memo_id",
+            "related_memo_id",
+            "type"
+          ],
+          "name": "memo_relations_memo_id_related_memo_id_type_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memo_revisions": {
+      "name": "memo_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo_id": {
+          "name": "memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memo_revisions_memo_created_idx": {
+          "name": "memo_revisions_memo_created_idx",
+          "columns": [
+            "memo_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "memo_revisions_user_created_idx": {
+          "name": "memo_revisions_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memo_revisions_memo_id_memos_id_fk": {
+          "name": "memo_revisions_memo_id_memos_id_fk",
+          "tableFrom": "memo_revisions",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memo_revisions_user_id_users_id_fk": {
+          "name": "memo_revisions_user_id_users_id_fk",
+          "tableFrom": "memo_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memo_tags": {
+      "name": "memo_tags",
+      "columns": {
+        "memo_id": {
+          "name": "memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memo_tags_user_tag_memo_idx": {
+          "name": "memo_tags_user_tag_memo_idx",
+          "columns": [
+            "user_id",
+            "tag",
+            "memo_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memo_tags_memo_id_memos_id_fk": {
+          "name": "memo_tags_memo_id_memos_id_fk",
+          "tableFrom": "memo_tags",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memo_tags_user_id_users_id_fk": {
+          "name": "memo_tags_user_id_users_id_fk",
+          "tableFrom": "memo_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memo_tags_memo_id_tag_pk": {
+          "columns": [
+            "memo_id",
+            "tag"
+          ],
+          "name": "memo_tags_memo_id_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memory_items": {
+      "name": "memory_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'semantic'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'fact'"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "verification": {
+          "name": "verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'observed'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "importance": {
+          "name": "importance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_type": {
+          "name": "created_by_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "source_agent": {
+          "name": "source_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session": {
+          "name": "source_session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_status": {
+          "name": "embedding_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_indexed'"
+        },
+        "embedding_version": {
+          "name": "embedding_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_error": {
+          "name": "embedding_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memory_items_user_scope_status_idx": {
+          "name": "memory_items_user_scope_status_idx",
+          "columns": [
+            "user_id",
+            "scope_type",
+            "scope_key",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "memory_items_user_type_kind_idx": {
+          "name": "memory_items_user_type_kind_idx",
+          "columns": [
+            "user_id",
+            "type",
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "memory_items_user_tier_idx": {
+          "name": "memory_items_user_tier_idx",
+          "columns": [
+            "user_id",
+            "tier"
+          ],
+          "isUnique": false
+        },
+        "memory_items_user_fingerprint_idx": {
+          "name": "memory_items_user_fingerprint_idx",
+          "columns": [
+            "user_id",
+            "fingerprint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "memory_items_user_id_users_id_fk": {
+          "name": "memory_items_user_id_users_id_fk",
+          "tableFrom": "memory_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memory_relations": {
+      "name": "memory_relations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_memory_id": {
+          "name": "related_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'related_to'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memory_relations_memory_related_type_idx": {
+          "name": "memory_relations_memory_related_type_idx",
+          "columns": [
+            "memory_id",
+            "related_memory_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "memory_relations_related_idx": {
+          "name": "memory_relations_related_idx",
+          "columns": [
+            "related_memory_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memory_relations_memory_id_memory_items_id_fk": {
+          "name": "memory_relations_memory_id_memory_items_id_fk",
+          "tableFrom": "memory_relations",
+          "tableTo": "memory_items",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_relations_related_memory_id_memory_items_id_fk": {
+          "name": "memory_relations_related_memory_id_memory_items_id_fk",
+          "tableFrom": "memory_relations",
+          "tableTo": "memory_items",
+          "columnsFrom": [
+            "related_memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_relations_user_id_users_id_fk": {
+          "name": "memory_relations_user_id_users_id_fk",
+          "tableFrom": "memory_relations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memory_resource_links": {
+      "name": "memory_resource_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'derived_from'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memory_resource_links_memory_idx": {
+          "name": "memory_resource_links_memory_idx",
+          "columns": [
+            "memory_id"
+          ],
+          "isUnique": false
+        },
+        "memory_resource_links_resource_idx": {
+          "name": "memory_resource_links_resource_idx",
+          "columns": [
+            "resource_type",
+            "resource_ref"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memory_resource_links_memory_id_memory_items_id_fk": {
+          "name": "memory_resource_links_memory_id_memory_items_id_fk",
+          "tableFrom": "memory_resource_links",
+          "tableTo": "memory_items",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_resource_links_user_id_users_id_fk": {
+          "name": "memory_resource_links_user_id_users_id_fk",
+          "tableFrom": "memory_resource_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memory_revisions": {
+      "name": "memory_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_snapshot": {
+          "name": "metadata_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_by_type": {
+          "name": "created_by_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_agent": {
+          "name": "created_by_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memory_revisions_memory_created_idx": {
+          "name": "memory_revisions_memory_created_idx",
+          "columns": [
+            "memory_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "memory_revisions_user_created_idx": {
+          "name": "memory_revisions_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memory_revisions_memory_id_memory_items_id_fk": {
+          "name": "memory_revisions_memory_id_memory_items_id_fk",
+          "tableFrom": "memory_revisions",
+          "tableTo": "memory_items",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_revisions_user_id_users_id_fk": {
+          "name": "memory_revisions_user_id_users_id_fk",
+          "tableFrom": "memory_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memos": {
+      "name": "memos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'web'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memos_user_status_pinned_created_id_idx": {
+          "name": "memos_user_status_pinned_created_id_idx",
+          "columns": [
+            "user_id",
+            "status",
+            "pinned",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "memos_user_updated_id_idx": {
+          "name": "memos_user_updated_id_idx",
+          "columns": [
+            "user_id",
+            "updated_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "memos_user_client_id_idx": {
+          "name": "memos_user_client_id_idx",
+          "columns": [
+            "user_id",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "memos_visibility_idx": {
+          "name": "memos_visibility_idx",
+          "columns": [
+            "visibility"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memos_user_id_users_id_fk": {
+          "name": "memos_user_id_users_id_fk",
+          "tableFrom": "memos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memos_notifications": {
+      "name": "memos_notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unread'"
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo_id": {
+          "name": "memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_memo_id": {
+          "name": "related_memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memos_notifications_receiver_source_type_idx": {
+          "name": "memos_notifications_receiver_source_type_idx",
+          "columns": [
+            "receiver_id",
+            "source_event_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "memos_notifications_receiver_created_id_idx": {
+          "name": "memos_notifications_receiver_created_id_idx",
+          "columns": [
+            "receiver_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "memos_notifications_receiver_status_created_idx": {
+          "name": "memos_notifications_receiver_status_created_idx",
+          "columns": [
+            "receiver_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memos_notifications_receiver_id_users_id_fk": {
+          "name": "memos_notifications_receiver_id_users_id_fk",
+          "tableFrom": "memos_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memos_notifications_sender_id_users_id_fk": {
+          "name": "memos_notifications_sender_id_users_id_fk",
+          "tableFrom": "memos_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memos_notifications_memo_id_memos_id_fk": {
+          "name": "memos_notifications_memo_id_memos_id_fk",
+          "tableFrom": "memos_notifications",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memos_notifications_related_memo_id_memos_id_fk": {
+          "name": "memos_notifications_related_memo_id_memos_id_fk",
+          "tableFrom": "memos_notifications",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "related_memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memos_sse_events": {
+      "name": "memos_sse_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memos_sse_events_created_id_idx": {
+          "name": "memos_sse_events_created_id_idx",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "memos_sse_events_creator_id_idx": {
+          "name": "memos_sse_events_creator_id_idx",
+          "columns": [
+            "creator_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memos_sse_events_creator_id_users_id_fk": {
+          "name": "memos_sse_events_creator_id_users_id_fk",
+          "tableFrom": "memos_sse_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memos_webhook_deliveries": {
+      "name": "memos_webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memos_webhook_deliveries_event_webhook_idx": {
+          "name": "memos_webhook_deliveries_event_webhook_idx",
+          "columns": [
+            "event_id",
+            "webhook_id"
+          ],
+          "isUnique": true
+        },
+        "memos_webhook_deliveries_claim_idx": {
+          "name": "memos_webhook_deliveries_claim_idx",
+          "columns": [
+            "status",
+            "next_attempt_at",
+            "lease_until"
+          ],
+          "isUnique": false
+        },
+        "memos_webhook_deliveries_event_idx": {
+          "name": "memos_webhook_deliveries_event_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memos_webhook_deliveries_event_id_memos_webhook_events_id_fk": {
+          "name": "memos_webhook_deliveries_event_id_memos_webhook_events_id_fk",
+          "tableFrom": "memos_webhook_deliveries",
+          "tableTo": "memos_webhook_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memos_webhook_deliveries_webhook_id_memos_webhooks_id_fk": {
+          "name": "memos_webhook_deliveries_webhook_id_memos_webhooks_id_fk",
+          "tableFrom": "memos_webhook_deliveries",
+          "tableTo": "memos_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memos_webhook_events": {
+      "name": "memos_webhook_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expanded_at": {
+          "name": "expanded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memos_webhook_events_receiver_created_idx": {
+          "name": "memos_webhook_events_receiver_created_idx",
+          "columns": [
+            "receiver_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "memos_webhook_events_expanded_created_idx": {
+          "name": "memos_webhook_events_expanded_created_idx",
+          "columns": [
+            "expanded_at",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memos_webhook_events_receiver_id_users_id_fk": {
+          "name": "memos_webhook_events_receiver_id_users_id_fk",
+          "tableFrom": "memos_webhook_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memos_webhooks": {
+      "name": "memos_webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memos_webhooks_user_created_id_idx": {
+          "name": "memos_webhooks_user_created_id_idx",
+          "columns": [
+            "user_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memos_webhooks_user_id_users_id_fk": {
+          "name": "memos_webhooks_user_id_users_id_fk",
+          "tableFrom": "memos_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reactions": {
+      "name": "reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reactions_creator_content_type_idx": {
+          "name": "reactions_creator_content_type_idx",
+          "columns": [
+            "creator_id",
+            "content_id",
+            "reaction_type"
+          ],
+          "isUnique": true
+        },
+        "reactions_content_created_id_idx": {
+          "name": "reactions_content_created_id_idx",
+          "columns": [
+            "content_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "reactions_creator_idx": {
+          "name": "reactions_creator_idx",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reactions_creator_id_users_id_fk": {
+          "name": "reactions_creator_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_content_id_memos_id_fk": {
+          "name": "reactions_content_id_memos_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_user_id_key_pk": {
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "name": "settings_user_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo_id": {
+          "name": "memo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shares_token_idx": {
+          "name": "shares_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "shares_memo_idx": {
+          "name": "shares_memo_idx",
+          "columns": [
+            "memo_id"
+          ],
+          "isUnique": false
+        },
+        "shares_user_memo_revoked_idx": {
+          "name": "shares_user_memo_revoked_idx",
+          "columns": [
+            "user_id",
+            "memo_id",
+            "revoked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "shares_memo_id_memos_id_fk": {
+          "name": "shares_memo_id_memos_id_fk",
+          "tableFrom": "shares",
+          "tableTo": "memos",
+          "columnsFrom": [
+            "memo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shares_user_id_users_id_fk": {
+          "name": "shares_user_id_users_id_fk",
+          "tableFrom": "shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shortcuts": {
+      "name": "shortcuts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shortcuts_user_created_id_idx": {
+          "name": "shortcuts_user_created_id_idx",
+          "columns": [
+            "user_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "shortcuts_user_id_users_id_fk": {
+          "name": "shortcuts_user_id_users_id_fk",
+          "tableFrom": "shortcuts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1786380428760,
       "tag": "0010_deep_gateway",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1787417444838,
+      "tag": "0011_daffy_ultron",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./memory";
 export * from "./memos";
 export * from "./memos-current";
 export * from "./openapi";

--- a/packages/contracts/src/memory.test.ts
+++ b/packages/contracts/src/memory.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkpointInputSchema,
+  createMemorySchema,
+  forgetInputSchema,
+  rememberInputSchema,
+  updateMemorySchema,
+} from "./memory";
+
+describe("memory contracts", () => {
+  it("createMemorySchema defaults to user-confirmed, global, semantic fact", () => {
+    const parsed = createMemorySchema.parse({ content: "FlareMo 使用 D1" });
+    expect(parsed).toMatchObject({
+      content: "FlareMo 使用 D1",
+      type: "semantic",
+      kind: "fact",
+      scope_type: "global",
+      tier: "normal",
+      importance: 50,
+      lock: false,
+    });
+  });
+
+  it("createMemorySchema rejects empty content and oversized content", () => {
+    expect(() => createMemorySchema.parse({ content: "  " })).toThrow();
+    expect(() =>
+      createMemorySchema.parse({ content: "x".repeat(4_001) }),
+    ).toThrow();
+  });
+
+  it("updateMemorySchema requires at least one field", () => {
+    expect(() => updateMemorySchema.parse({})).toThrow();
+    expect(updateMemorySchema.parse({ content: "new" }).content).toBe("new");
+  });
+
+  it("rememberInputSchema forbids an agent from locking", () => {
+    expect(
+      rememberInputSchema.parse({ content: "x", verification: "observed" })
+        .verification,
+    ).toBe("observed");
+    expect(() =>
+      rememberInputSchema.parse({ content: "x", verification: "locked" }),
+    ).toThrow();
+  });
+
+  it("checkpointInputSchema caps items at 20", () => {
+    const items = Array.from({ length: 21 }, (_, i) => ({
+      content: `item ${i}`,
+    }));
+    expect(() =>
+      checkpointInputSchema.parse({ agent: "codex", summary: "s", items }),
+    ).toThrow();
+    expect(
+      checkpointInputSchema.parse({
+        agent: "codex",
+        summary: "s",
+        items: items.slice(0, 20),
+      }).items,
+    ).toHaveLength(20);
+  });
+
+  it("forgetInputSchema defaults reason to superseded", () => {
+    expect(forgetInputSchema.parse({ memory_id: "memories/x" }).reason).toBe(
+      "superseded",
+    );
+  });
+});

--- a/packages/contracts/src/memory.ts
+++ b/packages/contracts/src/memory.ts
@@ -1,0 +1,277 @@
+import { z } from "zod";
+
+// --- Domain enums -----------------------------------------------------------
+
+export const memoryTypeSchema = z.enum(["semantic", "episodic", "procedural"]);
+
+export const memoryKindSchema = z.enum([
+  "preference",
+  "fact",
+  "decision",
+  "constraint",
+  "entity",
+  "event",
+  "outcome",
+  "lesson",
+  "procedure",
+]);
+
+export const memoryScopeTypeSchema = z.enum([
+  "global",
+  "workspace",
+  "project",
+  "agent",
+]);
+
+export const memoryTierSchema = z.enum(["core", "normal"]);
+
+export const memoryVerificationSchema = z.enum([
+  "inferred",
+  "observed",
+  "confirmed",
+  "locked",
+]);
+
+export const memoryStatusSchema = z.enum([
+  "active",
+  "superseded",
+  "disputed",
+  "archived",
+  "deleted",
+]);
+
+export const memoryRelationTypeSchema = z.enum([
+  "related_to",
+  "supports",
+  "contradicts",
+  "supersedes",
+  "depends_on",
+  "part_of",
+]);
+
+export const memoryResourceTypeSchema = z.enum([
+  "memo",
+  "session",
+  "github",
+  "url",
+  "document",
+  "other",
+]);
+
+export const memoryResourceRelationTypeSchema = z.enum([
+  "derived_from",
+  "evidence",
+  "references",
+  "promoted_to",
+]);
+
+export const memoryCreatedByTypeSchema = z.enum(["user", "agent"]);
+
+export const memoryEmbeddingStatusSchema = z.enum([
+  "not_indexed",
+  "pending",
+  "indexed",
+  "error",
+]);
+
+export const memoryForgetReasonSchema = z.enum([
+  "incorrect",
+  "superseded",
+  "expired",
+  "irrelevant",
+]);
+
+// --- DTO --------------------------------------------------------------------
+
+export const memoryDtoSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  type: memoryTypeSchema,
+  kind: memoryKindSchema,
+  scope_type: memoryScopeTypeSchema,
+  scope_key: z.string().nullable(),
+  tier: memoryTierSchema,
+  verification: memoryVerificationSchema,
+  status: memoryStatusSchema,
+  importance: z.number().int().min(0).max(100),
+  confidence: z.number().int().min(0).max(100),
+  needs_review: z.boolean(),
+  review_reason: z.string().nullable(),
+  created_by_type: memoryCreatedByTypeSchema,
+  source_agent: z.string().nullable(),
+  source_session: z.string().nullable(),
+  source_ref: z.string().nullable(),
+  valid_from: z.string().nullable(),
+  valid_to: z.string().nullable(),
+  access_count: z.number().int(),
+  last_accessed_at: z.string().nullable(),
+  embedding_status: memoryEmbeddingStatusSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export const memoryRevisionDtoSchema = z.object({
+  id: z.string(),
+  memory_id: z.string(),
+  content: z.string(),
+  metadata_snapshot: z.record(z.string(), z.unknown()),
+  created_by_type: memoryCreatedByTypeSchema,
+  created_by_agent: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export const memoryRelationDtoSchema = z.object({
+  memory_id: z.string(),
+  related_memory_id: z.string(),
+  type: memoryRelationTypeSchema,
+  created_at: z.string(),
+});
+
+export const memoryResourceLinkDtoSchema = z.object({
+  memory_id: z.string(),
+  resource_type: memoryResourceTypeSchema,
+  resource_ref: z.string(),
+  relation_type: memoryResourceRelationTypeSchema,
+  metadata: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+});
+
+// --- REST request schemas ---------------------------------------------------
+
+export const createMemorySchema = z.object({
+  content: z.string().trim().min(1).max(4_000),
+  type: memoryTypeSchema.default("semantic"),
+  kind: memoryKindSchema.default("fact"),
+  scope_type: memoryScopeTypeSchema.default("global"),
+  scope_key: z.string().trim().max(512).optional(),
+  tier: memoryTierSchema.default("normal"),
+  importance: z.number().int().min(0).max(100).default(50),
+  // A user-created memory is always `confirmed`, unless the user explicitly
+  // locks it at creation time.
+  lock: z.boolean().default(false),
+});
+
+export const updateMemorySchema = z
+  .object({
+    content: z.string().trim().min(1).max(4_000).optional(),
+    type: memoryTypeSchema.optional(),
+    kind: memoryKindSchema.optional(),
+    scope_type: memoryScopeTypeSchema.optional(),
+    scope_key: z.string().trim().max(512).optional(),
+    tier: memoryTierSchema.optional(),
+    importance: z.number().int().min(0).max(100).optional(),
+  })
+  .refine(
+    (value) => Object.keys(value).length > 0,
+    "At least one field must be updated.",
+  );
+
+export const listMemoriesQuerySchema = z.object({
+  page_size: z.coerce.number().int().min(1).max(100).default(30),
+  page_token: z.string().optional(),
+  q: z.string().trim().max(500).optional(),
+  type: memoryTypeSchema.optional(),
+  kind: memoryKindSchema.optional(),
+  scope_type: memoryScopeTypeSchema.optional(),
+  scope_key: z.string().trim().max(512).optional(),
+  tier: memoryTierSchema.optional(),
+  verification: memoryVerificationSchema.optional(),
+  status: memoryStatusSchema.optional(),
+  source_agent: z.string().trim().max(128).optional(),
+  needs_review: z.coerce.boolean().optional(),
+});
+
+// --- MCP input schemas ------------------------------------------------------
+
+export const bootstrapInputSchema = z.object({
+  agent: z.string().trim().min(1).max(128),
+  project_key: z.string().trim().max(512).optional(),
+  workspace_key: z.string().trim().max(512).optional(),
+  cwd: z.string().trim().max(1_024).optional(),
+  task: z.string().trim().max(4_000).optional(),
+  max_items: z.number().int().min(1).max(50).default(20),
+});
+
+export const recallInputSchema = z.object({
+  query: z.string().trim().min(1).max(4_000),
+  agent: z.string().trim().min(1).max(128),
+  project_key: z.string().trim().max(512).optional(),
+  workspace_key: z.string().trim().max(512).optional(),
+  types: z.array(memoryTypeSchema).optional(),
+  kinds: z.array(memoryKindSchema).optional(),
+  limit: z.number().int().min(1).max(20).default(8),
+});
+
+export const rememberInputSchema = z.object({
+  content: z.string().trim().min(1).max(4_000),
+  type: memoryTypeSchema.default("semantic"),
+  kind: memoryKindSchema.default("fact"),
+  scope_type: memoryScopeTypeSchema.default("global"),
+  scope_key: z.string().trim().max(512).optional(),
+  tier: memoryTierSchema.default("normal"),
+  importance: z.number().int().min(0).max(100).default(50),
+  confidence: z.number().int().min(0).max(100).default(50),
+  // Agents may only record what they observed or inferred; confirmation and
+  // locking are user actions surfaced through the web API.
+  verification: z.enum(["inferred", "observed"]).default("observed"),
+  source_agent: z.string().trim().max(128).optional(),
+  source_session: z.string().trim().max(512).optional(),
+  source_ref: z.string().trim().max(512).optional(),
+});
+
+export const checkpointInputSchema = z.object({
+  agent: z.string().trim().min(1).max(128),
+  project_key: z.string().trim().max(512).optional(),
+  scope_type: memoryScopeTypeSchema.default("project"),
+  scope_key: z.string().trim().max(512).optional(),
+  summary: z.string().trim().min(1).max(4_000),
+  items: z
+    .array(
+      z.object({
+        content: z.string().trim().min(1).max(4_000),
+        type: memoryTypeSchema.default("semantic"),
+        kind: memoryKindSchema.default("fact"),
+        importance: z.number().int().min(0).max(100).default(50),
+      }),
+    )
+    .min(1)
+    .max(20),
+});
+
+export const linkInputSchema = z.object({
+  memory_id: z.string().trim().min(1).max(256),
+  related_memory_id: z.string().trim().min(1).max(256).optional(),
+  relation_type: memoryRelationTypeSchema.default("related_to"),
+  resource_type: memoryResourceTypeSchema.optional(),
+  resource_ref: z.string().trim().max(512).optional(),
+  resource_relation_type:
+    memoryResourceRelationTypeSchema.default("references"),
+});
+
+export const forgetInputSchema = z.object({
+  memory_id: z.string().trim().min(1).max(256),
+  reason: memoryForgetReasonSchema.default("superseded"),
+});
+
+// --- Types ------------------------------------------------------------------
+
+export type MemoryType = z.infer<typeof memoryTypeSchema>;
+export type MemoryKind = z.infer<typeof memoryKindSchema>;
+export type MemoryScopeType = z.infer<typeof memoryScopeTypeSchema>;
+export type MemoryTier = z.infer<typeof memoryTierSchema>;
+export type MemoryVerification = z.infer<typeof memoryVerificationSchema>;
+export type MemoryStatus = z.infer<typeof memoryStatusSchema>;
+export type MemoryRelationType = z.infer<typeof memoryRelationTypeSchema>;
+export type MemoryResourceType = z.infer<typeof memoryResourceTypeSchema>;
+export type MemoryDto = z.infer<typeof memoryDtoSchema>;
+export type MemoryRevisionDto = z.infer<typeof memoryRevisionDtoSchema>;
+export type MemoryRelationDto = z.infer<typeof memoryRelationDtoSchema>;
+export type MemoryResourceLinkDto = z.infer<typeof memoryResourceLinkDtoSchema>;
+export type CreateMemoryInput = z.infer<typeof createMemorySchema>;
+export type UpdateMemoryInput = z.infer<typeof updateMemorySchema>;
+export type BootstrapInput = z.infer<typeof bootstrapInputSchema>;
+export type RecallInput = z.infer<typeof recallInputSchema>;
+export type RememberInput = z.infer<typeof rememberInputSchema>;
+export type CheckpointInput = z.infer<typeof checkpointInputSchema>;
+export type LinkInput = z.infer<typeof linkInputSchema>;
+export type ForgetInput = z.infer<typeof forgetInputSchema>;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -659,6 +659,216 @@ export const dataTasks = sqliteTable(
   ],
 );
 
+// Agent Memory keeps AI-contributed long-term knowledge separate from the
+// user's memo timeline. Each memory is an atomic conclusion (see
+// docs/product-requirements.md and the Agent Memory design); long-form content
+// belongs in a memo, and a memory's `content` only stores the conclusion.
+// D1 remains the single source of truth: FTS and any future embedding index
+// are derived and rebuildable from these rows.
+export const memoryItems = sqliteTable(
+  "memory_items",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    content: text("content").notNull(),
+    type: text("type", {
+      enum: ["semantic", "episodic", "procedural"],
+    })
+      .notNull()
+      .default("semantic"),
+    kind: text("kind", {
+      enum: [
+        "preference",
+        "fact",
+        "decision",
+        "constraint",
+        "entity",
+        "event",
+        "outcome",
+        "lesson",
+        "procedure",
+      ],
+    })
+      .notNull()
+      .default("fact"),
+    scopeType: text("scope_type", {
+      enum: ["global", "workspace", "project", "agent"],
+    })
+      .notNull()
+      .default("global"),
+    scopeKey: text("scope_key"),
+    tier: text("tier", { enum: ["core", "normal"] })
+      .notNull()
+      .default("normal"),
+    verification: text("verification", {
+      enum: ["inferred", "observed", "confirmed", "locked"],
+    })
+      .notNull()
+      .default("observed"),
+    status: text("status", {
+      enum: ["active", "superseded", "disputed", "archived", "deleted"],
+    })
+      .notNull()
+      .default("active"),
+    importance: integer("importance").notNull().default(50),
+    confidence: integer("confidence").notNull().default(50),
+    needsReview: integer("needs_review", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    reviewReason: text("review_reason"),
+    createdByType: text("created_by_type", { enum: ["user", "agent"] })
+      .notNull()
+      .default("agent"),
+    sourceAgent: text("source_agent"),
+    sourceSession: text("source_session"),
+    sourceRef: text("source_ref"),
+    validFrom: text("valid_from"),
+    validTo: text("valid_to"),
+    // Normalized content + type + kind + scope hash, used to reject exact
+    // duplicates without an embedding index.
+    fingerprint: text("fingerprint").notNull(),
+    accessCount: integer("access_count").notNull().default(0),
+    lastAccessedAt: text("last_accessed_at"),
+    // Reserved for the optional P1 embedding layer. P0 keeps these at
+    // `not_indexed` and never touches a vector binding.
+    embeddingStatus: text("embedding_status", {
+      enum: ["not_indexed", "pending", "indexed", "error"],
+    })
+      .notNull()
+      .default("not_indexed"),
+    embeddingVersion: text("embedding_version"),
+    embeddedAt: text("embedded_at"),
+    embeddingError: text("embedding_error"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("memory_items_user_scope_status_idx").on(
+      table.userId,
+      table.scopeType,
+      table.scopeKey,
+      table.status,
+    ),
+    index("memory_items_user_type_kind_idx").on(
+      table.userId,
+      table.type,
+      table.kind,
+    ),
+    index("memory_items_user_tier_idx").on(table.userId, table.tier),
+    uniqueIndex("memory_items_user_fingerprint_idx").on(
+      table.userId,
+      table.fingerprint,
+    ),
+  ],
+);
+
+export const memoryRevisions = sqliteTable(
+  "memory_revisions",
+  {
+    id: text("id").primaryKey(),
+    memoryId: text("memory_id")
+      .notNull()
+      .references(() => memoryItems.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    content: text("content").notNull(),
+    metadataSnapshot: text("metadata_snapshot", { mode: "json" })
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    createdByType: text("created_by_type", {
+      enum: ["user", "agent"],
+    }).notNull(),
+    createdByAgent: text("created_by_agent"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("memory_revisions_memory_created_idx").on(
+      table.memoryId,
+      table.createdAt,
+    ),
+    index("memory_revisions_user_created_idx").on(
+      table.userId,
+      table.createdAt,
+    ),
+  ],
+);
+
+export const memoryRelations = sqliteTable(
+  "memory_relations",
+  {
+    id: text("id").primaryKey(),
+    memoryId: text("memory_id")
+      .notNull()
+      .references(() => memoryItems.id, { onDelete: "cascade" }),
+    relatedMemoryId: text("related_memory_id")
+      .notNull()
+      .references(() => memoryItems.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: text("type", {
+      enum: [
+        "related_to",
+        "supports",
+        "contradicts",
+        "supersedes",
+        "depends_on",
+        "part_of",
+      ],
+    })
+      .notNull()
+      .default("related_to"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("memory_relations_memory_related_type_idx").on(
+      table.memoryId,
+      table.relatedMemoryId,
+      table.type,
+    ),
+    index("memory_relations_related_idx").on(table.relatedMemoryId, table.type),
+  ],
+);
+
+export const memoryResourceLinks = sqliteTable(
+  "memory_resource_links",
+  {
+    id: text("id").primaryKey(),
+    memoryId: text("memory_id")
+      .notNull()
+      .references(() => memoryItems.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    resourceType: text("resource_type", {
+      enum: ["memo", "session", "github", "url", "document", "other"],
+    }).notNull(),
+    resourceRef: text("resource_ref").notNull(),
+    relationType: text("relation_type", {
+      enum: ["derived_from", "evidence", "references", "promoted_to"],
+    })
+      .notNull()
+      .default("derived_from"),
+    metadata: text("metadata", { mode: "json" })
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("memory_resource_links_memory_idx").on(table.memoryId),
+    index("memory_resource_links_resource_idx").on(
+      table.resourceType,
+      table.resourceRef,
+    ),
+  ],
+);
+
 export type MemoPayload = {
   tags?: string[];
   property?: {
@@ -693,3 +903,8 @@ export type AttachmentRow = typeof attachments.$inferSelect;
 export type ShareRow = typeof shares.$inferSelect;
 export type DataTaskRow = typeof dataTasks.$inferSelect;
 export type NewDataTaskRow = typeof dataTasks.$inferInsert;
+export type MemoryItemRow = typeof memoryItems.$inferSelect;
+export type NewMemoryItemRow = typeof memoryItems.$inferInsert;
+export type MemoryRevisionRow = typeof memoryRevisions.$inferSelect;
+export type MemoryRelationRow = typeof memoryRelations.$inferSelect;
+export type MemoryResourceLinkRow = typeof memoryResourceLinks.$inferSelect;

--- a/packages/domain/src/ids.ts
+++ b/packages/domain/src/ids.ts
@@ -1,12 +1,12 @@
 export function createResourceId(
-  prefix: "attachments" | "memos" | "revisions" | "shares",
+  prefix: "attachments" | "memos" | "memories" | "revisions" | "shares",
 ) {
   return `${prefix}/${crypto.randomUUID()}`;
 }
 
 export function parseResourceName(
   name: string,
-  prefix: "attachments" | "memos" | "revisions" | "shares",
+  prefix: "attachments" | "memos" | "memories" | "revisions" | "shares",
 ) {
   if (name.startsWith(`${prefix}/`)) {
     return name;


### PR DESCRIPTION
## 验证

```bash
pnpm check
pnpm --filter @flaremo/contracts test
pnpm deploy:dry-run
pnpm format:check
```

## 内容

- `packages/db/src/schema.ts`：新增 `memory_items` / `memory_revisions` / `memory_relations` / `memory_resource_links` 四张表（完整字段，含预留的 `embedding_*` 列），全部带 `user_id` 边界。
- `migrations/0011_daffy_ultron.sql`：Drizzle 生成的建表 + 手工追加 trigram FTS5 `memory_fts` 与 insert/update/delete 触发器。
- `packages/domain/src/ids.ts`：资源前缀扩展 `memories`。
- `packages/contracts/src/memory.ts`：Zod enum / DTO / REST 请求 schema / 六个 MCP tool 输入 schema。
- `.gitignore`：忽略 `.zcode/` 本地工作目录。

Closes #76