### PR TITLE
feat(memory): implement memory domain services

### DIFF
--- a/packages/contracts/src/memory.ts
+++ b/packages/contracts/src/memory.ts
@@ -263,6 +263,11 @@ export type MemoryVerification = z.infer<typeof memoryVerificationSchema>;
 export type MemoryStatus = z.infer<typeof memoryStatusSchema>;
 export type MemoryRelationType = z.infer<typeof memoryRelationTypeSchema>;
 export type MemoryResourceType = z.infer<typeof memoryResourceTypeSchema>;
+export type MemoryResourceRelationType = z.infer<
+  typeof memoryResourceRelationTypeSchema
+>;
+export type MemoryForgetReason = z.infer<typeof memoryForgetReasonSchema>;
+export type MemoryCreatedByType = z.infer<typeof memoryCreatedByTypeSchema>;
 export type MemoryDto = z.infer<typeof memoryDtoSchema>;
 export type MemoryRevisionDto = z.infer<typeof memoryRevisionDtoSchema>;
 export type MemoryRelationDto = z.infer<typeof memoryRelationDtoSchema>;

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -6,6 +6,7 @@ export * from "./ids";
 export * from "./import-export";
 export * from "./memo-context";
 export * from "./memo-filter";
+export * from "./memory";
 export * from "./memos";
 export * from "./memos-social";
 export * from "./memos-sse";

--- a/packages/domain/src/memory.test.ts
+++ b/packages/domain/src/memory.test.ts
@@ -1,0 +1,397 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { UserRow } from "@flaremo/db";
+import { createDb } from "@flaremo/db";
+import { Miniflare } from "miniflare";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  archiveMemory,
+  bootstrapMemory,
+  checkpointMemory,
+  confirmMemory,
+  createMemory,
+  forgetMemory,
+  hardDeleteMemory,
+  linkMemory,
+  listMemories,
+  listMemoryReview,
+  listMemoryRevisions,
+  lockMemory,
+  type MemoryActor,
+  recallMemories,
+  unlockMemory,
+  updateMemory,
+} from "./memory";
+import { ensureSingleUser } from "./users";
+
+let mf: Miniflare;
+let db: ReturnType<typeof createDb>;
+let user: UserRow;
+
+const USER: MemoryActor = { type: "user" };
+const AGENT: MemoryActor = { type: "agent", name: "codex" };
+
+async function applyMigration(
+  database: Awaited<ReturnType<Miniflare["getD1Database"]>>,
+  sql: string,
+) {
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  for (const statement of statements) {
+    await database.prepare(statement).run();
+  }
+}
+
+describe("memory domain services", () => {
+  beforeEach(async () => {
+    mf = new Miniflare({
+      script: "export default { fetch() { return new Response('ok') } }",
+      modules: true,
+      compatibilityDate: "2026-07-10",
+      compatibilityFlags: ["nodejs_compat"],
+      d1Databases: { DB: "flaremo-memory-test" },
+    });
+    const database = await mf.getD1Database("DB");
+    db = createDb(database);
+    const initial = await readFile(
+      resolve(
+        import.meta.dirname,
+        "../../../migrations/0000_illegal_inhumans.sql",
+      ),
+      "utf8",
+    );
+    const memory = await readFile(
+      resolve(import.meta.dirname, "../../../migrations/0011_daffy_ultron.sql"),
+      "utf8",
+    );
+    await applyMigration(database, initial);
+    await applyMigration(database, memory);
+    user = await ensureSingleUser(db, {
+      email: "owner@example.com",
+      name: "Owner",
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+  });
+
+  it("creates a user memory as confirmed and an agent memory as observed", async () => {
+    const userCreated = await createMemory(db, user, USER, {
+      content: "FlareMo 使用 D1 作为事实源",
+      type: "semantic",
+      kind: "fact",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "core",
+      importance: 90,
+      confidence: 100,
+    });
+    expect(userCreated.duplicate).toBe(false);
+    expect(userCreated.memory.verification).toBe("confirmed");
+    expect(userCreated.memory.created_by_type).toBe("user");
+
+    const agentCreated = await createMemory(db, user, AGENT, {
+      content: "用户默认使用 pnpm",
+      type: "semantic",
+      kind: "preference",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "normal",
+      importance: 60,
+      confidence: 70,
+    });
+    expect(agentCreated.duplicate).toBe(false);
+    expect(agentCreated.memory.verification).toBe("observed");
+    expect(agentCreated.memory.created_by_type).toBe("agent");
+    expect(agentCreated.memory.source_agent).toBe("codex");
+  });
+
+  it("rejects exact duplicates and credential material", async () => {
+    const first = await createMemory(db, user, AGENT, {
+      content: "FlareMo 部署在 Cloudflare Workers",
+      type: "semantic",
+      kind: "fact",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "normal",
+      importance: 50,
+      confidence: 50,
+    });
+    expect(first.duplicate).toBe(false);
+
+    const dup = await createMemory(db, user, AGENT, {
+      content: "FlareMo 部署在 Cloudflare Workers",
+      type: "semantic",
+      kind: "fact",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "normal",
+      importance: 50,
+      confidence: 50,
+    });
+    expect(dup.duplicate).toBe(true);
+    expect(dup.memory.id).toBe(first.memory.id);
+
+    await expect(
+      createMemory(db, user, AGENT, {
+        content: "token: memos_pat_abc123",
+        type: "semantic",
+        kind: "fact",
+        scopeType: "global",
+        scopeKey: null,
+        tier: "normal",
+        importance: 50,
+        confidence: 50,
+      }),
+    ).rejects.toThrow(/MEMORY_SECRET_REJECTED/);
+  });
+
+  it("forbids agents from locking, and from mutating confirmed or locked memories", async () => {
+    const created = await createMemory(db, user, USER, {
+      content: "发布前必须执行 pnpm verify",
+      type: "procedural",
+      kind: "procedure",
+      scopeType: "project",
+      scopeKey: "github:realchendahuang/FlareMo",
+      tier: "core",
+      importance: 90,
+      confidence: 100,
+    });
+    const id = created.memory.id;
+
+    await expect(
+      createMemory(db, user, AGENT, {
+        content: "x",
+        type: "semantic",
+        kind: "fact",
+        scopeType: "global",
+        scopeKey: null,
+        tier: "normal",
+        importance: 50,
+        confidence: 50,
+        verification: "locked",
+      }),
+    ).rejects.toThrow(/cannot lock/i);
+
+    await expect(
+      updateMemory(db, user, AGENT, id, { content: "agent override" }),
+    ).rejects.toThrow(/confirmed/i);
+
+    await lockMemory(db, user, USER, id);
+    await expect(
+      updateMemory(db, user, AGENT, id, { content: "agent override" }),
+    ).rejects.toThrow(/locked/i);
+  });
+
+  it("upgrades an agent memory to confirmed on user edit and records revisions", async () => {
+    const created = await createMemory(db, user, AGENT, {
+      content: "用户似乎偏好 Cloudflare",
+      type: "semantic",
+      kind: "preference",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "normal",
+      importance: 50,
+      confidence: 50,
+      verification: "inferred",
+    });
+    expect(created.memory.verification).toBe("inferred");
+    expect(created.memory.needs_review).toBe(true);
+
+    const updated = await updateMemory(db, user, USER, created.memory.id, {
+      content: "用户明确偏好 Cloudflare",
+    });
+    expect(updated.verification).toBe("confirmed");
+    expect(updated.needs_review).toBe(false);
+
+    const revisions = await listMemoryRevisions(db, user, created.memory.id);
+    expect(revisions).toHaveLength(1);
+    expect(revisions[0]?.content).toBe("用户似乎偏好 Cloudflare");
+  });
+
+  it("scopes recall to global plus the requested project only", async () => {
+    await createMemory(db, user, AGENT, {
+      content: "全局偏好：使用 TypeScript",
+      type: "semantic",
+      kind: "preference",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "core",
+      importance: 80,
+      confidence: 90,
+    });
+    await createMemory(db, user, AGENT, {
+      content: "FlareMo 项目使用 pnpm",
+      type: "semantic",
+      kind: "fact",
+      scopeType: "project",
+      scopeKey: "github:realchendahuang/FlareMo",
+      tier: "normal",
+      importance: 60,
+      confidence: 80,
+    });
+    await createMemory(db, user, AGENT, {
+      content: "signal-loom 项目使用 bun",
+      type: "semantic",
+      kind: "fact",
+      scopeType: "project",
+      scopeKey: "github:realchendahuang/signal-loom",
+      tier: "normal",
+      importance: 60,
+      confidence: 80,
+    });
+
+    const results = await recallMemories(db, user, {
+      query: "使用",
+      agent: "codex",
+      projectKey: "github:realchendahuang/FlareMo",
+      limit: 8,
+    });
+    const contents = results.map((row) => row.content);
+    expect(contents).toContain("FlareMo 项目使用 pnpm");
+    expect(contents).toContain("全局偏好：使用 TypeScript");
+    expect(contents).not.toContain("signal-loom 项目使用 bun");
+  });
+
+  it("bootstraps core and confirmed constraints within the char budget", async () => {
+    await createMemory(db, user, USER, {
+      content: "FlareMo 必须保持 Cloudflare Native",
+      type: "semantic",
+      kind: "constraint",
+      scopeType: "project",
+      scopeKey: "github:realchendahuang/FlareMo",
+      tier: "core",
+      importance: 90,
+      confidence: 100,
+    });
+    await createMemory(db, user, AGENT, {
+      content: "某个无关的普通记忆",
+      type: "episodic",
+      kind: "event",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "normal",
+      importance: 30,
+      confidence: 30,
+    });
+
+    const boot = await bootstrapMemory(db, user, {
+      agent: "claude-code",
+      projectKey: "github:realchendahuang/FlareMo",
+    });
+    expect(
+      boot.items.some(
+        (item) => item.content === "FlareMo 必须保持 Cloudflare Native",
+      ),
+    ).toBe(true);
+    const totalChars = boot.items.reduce(
+      (sum, item) => sum + item.content.length,
+      0,
+    );
+    expect(totalChars).toBeLessThanOrEqual(6_000);
+  });
+
+  it("checkpoint creates an episode plus atomic items linked together", async () => {
+    const result = await checkpointMemory(db, user, AGENT, {
+      agent: "codex",
+      project_key: "github:realchendahuang/FlareMo",
+      scope_type: "project",
+      scope_key: "github:realchendahuang/FlareMo",
+      summary: "完成 Agent Memory V1 架构设计",
+      items: [
+        {
+          content: "Memory 使用独立 /memory/mcp",
+          type: "semantic",
+          kind: "decision",
+          importance: 80,
+        },
+        {
+          content: "Embedding 不能成为 Memory 硬依赖",
+          type: "semantic",
+          kind: "constraint",
+          importance: 85,
+        },
+      ],
+    });
+    expect(result.episode.type).toBe("episodic");
+    expect(result.items).toHaveLength(2);
+
+    const listed = await listMemories(db, user, {
+      scopeKey: "github:realchendahuang/FlareMo",
+    });
+    expect(listed).toHaveLength(3);
+  });
+
+  it("link supersedes retires the old memory and forget archives without hard delete", async () => {
+    const old = await createMemory(db, user, AGENT, {
+      content: "FlareMo 考虑使用 Supabase",
+      type: "semantic",
+      kind: "decision",
+      scopeType: "project",
+      scopeKey: "github:realchendahuang/FlareMo",
+      tier: "normal",
+      importance: 50,
+      confidence: 50,
+    });
+    const fresh = await createMemory(db, user, AGENT, {
+      content: "FlareMo 最终使用 D1",
+      type: "semantic",
+      kind: "decision",
+      scopeType: "project",
+      scopeKey: "github:realchendahuang/FlareMo",
+      tier: "normal",
+      importance: 80,
+      confidence: 90,
+    });
+
+    await linkMemory(db, user, AGENT, {
+      memoryId: fresh.memory.id,
+      relatedMemoryId: old.memory.id,
+      relationType: "supersedes",
+      resourceRelationType: "references",
+    });
+
+    const archived = await forgetMemory(db, user, AGENT, old.memory.id, {
+      reason: "superseded",
+    });
+    expect(archived.status).toBe("superseded");
+
+    const review = await listMemoryReview(db, user);
+    expect(review).toHaveLength(0);
+
+    await expect(
+      hardDeleteMemory(db, user, AGENT, fresh.memory.id),
+    ).rejects.toThrow(/only the user/i);
+  });
+
+  it("confirm, lock, unlock, and archive are user-only and idempotent", async () => {
+    const created = await createMemory(db, user, AGENT, {
+      content: "部署流程 verify → dry-run → deploy",
+      type: "procedural",
+      kind: "procedure",
+      scopeType: "global",
+      scopeKey: null,
+      tier: "normal",
+      importance: 60,
+      confidence: 70,
+    });
+    const id = created.memory.id;
+
+    await expect(confirmMemory(db, user, AGENT, id)).rejects.toThrow(
+      /only the user/i,
+    );
+    await confirmMemory(db, user, USER, id);
+    await lockMemory(db, user, USER, id);
+    expect(
+      (await listMemories(db, user, {})).find((m) => m.id === id)?.verification,
+    ).toBe("locked");
+    await unlockMemory(db, user, USER, id);
+    await archiveMemory(db, user, USER, id);
+    expect(await listMemories(db, user, { status: "archived" })).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/domain/src/memory.ts
+++ b/packages/domain/src/memory.ts
@@ -1,0 +1,1119 @@
+import type {
+  CheckpointInput,
+  CreateMemoryInput,
+  MemoryDto,
+  MemoryForgetReason,
+  MemoryRelationDto,
+  MemoryRelationType,
+  MemoryResourceLinkDto,
+  MemoryResourceRelationType,
+  MemoryResourceType,
+  MemoryRevisionDto,
+  RememberInput,
+  UpdateMemoryInput,
+} from "@flaremo/contracts";
+import type { FlareMoDb, MemoryItemRow, UserRow } from "@flaremo/db";
+import {
+  memoryItems,
+  memoryRelations,
+  memoryResourceLinks,
+  memoryRevisions,
+} from "@flaremo/db";
+import { and, asc, desc, eq, or, type SQL, sql } from "drizzle-orm";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "./errors";
+import { createResourceId } from "./ids";
+
+export const MEMORY_MAX_CONTENT_LENGTH = 4_000;
+export const MEMORY_DEFAULT_RECALL_LIMIT = 8;
+export const MEMORY_MAX_RECALL_LIMIT = 20;
+export const MEMORY_DEFAULT_BOOTSTRAP_MAX_ITEMS = 20;
+export const MEMORY_BOOTSTRAP_CHAR_BUDGET = 6_000;
+const MEMORY_RECALL_CANDIDATE_LIMIT = 50;
+
+/**
+ * The actor behind a memory mutation. Browser sessions are the owner; PATs
+ * (MCP clients and scripts) are agents. Agents operate one tier below the
+ * user in the verification hierarchy and may never overwrite confirmed or
+ * locked memories.
+ */
+export type MemoryActor = { type: "user" } | { type: "agent"; name: string };
+
+type MemoryWriteInput = {
+  content: string;
+  type: MemoryItemRow["type"];
+  kind: MemoryItemRow["kind"];
+  scopeType: MemoryItemRow["scopeType"];
+  scopeKey: string | null;
+  tier: MemoryItemRow["tier"];
+  importance: number;
+  confidence: number;
+  verification?: MemoryItemRow["verification"];
+  sourceAgent?: string | null;
+  sourceSession?: string | null;
+  sourceRef?: string | null;
+};
+
+type MemoryScopeFilter = {
+  projectKey?: string;
+  workspaceKey?: string;
+  agentName?: string;
+};
+
+export type RecallMemoriesInput = {
+  query: string;
+  agent: string;
+  projectKey?: string;
+  workspaceKey?: string;
+  types?: MemoryItemRow["type"][];
+  kinds?: MemoryItemRow["kind"][];
+  limit?: number;
+};
+
+export type LinkMemoryInput = {
+  memoryId: string;
+  relatedMemoryId?: string;
+  relationType: MemoryRelationType;
+  resourceType?: MemoryResourceType;
+  resourceRef?: string;
+  resourceRelationType: MemoryResourceRelationType;
+};
+
+export type ForgetMemoryInput = {
+  reason: MemoryForgetReason;
+};
+
+// Verification is a hard authority tier, not a soft relevance hint, so locked
+// and confirmed memories outrank anything an agent inferred.
+const VERIFICATION_WEIGHT: Record<MemoryItemRow["verification"], number> = {
+  locked: 100,
+  confirmed: 80,
+  observed: 50,
+  inferred: 20,
+};
+
+// ---------------------------------------------------------------------------
+// DTO mapping
+// ---------------------------------------------------------------------------
+
+export function memoryToDto(row: MemoryItemRow): MemoryDto {
+  return {
+    id: row.id,
+    content: row.content,
+    type: row.type,
+    kind: row.kind,
+    scope_type: row.scopeType,
+    scope_key: row.scopeKey,
+    tier: row.tier,
+    verification: row.verification,
+    status: row.status,
+    importance: row.importance,
+    confidence: row.confidence,
+    needs_review: row.needsReview,
+    review_reason: row.reviewReason,
+    created_by_type: row.createdByType,
+    source_agent: row.sourceAgent,
+    source_session: row.sourceSession,
+    source_ref: row.sourceRef,
+    valid_from: row.validFrom,
+    valid_to: row.validTo,
+    access_count: row.accessCount,
+    last_accessed_at: row.lastAccessedAt,
+    embedding_status: row.embeddingStatus,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}
+
+function memoryRevisionToDto(
+  row: typeof memoryRevisions.$inferSelect,
+): MemoryRevisionDto {
+  return {
+    id: row.id,
+    memory_id: row.memoryId,
+    content: row.content,
+    metadata_snapshot: row.metadataSnapshot,
+    created_by_type: row.createdByType,
+    created_by_agent: row.createdByAgent,
+    created_at: row.createdAt,
+  };
+}
+
+function memoryRelationToDto(
+  row: typeof memoryRelations.$inferSelect,
+): MemoryRelationDto {
+  return {
+    memory_id: row.memoryId,
+    related_memory_id: row.relatedMemoryId,
+    type: row.type,
+    created_at: row.createdAt,
+  };
+}
+
+function memoryResourceLinkToDto(
+  row: typeof memoryResourceLinks.$inferSelect,
+): MemoryResourceLinkDto {
+  return {
+    memory_id: row.memoryId,
+    resource_type: row.resourceType,
+    resource_ref: row.resourceRef,
+    relation_type: row.relationType,
+    metadata: row.metadata,
+    created_at: row.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Write Gate helpers
+// ---------------------------------------------------------------------------
+
+function normalizeMemoryContent(content: string) {
+  return content.trim().replace(/\s+/g, " ");
+}
+
+function assertMemoryContentLength(content: string) {
+  if (content.length > MEMORY_MAX_CONTENT_LENGTH) {
+    throw new ValidationError(
+      "Memory content must be 4000 characters or fewer; store long-form content as a memo instead.",
+    );
+  }
+}
+
+/**
+ * Reject obvious credential material at write time. This is a high-confidence
+ * rule list, not a parser: P0 blocks the clearly dangerous shapes and lets the
+ * user's review flow catch subtler secrets.
+ */
+function assertNoSecrets(content: string) {
+  const lowered = content.toLowerCase();
+  const markers = [
+    "authorization:",
+    "authorization bearer",
+    "memos_pat_",
+    "-----begin rsa private key-----",
+    "-----begin private key-----",
+    "-----begin pgp private key-----",
+    "cookie:",
+    "set-cookie:",
+    "api_key=",
+    "apikey=",
+    "client_secret=",
+    "password=",
+    "passwd=",
+  ];
+  if (markers.some((marker) => lowered.includes(marker))) {
+    throw new ValidationError("MEMORY_SECRET_REJECTED");
+  }
+}
+
+async function computeFingerprint(
+  user: UserRow,
+  content: string,
+  type: string,
+  kind: string,
+  scopeType: string,
+  scopeKey: string | null,
+) {
+  const canonical = [
+    user.id,
+    type,
+    kind,
+    scopeType,
+    scopeKey ?? "",
+    content,
+  ].join("\u001f");
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonical),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function resolveVerificationForActor(
+  actor: MemoryActor,
+  input: MemoryWriteInput,
+): MemoryItemRow["verification"] {
+  if (actor.type === "user") {
+    // The web UI only exposes "create" and "lock at create"; both are user
+    // affirmations and therefore confirmed or locked.
+    return input.verification === "locked" ? "locked" : "confirmed";
+  }
+  if (input.verification === "locked" || input.verification === "confirmed") {
+    throw new ForbiddenError("Agents cannot lock or confirm memories.");
+  }
+  return input.verification ?? "observed";
+}
+
+function resolveConfidenceForActor(
+  actor: MemoryActor,
+  input: MemoryWriteInput,
+) {
+  if (actor.type === "user") return 100;
+  return input.confidence;
+}
+
+// ---------------------------------------------------------------------------
+// Ownership / permission
+// ---------------------------------------------------------------------------
+
+async function requireMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  id: string,
+): Promise<MemoryItemRow> {
+  const row = await db
+    .select()
+    .from(memoryItems)
+    .where(and(eq(memoryItems.id, id), eq(memoryItems.userId, user.id)))
+    .get();
+  if (!row) throw new NotFoundError(`Memory not found: ${id}`);
+  return row;
+}
+
+function assertAgentCanMutate(actor: MemoryActor, row: MemoryItemRow) {
+  if (actor.type !== "agent") return;
+  if (row.verification === "locked") {
+    throw new ForbiddenError(
+      "Agents cannot modify a locked memory; propose a conflict instead.",
+    );
+  }
+  if (row.verification === "confirmed") {
+    throw new ForbiddenError(
+      "Agents cannot modify a confirmed memory; propose a conflict instead.",
+    );
+  }
+}
+
+async function appendRevision(
+  db: FlareMoDb,
+  user: UserRow,
+  row: MemoryItemRow,
+  createdByType: "user" | "agent",
+  createdByAgent?: string | null,
+) {
+  const snapshot: Record<string, unknown> = {
+    type: row.type,
+    kind: row.kind,
+    scope_type: row.scopeType,
+    scope_key: row.scopeKey,
+    tier: row.tier,
+    verification: row.verification,
+    status: row.status,
+    importance: row.importance,
+    confidence: row.confidence,
+  };
+  await db.insert(memoryRevisions).values({
+    id: createResourceId("memories"),
+    memoryId: row.id,
+    userId: user.id,
+    content: row.content,
+    metadataSnapshot: snapshot,
+    createdByType,
+    createdByAgent: createdByAgent ?? null,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Create / update
+// ---------------------------------------------------------------------------
+
+export async function createMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  input: MemoryWriteInput,
+) {
+  const content = normalizeMemoryContent(input.content);
+  if (!content) throw new ValidationError("Memory content cannot be empty.");
+  assertMemoryContentLength(content);
+  assertNoSecrets(content);
+
+  const fingerprint = await computeFingerprint(
+    user,
+    content,
+    input.type,
+    input.kind,
+    input.scopeType,
+    input.scopeKey,
+  );
+
+  const existing = await db
+    .select()
+    .from(memoryItems)
+    .where(
+      and(
+        eq(memoryItems.userId, user.id),
+        eq(memoryItems.fingerprint, fingerprint),
+        sql`${memoryItems.status} != 'deleted'`,
+      ),
+    )
+    .get();
+  if (existing) {
+    return { duplicate: true as const, memory: memoryToDto(existing) };
+  }
+
+  const now = new Date().toISOString();
+  const verification = resolveVerificationForActor(actor, input);
+  const row = await db
+    .insert(memoryItems)
+    .values({
+      id: createResourceId("memories"),
+      userId: user.id,
+      content,
+      type: input.type,
+      kind: input.kind,
+      scopeType: input.scopeType,
+      scopeKey: input.scopeKey,
+      tier: input.tier,
+      verification,
+      status: "active",
+      importance: input.importance,
+      confidence: resolveConfidenceForActor(actor, input),
+      needsReview: verification === "inferred",
+      reviewReason: verification === "inferred" ? "inferred" : null,
+      createdByType: actor.type === "user" ? "user" : "agent",
+      sourceAgent: actor.type === "agent" ? actor.name : input.sourceAgent,
+      sourceSession: input.sourceSession,
+      sourceRef: input.sourceRef,
+      fingerprint,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+    .get();
+
+  return { duplicate: false as const, memory: memoryToDto(row) };
+}
+
+export async function updateMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+  input: UpdateMemoryInput,
+) {
+  const existing = await requireMemory(db, user, id);
+  assertAgentCanMutate(actor, existing);
+  if (existing.status === "deleted") {
+    throw new NotFoundError(`Memory not found: ${id}`);
+  }
+
+  const next = { ...existing };
+  if (input.content !== undefined) {
+    next.content = normalizeMemoryContent(input.content);
+    if (!next.content)
+      throw new ValidationError("Memory content cannot be empty.");
+    assertMemoryContentLength(next.content);
+    assertNoSecrets(next.content);
+  }
+  if (input.type !== undefined) next.type = input.type;
+  if (input.kind !== undefined) next.kind = input.kind;
+  if (input.scope_type !== undefined) next.scopeType = input.scope_type;
+  if (input.scope_key !== undefined) next.scopeKey = input.scope_key ?? null;
+  if (input.tier !== undefined) next.tier = input.tier;
+  if (input.importance !== undefined) next.importance = input.importance;
+
+  next.fingerprint = await computeFingerprint(
+    user,
+    next.content,
+    next.type,
+    next.kind,
+    next.scopeType,
+    next.scopeKey,
+  );
+
+  const duplicate = await db
+    .select()
+    .from(memoryItems)
+    .where(
+      and(
+        eq(memoryItems.userId, user.id),
+        eq(memoryItems.fingerprint, next.fingerprint),
+        sql`${memoryItems.id} != ${id}`,
+        sql`${memoryItems.status} != 'deleted'`,
+      ),
+    )
+    .get();
+  if (duplicate) {
+    throw new ConflictError("This memory already exists.");
+  }
+
+  const now = new Date().toISOString();
+  // A user edit is an affirmation: it upgrades observed/inferred to confirmed,
+  // while a locked memory stays locked.
+  if (actor.type === "user" && existing.verification !== "locked") {
+    next.verification = "confirmed";
+    next.needsReview = false;
+    next.reviewReason = null;
+  }
+
+  await appendRevision(
+    db,
+    user,
+    existing,
+    actor.type === "user" ? "user" : "agent",
+    actor.type === "agent" ? actor.name : null,
+  );
+  await db
+    .update(memoryItems)
+    .set({
+      content: next.content,
+      type: next.type,
+      kind: next.kind,
+      scopeType: next.scopeType,
+      scopeKey: next.scopeKey,
+      tier: next.tier,
+      verification: next.verification,
+      importance: next.importance,
+      needsReview: next.needsReview,
+      reviewReason: next.reviewReason,
+      fingerprint: next.fingerprint,
+      updatedAt: now,
+    })
+    .where(and(eq(memoryItems.id, id), eq(memoryItems.userId, user.id)));
+
+  const updated = await requireMemory(db, user, id);
+  return memoryToDto(updated);
+}
+
+// ---------------------------------------------------------------------------
+// User-only lifecycle actions
+// ---------------------------------------------------------------------------
+
+async function setVerification(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+  verification: MemoryItemRow["verification"],
+  reason?: string,
+) {
+  if (actor.type !== "user") {
+    throw new ForbiddenError(
+      "Only the user may change a memory's verification.",
+    );
+  }
+  const existing = await requireMemory(db, user, id);
+  await appendRevision(db, user, existing, "user");
+  await db
+    .update(memoryItems)
+    .set({
+      verification,
+      needsReview: false,
+      reviewReason: reason ?? null,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(and(eq(memoryItems.id, id), eq(memoryItems.userId, user.id)));
+  return memoryToDto(await requireMemory(db, user, id));
+}
+
+export function confirmMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+) {
+  return setVerification(db, user, actor, id, "confirmed");
+}
+
+export function lockMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+) {
+  return setVerification(db, user, actor, id, "locked");
+}
+
+export function unlockMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+) {
+  return setVerification(db, user, actor, id, "confirmed");
+}
+
+export async function archiveMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+) {
+  if (actor.type !== "user") {
+    throw new ForbiddenError("Only the user may archive a memory.");
+  }
+  const existing = await requireMemory(db, user, id);
+  await appendRevision(db, user, existing, "user");
+  await db
+    .update(memoryItems)
+    .set({
+      status: "archived",
+      needsReview: false,
+      reviewReason: null,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(and(eq(memoryItems.id, id), eq(memoryItems.userId, user.id)));
+  return memoryToDto(await requireMemory(db, user, id));
+}
+
+export async function hardDeleteMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+) {
+  if (actor.type !== "user") {
+    throw new ForbiddenError("Only the user may hard-delete a memory.");
+  }
+  await requireMemory(db, user, id);
+  await db
+    .delete(memoryItems)
+    .where(and(eq(memoryItems.id, id), eq(memoryItems.userId, user.id)));
+  return { ok: true };
+}
+
+/**
+ * `forget` is the agent-facing retirement path. Agents never hard-delete; a
+ * "superseded" reason marks the memory superseded, anything else archives it.
+ */
+export async function forgetMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  id: string,
+  input: ForgetMemoryInput,
+) {
+  const existing = await requireMemory(db, user, id);
+  assertAgentCanMutate(actor, existing);
+  await appendRevision(
+    db,
+    user,
+    existing,
+    actor.type === "user" ? "user" : "agent",
+    actor.type === "agent" ? actor.name : null,
+  );
+  const status: MemoryItemRow["status"] =
+    input.reason === "superseded" ? "superseded" : "archived";
+  await db
+    .update(memoryItems)
+    .set({ status, updatedAt: new Date().toISOString() })
+    .where(and(eq(memoryItems.id, id), eq(memoryItems.userId, user.id)));
+  return memoryToDto(await requireMemory(db, user, id));
+}
+
+// ---------------------------------------------------------------------------
+// Read / list / search
+// ---------------------------------------------------------------------------
+
+export async function getMemory(db: FlareMoDb, user: UserRow, id: string) {
+  const row = await requireMemory(db, user, id);
+  await db
+    .update(memoryItems)
+    .set({
+      accessCount: row.accessCount + 1,
+      lastAccessedAt: new Date().toISOString(),
+    })
+    .where(and(eq(memoryItems.id, id), eq(memoryItems.userId, user.id)));
+  return memoryToDto(await requireMemory(db, user, id));
+}
+
+function buildScopeFilter(user: UserRow, filter: MemoryScopeFilter) {
+  const scopes: Array<SQL | undefined> = [eq(memoryItems.scopeType, "global")];
+  if (filter.projectKey) {
+    scopes.push(
+      and(
+        eq(memoryItems.scopeType, "project"),
+        eq(memoryItems.scopeKey, filter.projectKey),
+      ),
+    );
+  }
+  if (filter.workspaceKey) {
+    scopes.push(
+      and(
+        eq(memoryItems.scopeType, "workspace"),
+        eq(memoryItems.scopeKey, filter.workspaceKey),
+      ),
+    );
+  }
+  if (filter.agentName) {
+    scopes.push(
+      and(
+        eq(memoryItems.scopeType, "agent"),
+        eq(memoryItems.scopeKey, `agent:${filter.agentName}`),
+      ),
+    );
+  }
+  return and(eq(memoryItems.userId, user.id), or(...scopes.filter(Boolean)));
+}
+
+function buildFtsCondition(content: string) {
+  const trimmed = content.trim();
+  if (!trimmed) return undefined;
+  const tokens = trimmed.match(/[\p{L}\p{N}_-]+/gu) ?? [];
+  // Trigram FTS5 cannot match queries shorter than three characters, so a
+  // short or token-less query falls back to a plain LIKE substring match.
+  const trigrams = tokens.filter((token) => [...token].length >= 3);
+  if (trigrams.length === 0) {
+    return sql`${memoryItems.content} LIKE ${`%${escapeLike(trimmed)}%`} ESCAPE '\\'`;
+  }
+  const match = trigrams
+    .map((token) => `"${token.replaceAll('"', '""')}"`)
+    .join(" OR ");
+  return sql`${memoryItems.id} IN (
+    SELECT memory_id FROM memory_fts WHERE memory_fts MATCH ${match}
+  )`;
+}
+
+export async function listMemories(
+  db: FlareMoDb,
+  user: UserRow,
+  input: {
+    q?: string;
+    type?: MemoryItemRow["type"];
+    kind?: MemoryItemRow["kind"];
+    scopeType?: MemoryItemRow["scopeType"];
+    scopeKey?: string;
+    tier?: MemoryItemRow["tier"];
+    verification?: MemoryItemRow["verification"];
+    status?: MemoryItemRow["status"];
+    sourceAgent?: string;
+    needsReview?: boolean;
+  } = {},
+) {
+  const filters = [eq(memoryItems.userId, user.id)];
+  if (input.q?.trim()) {
+    const fts = buildFtsCondition(input.q);
+    if (fts) filters.push(fts);
+  }
+  if (input.type) filters.push(eq(memoryItems.type, input.type));
+  if (input.kind) filters.push(eq(memoryItems.kind, input.kind));
+  if (input.scopeType) filters.push(eq(memoryItems.scopeType, input.scopeType));
+  if (input.scopeKey) filters.push(eq(memoryItems.scopeKey, input.scopeKey));
+  if (input.tier) filters.push(eq(memoryItems.tier, input.tier));
+  if (input.verification)
+    filters.push(eq(memoryItems.verification, input.verification));
+  if (input.status) filters.push(eq(memoryItems.status, input.status));
+  if (input.sourceAgent)
+    filters.push(eq(memoryItems.sourceAgent, input.sourceAgent));
+  if (input.needsReview !== undefined)
+    filters.push(eq(memoryItems.needsReview, input.needsReview));
+
+  const rows = await db
+    .select()
+    .from(memoryItems)
+    .where(and(...filters))
+    .orderBy(desc(memoryItems.updatedAt), desc(memoryItems.id));
+  return rows.map(memoryToDto);
+}
+
+export async function listMemoryReview(db: FlareMoDb, user: UserRow) {
+  const rows = await db
+    .select()
+    .from(memoryItems)
+    .where(
+      and(
+        eq(memoryItems.userId, user.id),
+        or(
+          eq(memoryItems.needsReview, true),
+          eq(memoryItems.status, "disputed"),
+        ),
+      ),
+    )
+    .orderBy(desc(memoryItems.updatedAt), desc(memoryItems.id));
+  return rows.map(memoryToDto);
+}
+
+export async function listMemoryRevisions(
+  db: FlareMoDb,
+  user: UserRow,
+  memoryId: string,
+) {
+  await requireMemory(db, user, memoryId);
+  const rows = await db
+    .select()
+    .from(memoryRevisions)
+    .where(
+      and(
+        eq(memoryRevisions.memoryId, memoryId),
+        eq(memoryRevisions.userId, user.id),
+      ),
+    )
+    .orderBy(desc(memoryRevisions.createdAt));
+  return rows.map(memoryRevisionToDto);
+}
+
+export async function listMemoryRelations(
+  db: FlareMoDb,
+  user: UserRow,
+  memoryId: string,
+) {
+  await requireMemory(db, user, memoryId);
+  const rows = await db
+    .select()
+    .from(memoryRelations)
+    .where(
+      and(
+        eq(memoryRelations.userId, user.id),
+        or(
+          eq(memoryRelations.memoryId, memoryId),
+          eq(memoryRelations.relatedMemoryId, memoryId),
+        ),
+      ),
+    )
+    .orderBy(desc(memoryRelations.createdAt));
+  return rows.map(memoryRelationToDto);
+}
+
+// ---------------------------------------------------------------------------
+// Recall / bootstrap
+// ---------------------------------------------------------------------------
+
+function rankMemory(row: MemoryItemRow): number {
+  let score =
+    VERIFICATION_WEIGHT[row.verification] + row.importance + row.confidence;
+  // Episodic memories fade with age; semantic facts, procedures, and decisions
+  // must not silently decay out of recall.
+  if (row.type === "episodic") {
+    const ageDays =
+      (Date.now() - new Date(row.updatedAt).getTime()) / 86_400_000;
+    score -= Math.min(Math.floor(ageDays / 30), 20);
+  }
+  return score;
+}
+
+export async function recallMemories(
+  db: FlareMoDb,
+  user: UserRow,
+  input: RecallMemoriesInput,
+) {
+  const scopeFilter = buildScopeFilter(user, {
+    projectKey: input.projectKey,
+    workspaceKey: input.workspaceKey,
+    agentName: input.agent,
+  });
+
+  const filters = [
+    scopeFilter,
+    eq(memoryItems.status, "active"),
+    eq(memoryItems.needsReview, false),
+  ];
+  if (input.types?.length) {
+    filters.push(sql`${memoryItems.type} IN ${input.types}`);
+  }
+  if (input.kinds?.length) {
+    filters.push(sql`${memoryItems.kind} IN ${input.kinds}`);
+  }
+
+  const rows = await db
+    .select()
+    .from(memoryItems)
+    .where(and(...filters))
+    .limit(MEMORY_RECALL_CANDIDATE_LIMIT);
+
+  const withText = buildFtsCondition(input.query);
+  let candidates = rows;
+  if (withText) {
+    const matchedIds = new Set(
+      (
+        await db
+          .select({ id: memoryItems.id })
+          .from(memoryItems)
+          .where(and(...filters, withText))
+          .limit(MEMORY_RECALL_CANDIDATE_LIMIT)
+      ).map((row) => row.id),
+    );
+    // A query that matches nothing via FTS should not silently recall by
+    // authority alone; return the empty set rather than unrelated memories.
+    candidates = rows.filter((row) => matchedIds.has(row.id));
+  }
+
+  candidates.sort((a, b) => rankMemory(b) - rankMemory(a));
+  const limit = Math.min(
+    input.limit ?? MEMORY_DEFAULT_RECALL_LIMIT,
+    MEMORY_MAX_RECALL_LIMIT,
+  );
+  return candidates.slice(0, limit).map((row) => ({
+    id: row.id,
+    content: row.content,
+    type: row.type,
+    kind: row.kind,
+    scope: row.scopeType,
+    scope_key: row.scopeKey,
+    tier: row.tier,
+    verification: row.verification,
+    importance: row.importance,
+    source: row.sourceRef,
+    source_agent: row.sourceAgent,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+    score: rankMemory(row),
+    matched_by: "fts" as const,
+  }));
+}
+
+export async function bootstrapMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  input: {
+    agent: string;
+    projectKey?: string;
+    workspaceKey?: string;
+    maxItems?: number;
+  },
+) {
+  const scopeFilter = buildScopeFilter(user, {
+    projectKey: input.projectKey,
+    workspaceKey: input.workspaceKey,
+    agentName: input.agent,
+  });
+
+  const rows = await db
+    .select()
+    .from(memoryItems)
+    .where(
+      and(
+        scopeFilter,
+        eq(memoryItems.status, "active"),
+        eq(memoryItems.needsReview, false),
+      ),
+    )
+    .orderBy(desc(memoryItems.updatedAt), desc(memoryItems.id));
+
+  // Core memories and locked/confirmed constraints are the highest-value
+  // bootstrap context; fill the remaining budget with recent lessons.
+  const core = rows.filter((row) => row.tier === "core");
+  const constraints = rows.filter(
+    (row) =>
+      row.kind === "constraint" &&
+      (row.verification === "locked" || row.verification === "confirmed"),
+  );
+  const decisions = rows.filter(
+    (row) =>
+      row.kind === "decision" &&
+      (row.verification === "locked" || row.verification === "confirmed"),
+  );
+  const rest = rows.filter(
+    (row) =>
+      row.tier !== "core" &&
+      row.kind !== "constraint" &&
+      row.kind !== "decision",
+  );
+
+  const maxItems = Math.min(
+    input.maxItems ?? MEMORY_DEFAULT_BOOTSTRAP_MAX_ITEMS,
+    MEMORY_DEFAULT_BOOTSTRAP_MAX_ITEMS,
+  );
+  const selected: MemoryItemRow[] = [];
+  const seen = new Set<string>();
+  const push = (row: MemoryItemRow) => {
+    if (!seen.has(row.id) && selected.length < maxItems) {
+      seen.add(row.id);
+      selected.push(row);
+    }
+  };
+  for (const group of [core, constraints, decisions, rest]) {
+    group.sort((a, b) => rankMemory(b) - rankMemory(a));
+    for (const row of group) push(row);
+  }
+
+  const items = selected
+    .sort((a, b) => rankMemory(b) - rankMemory(a))
+    .map((row) => ({
+      id: row.id,
+      content: row.content,
+      type: row.type,
+      kind: row.kind,
+      scope: row.scopeType,
+      scope_key: row.scopeKey,
+      tier: row.tier,
+      verification: row.verification,
+      importance: row.importance,
+      source: row.sourceRef,
+      source_agent: row.sourceAgent,
+    }));
+
+  let total = 0;
+  const trimmed: typeof items = [];
+  for (const item of items) {
+    if (total + item.content.length > MEMORY_BOOTSTRAP_CHAR_BUDGET) break;
+    total += item.content.length;
+    trimmed.push(item);
+  }
+
+  return { items: trimmed };
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint / link
+// ---------------------------------------------------------------------------
+
+export async function checkpointMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  input: CheckpointInput,
+) {
+  const scopeKey = input.scope_key ?? input.project_key ?? null;
+  const episode = await createMemory(db, user, actor, {
+    content: input.summary,
+    type: "episodic",
+    kind: "event",
+    scopeType: input.scope_type,
+    scopeKey,
+    tier: "normal",
+    importance: 50,
+    confidence: actor.type === "user" ? 100 : 50,
+    verification: actor.type === "user" ? "confirmed" : "observed",
+    sourceAgent: actor.type === "agent" ? actor.name : null,
+  });
+
+  if (episode.duplicate) {
+    throw new ConflictError("This checkpoint already exists.");
+  }
+
+  const episodeId = episode.memory.id;
+  const createdIds: string[] = [];
+  for (const item of input.items) {
+    const result = await createMemory(db, user, actor, {
+      content: item.content,
+      type: item.type,
+      kind: item.kind,
+      scopeType: input.scope_type,
+      scopeKey,
+      tier: "normal",
+      importance: item.importance,
+      confidence: actor.type === "user" ? 100 : 50,
+      verification: actor.type === "user" ? "confirmed" : "observed",
+      sourceAgent: actor.type === "agent" ? actor.name : null,
+    });
+    const itemId = result.memory.id;
+    createdIds.push(itemId);
+    await db
+      .insert(memoryRelations)
+      .values({
+        id: createResourceId("memories"),
+        memoryId: itemId,
+        relatedMemoryId: episodeId,
+        userId: user.id,
+        type: "related_to",
+        createdAt: new Date().toISOString(),
+      })
+      .onConflictDoNothing();
+  }
+
+  return {
+    episode: episode.memory,
+    items: createdIds,
+  };
+}
+
+export async function linkMemory(
+  db: FlareMoDb,
+  user: UserRow,
+  actor: MemoryActor,
+  input: LinkMemoryInput,
+) {
+  const memory = await requireMemory(db, user, input.memoryId);
+  assertAgentCanMutate(actor, memory);
+
+  const relations: MemoryRelationDto[] = [];
+  const resourceLinks: MemoryResourceLinkDto[] = [];
+
+  if (input.relatedMemoryId) {
+    const related = await requireMemory(db, user, input.relatedMemoryId);
+    if (input.relationType === "supersedes") {
+      assertAgentCanMutate(actor, related);
+      await db
+        .update(memoryItems)
+        .set({ status: "superseded", updatedAt: new Date().toISOString() })
+        .where(
+          and(eq(memoryItems.id, related.id), eq(memoryItems.userId, user.id)),
+        );
+    }
+    const inserted = await db
+      .insert(memoryRelations)
+      .values({
+        id: createResourceId("memories"),
+        memoryId: memory.id,
+        relatedMemoryId: related.id,
+        userId: user.id,
+        type: input.relationType,
+        createdAt: new Date().toISOString(),
+      })
+      .onConflictDoNothing()
+      .returning()
+      .get();
+    if (inserted) relations.push(memoryRelationToDto(inserted));
+  }
+
+  if (input.resourceType && input.resourceRef) {
+    const inserted = await db
+      .insert(memoryResourceLinks)
+      .values({
+        id: createResourceId("memories"),
+        memoryId: memory.id,
+        userId: user.id,
+        resourceType: input.resourceType,
+        resourceRef: input.resourceRef,
+        relationType: input.resourceRelationType,
+        createdAt: new Date().toISOString(),
+      })
+      .returning()
+      .get();
+    resourceLinks.push(memoryResourceLinkToDto(inserted));
+  }
+
+  return { relations, resource_links: resourceLinks };
+}
+
+// ---------------------------------------------------------------------------
+// REST input adapters
+// ---------------------------------------------------------------------------
+
+export function createMemoryInputToWrite(
+  input: CreateMemoryInput,
+): MemoryWriteInput {
+  return {
+    content: input.content,
+    type: input.type,
+    kind: input.kind,
+    scopeType: input.scope_type,
+    scopeKey: input.scope_key ?? null,
+    tier: input.tier,
+    importance: input.importance,
+    confidence: 100,
+    verification: input.lock ? "locked" : "confirmed",
+  };
+}
+
+export function rememberInputToWrite(input: RememberInput): MemoryWriteInput {
+  return {
+    content: input.content,
+    type: input.type,
+    kind: input.kind,
+    scopeType: input.scope_type,
+    scopeKey: input.scope_key ?? null,
+    tier: input.tier,
+    importance: input.importance,
+    confidence: input.confidence,
+    verification: input.verification,
+    sourceAgent: input.source_agent,
+    sourceSession: input.source_session,
+    sourceRef: input.source_ref,
+  };
+}
+
+function escapeLike(value: string) {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+}


### PR DESCRIPTION
## 验证

```bash
pnpm check
pnpm --filter @flaremo/domain test
pnpm test
```

## 内容

- `packages/domain/src/memory.ts`：Agent Memory domain 层。
  - Write Gate：normalize + fingerprint 去重 + scope/长度校验 + 凭据安全拒绝（`MEMORY_SECRET_REJECTED`）。
  - CRUD 与用户权威门禁：Agent 不能覆盖 confirmed/locked 记忆，只能提 conflict。
  - recall：D1 + FTS5（trigram）+ scope 隔离（global + 当前 project/workspace/agent，禁止跨 project）。
  - bootstrap（6000 字符预算）、checkpoint、link/supersede、forget/archive。
- `packages/domain/src/memory.test.ts`：9 个用例覆盖 scope 隔离、confirm/lock/supersede、去重、hard-delete、checkpoint、凭据拒绝。

Closes #77

> 依赖 #83（domain schema），先合并 #83 再合并本 PR。