### PR TITLE
feat(memory): add memory export and import

### DIFF
--- a/packages/contracts/src/memory.ts
+++ b/packages/contracts/src/memory.ts
@@ -136,6 +136,66 @@ export const memoryResourceLinkDtoSchema = z.object({
   created_at: z.string(),
 });
 
+// --- Export / import --------------------------------------------------------
+
+// A memory's export record keeps the business fields plus its namespaced id
+// (`name`), but omits derived/secret state: fingerprint, access counters, and
+// embedding columns are all rebuilt or reset on import.
+export const exportMemorySchema = z.object({
+  name: z.string(),
+  content: z.string(),
+  type: memoryTypeSchema,
+  kind: memoryKindSchema,
+  scope_type: memoryScopeTypeSchema,
+  scope_key: z.string().nullable(),
+  tier: memoryTierSchema,
+  verification: memoryVerificationSchema,
+  status: memoryStatusSchema,
+  importance: z.number().int().min(0).max(100),
+  confidence: z.number().int().min(0).max(100),
+  needs_review: z.boolean(),
+  review_reason: z.string().nullable(),
+  created_by_type: memoryCreatedByTypeSchema,
+  source_agent: z.string().nullable(),
+  source_session: z.string().nullable(),
+  source_ref: z.string().nullable(),
+  valid_from: z.string().nullable(),
+  valid_to: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export const importMemorySchema = exportMemorySchema.partial({
+  created_at: true,
+  updated_at: true,
+});
+
+export const exportMemoryRevisionSchema = z.object({
+  name: z.string(),
+  memory_id: z.string(),
+  content: z.string(),
+  metadata_snapshot: z.record(z.string(), z.unknown()),
+  created_by_type: memoryCreatedByTypeSchema,
+  created_by_agent: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export const exportMemoryRelationSchema = z.object({
+  memory_id: z.string(),
+  related_memory_id: z.string(),
+  type: memoryRelationTypeSchema,
+  created_at: z.string(),
+});
+
+export const exportMemoryResourceLinkSchema = z.object({
+  memory_id: z.string(),
+  resource_type: memoryResourceTypeSchema,
+  resource_ref: z.string(),
+  relation_type: memoryResourceRelationTypeSchema,
+  metadata: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+});
+
 // --- REST request schemas ---------------------------------------------------
 
 export const createMemorySchema = z.object({
@@ -282,6 +342,13 @@ export type MemoryResourceRelationType = z.infer<
 export type MemoryForgetReason = z.infer<typeof memoryForgetReasonSchema>;
 export type MemoryCreatedByType = z.infer<typeof memoryCreatedByTypeSchema>;
 export type MemoryDto = z.infer<typeof memoryDtoSchema>;
+export type ExportMemory = z.infer<typeof exportMemorySchema>;
+export type ImportMemory = z.infer<typeof importMemorySchema>;
+export type ExportMemoryRevision = z.infer<typeof exportMemoryRevisionSchema>;
+export type ExportMemoryRelation = z.infer<typeof exportMemoryRelationSchema>;
+export type ExportMemoryResourceLink = z.infer<
+  typeof exportMemoryResourceLinkSchema
+>;
 export type MemoryRevisionDto = z.infer<typeof memoryRevisionDtoSchema>;
 export type MemoryRelationDto = z.infer<typeof memoryRelationDtoSchema>;
 export type MemoryResourceLinkDto = z.infer<typeof memoryResourceLinkDtoSchema>;

--- a/packages/contracts/src/memos.ts
+++ b/packages/contracts/src/memos.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
-import { memoryDtoSchema } from "./memory";
+import {
+  exportMemoryRelationSchema,
+  exportMemoryResourceLinkSchema,
+  exportMemoryRevisionSchema,
+  importMemorySchema,
+  memoryDtoSchema,
+} from "./memory";
 import { memoSearchScopes } from "./search-query";
 
 export const memoVisibilitySchema = z.enum(["private", "protected", "public"]);
@@ -285,7 +291,7 @@ const importShareSchema = shareDtoSchema.partial({
 });
 
 export const importBundleSchema = z.object({
-  version: z.union([z.literal(1), z.literal(2)]).default(1),
+  version: z.union([z.literal(1), z.literal(2), z.literal(3)]).default(1),
   memos: z
     .array(
       memoDtoSchema
@@ -311,6 +317,19 @@ export const importBundleSchema = z.object({
   attachments: z.array(importAttachmentSchema).max(5_000).default([]),
   relations: z.array(memoRelationDtoSchema).max(100_000).default([]),
   shares: z.array(importShareSchema).max(10_000).default([]),
+  memories: z.array(importMemorySchema).max(50_000).default([]),
+  memory_revisions: z
+    .array(exportMemoryRevisionSchema)
+    .max(200_000)
+    .default([]),
+  memory_relations: z
+    .array(exportMemoryRelationSchema)
+    .max(100_000)
+    .default([]),
+  memory_resource_links: z
+    .array(exportMemoryResourceLinkSchema)
+    .max(100_000)
+    .default([]),
   exported_at: z.string().optional(),
 });
 
@@ -325,6 +344,7 @@ export const importResultSchema = z.object({
   imported_attachments: z.number().int().nonnegative(),
   imported_relations: z.number().int().nonnegative(),
   imported_shares: z.number().int().nonnegative(),
+  imported_memories: z.number().int().nonnegative().default(0),
 });
 
 export const dataTaskStatusSchema = z.enum([

--- a/packages/domain/src/import-export.ts
+++ b/packages/domain/src/import-export.ts
@@ -3,6 +3,10 @@ import type { FlareMoDb, UserRow } from "@flaremo/db";
 import {
   attachments,
   memoRelations,
+  memoryItems,
+  memoryRelations,
+  memoryResourceLinks,
+  memoryRevisions,
   memos,
   memoTags,
   shares,
@@ -20,18 +24,38 @@ export async function exportData(
   db: FlareMoDb,
   user: UserRow,
 ): Promise<ImportBundle> {
-  const [memoRows, attachmentRows, relationRows, shareRows] = await Promise.all(
-    [
-      db.select().from(memos).where(eq(memos.userId, user.id)),
-      db.select().from(attachments).where(eq(attachments.userId, user.id)),
-      db.select().from(memoRelations),
-      db.select().from(shares).where(eq(shares.userId, user.id)),
-    ],
-  );
+  const [
+    memoRows,
+    attachmentRows,
+    relationRows,
+    shareRows,
+    memoryRows,
+    memoryRevisionRows,
+    memoryRelationRows,
+    memoryResourceLinkRows,
+  ] = await Promise.all([
+    db.select().from(memos).where(eq(memos.userId, user.id)),
+    db.select().from(attachments).where(eq(attachments.userId, user.id)),
+    db.select().from(memoRelations),
+    db.select().from(shares).where(eq(shares.userId, user.id)),
+    db.select().from(memoryItems).where(eq(memoryItems.userId, user.id)),
+    db
+      .select()
+      .from(memoryRevisions)
+      .where(eq(memoryRevisions.userId, user.id)),
+    db
+      .select()
+      .from(memoryRelations)
+      .where(eq(memoryRelations.userId, user.id)),
+    db
+      .select()
+      .from(memoryResourceLinks)
+      .where(eq(memoryResourceLinks.userId, user.id)),
+  ]);
 
   const memoIds = new Set(memoRows.map((memo) => memo.id));
   return {
-    version: 2,
+    version: 3,
     exported_at: new Date().toISOString(),
     memos: memoRows.map((memo) => ({
       name: memo.id,
@@ -80,6 +104,52 @@ export async function exportData(
       create_time: share.createdAt,
       update_time: share.updatedAt,
       revoked_at: share.revokedAt,
+    })),
+    memories: memoryRows.map((memory) => ({
+      name: memory.id,
+      content: memory.content,
+      type: memory.type,
+      kind: memory.kind,
+      scope_type: memory.scopeType,
+      scope_key: memory.scopeKey,
+      tier: memory.tier,
+      verification: memory.verification,
+      status: memory.status,
+      importance: memory.importance,
+      confidence: memory.confidence,
+      needs_review: memory.needsReview,
+      review_reason: memory.reviewReason,
+      created_by_type: memory.createdByType,
+      source_agent: memory.sourceAgent,
+      source_session: memory.sourceSession,
+      source_ref: memory.sourceRef,
+      valid_from: memory.validFrom,
+      valid_to: memory.validTo,
+      created_at: memory.createdAt,
+      updated_at: memory.updatedAt,
+    })),
+    memory_revisions: memoryRevisionRows.map((revision) => ({
+      name: revision.id,
+      memory_id: revision.memoryId,
+      content: revision.content,
+      metadata_snapshot: revision.metadataSnapshot,
+      created_by_type: revision.createdByType,
+      created_by_agent: revision.createdByAgent,
+      created_at: revision.createdAt,
+    })),
+    memory_relations: memoryRelationRows.map((relation) => ({
+      memory_id: relation.memoryId,
+      related_memory_id: relation.relatedMemoryId,
+      type: relation.type,
+      created_at: relation.createdAt,
+    })),
+    memory_resource_links: memoryResourceLinkRows.map((link) => ({
+      memory_id: link.memoryId,
+      resource_type: link.resourceType,
+      resource_ref: link.resourceRef,
+      relation_type: link.relationType,
+      metadata: link.metadata,
+      created_at: link.createdAt,
     })),
   };
 }
@@ -304,6 +374,140 @@ export async function importData(
     importedShares += 1;
   }
 
+  // Memories are user-owned, atomic records. Import preserves the namespaced
+  // id so memory↔memo resource links stay intact, resets derived fields
+  // (fingerprint, access counters, embedding state), and skips rows that
+  // already exist under `skip` or `overwrite` conflict handling.
+  let importedMemories = 0;
+  const memoryIdMap = new Map<string, string>();
+  for (const memory of bundle.memories) {
+    const sourceId = parseResourceName(memory.name, "memories");
+    const existing = await db
+      .select({ id: memoryItems.id })
+      .from(memoryItems)
+      .where(and(eq(memoryItems.id, sourceId), eq(memoryItems.userId, user.id)))
+      .get();
+    if (existing && conflict === "skip") {
+      memoryIdMap.set(memory.name, existing.id);
+      continue;
+    }
+    const importedId = existing ? createResourceId("memories") : sourceId;
+    memoryIdMap.set(memory.name, importedId);
+    const createdAt = memory.created_at ?? now;
+    const updatedAt = memory.updated_at ?? createdAt;
+    await db
+      .insert(memoryItems)
+      .values({
+        id: importedId,
+        userId: user.id,
+        content: memory.content,
+        type: memory.type,
+        kind: memory.kind,
+        scopeType: memory.scope_type,
+        scopeKey: memory.scope_key,
+        tier: memory.tier,
+        verification: memory.verification,
+        status: memory.status,
+        importance: memory.importance,
+        confidence: memory.confidence,
+        needsReview: memory.needs_review,
+        reviewReason: memory.review_reason,
+        createdByType: memory.created_by_type,
+        sourceAgent: memory.source_agent,
+        sourceSession: memory.source_session,
+        sourceRef: memory.source_ref,
+        validFrom: memory.valid_from,
+        validTo: memory.valid_to,
+        // The canonical fingerprint is rebuilt from content on the next write;
+        // an import-scoped placeholder keeps the per-user unique index intact
+        // without trusting the exported (derived) value.
+        fingerprint: `import:${importedId}`,
+        accessCount: 0,
+        lastAccessedAt: null,
+        embeddingStatus: "not_indexed",
+        createdAt,
+        updatedAt,
+        deletedAt: memory.status === "deleted" ? updatedAt : null,
+      })
+      .onConflictDoUpdate({
+        target: memoryItems.id,
+        set: {
+          content: memory.content,
+          type: memory.type,
+          kind: memory.kind,
+          scopeType: memory.scope_type,
+          scopeKey: memory.scope_key,
+          tier: memory.tier,
+          verification: memory.verification,
+          status: memory.status,
+          importance: memory.importance,
+          confidence: memory.confidence,
+          needsReview: memory.needs_review,
+          reviewReason: memory.review_reason,
+          sourceAgent: memory.source_agent,
+          sourceSession: memory.source_session,
+          sourceRef: memory.source_ref,
+          validFrom: memory.valid_from,
+          validTo: memory.valid_to,
+          updatedAt,
+        },
+      });
+    importedMemories += 1;
+  }
+
+  for (const revision of bundle.memory_revisions) {
+    const memoryId = memoryIdMap.get(revision.memory_id);
+    if (!memoryId) continue;
+    await db
+      .insert(memoryRevisions)
+      .values({
+        id: parseResourceName(revision.name, "memories"),
+        memoryId,
+        userId: user.id,
+        content: revision.content,
+        metadataSnapshot: revision.metadata_snapshot,
+        createdByType: revision.created_by_type,
+        createdByAgent: revision.created_by_agent,
+        createdAt: revision.created_at ?? now,
+      })
+      .onConflictDoNothing();
+  }
+
+  for (const relation of bundle.memory_relations) {
+    const memoryId = memoryIdMap.get(relation.memory_id);
+    const relatedMemoryId = memoryIdMap.get(relation.related_memory_id);
+    if (!memoryId || !relatedMemoryId) continue;
+    await db
+      .insert(memoryRelations)
+      .values({
+        id: createResourceId("memories"),
+        memoryId,
+        relatedMemoryId,
+        userId: user.id,
+        type: relation.type,
+        createdAt: relation.created_at ?? now,
+      })
+      .onConflictDoNothing();
+  }
+
+  for (const link of bundle.memory_resource_links) {
+    const memoryId = memoryIdMap.get(link.memory_id);
+    if (!memoryId) continue;
+    await db
+      .insert(memoryResourceLinks)
+      .values({
+        id: createResourceId("memories"),
+        memoryId,
+        userId: user.id,
+        resourceType: link.resource_type,
+        resourceRef: link.resource_ref,
+        relationType: link.relation_type,
+        metadata: link.metadata,
+        createdAt: link.created_at ?? now,
+      })
+      .onConflictDoNothing();
+  }
+
   return {
     imported_memos: importedMemos,
     skipped_memos: skippedMemos,
@@ -311,6 +515,7 @@ export async function importData(
     imported_attachments: importedAttachments,
     imported_relations: importedRelations,
     imported_shares: importedShares,
+    imported_memories: importedMemories,
     cleanupR2Keys,
   };
 }

--- a/packages/domain/src/memory.test.ts
+++ b/packages/domain/src/memory.test.ts
@@ -1,9 +1,16 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import type { UserRow } from "@flaremo/db";
-import { createDb } from "@flaremo/db";
+import {
+  createDb,
+  memoryItems,
+  memoryRelations,
+  memoryResourceLinks,
+  memoryRevisions,
+} from "@flaremo/db";
 import { Miniflare } from "miniflare";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { exportData, importData } from "./import-export";
 import {
   archiveMemory,
   bootstrapMemory,
@@ -435,7 +442,12 @@ describe("memory domain services", () => {
     const linked = await listMemoriesForMemo(db, user, memo.id);
     expect(linked.map((memory) => memory.id)).toContain(created.memory.id);
 
-    const promoted = await promoteMemoryToMemo(db, user, USER, created.memory.id);
+    const promoted = await promoteMemoryToMemo(
+      db,
+      user,
+      USER,
+      created.memory.id,
+    );
     expect(promoted.memo).toMatch(/^memos\//);
 
     // The promoted memo references the same conclusion back to the memory.
@@ -443,5 +455,39 @@ describe("memory domain services", () => {
     expect(linksAfterPromote.map((memory) => memory.id)).toContain(
       created.memory.id,
     );
+  });
+
+  it("round-trips memories through export and import", async () => {
+    const created = await createMemory(db, user, USER, {
+      content: "FlareMo 必须保持 Cloudflare Native",
+      type: "semantic",
+      kind: "constraint",
+      scopeType: "project",
+      scopeKey: "github:realchendahuang/FlareMo",
+      tier: "core",
+      importance: 90,
+      confidence: 100,
+    });
+
+    const bundle = await exportData(db, user);
+    expect(bundle.version).toBe(3);
+    expect(bundle.memories).toHaveLength(1);
+    expect(bundle.memories[0]?.name).toBe(created.memory.id);
+
+    // Wipe the memory tables, then re-import and verify the record survives
+    // with the same namespaced id and content.
+    await db.delete(memoryRelations).all();
+    await db.delete(memoryResourceLinks).all();
+    await db.delete(memoryRevisions).all();
+    await db.delete(memoryItems).all();
+
+    const result = await importData(db, user, bundle);
+    expect(result.imported_memories).toBe(1);
+
+    const restored = await listMemories(db, user, {});
+    expect(restored).toHaveLength(1);
+    expect(restored[0]?.id).toBe(created.memory.id);
+    expect(restored[0]?.content).toBe("FlareMo 必须保持 Cloudflare Native");
+    expect(restored[0]?.verification).toBe("confirmed");
   });
 });


### PR DESCRIPTION
## 验证

```bash
pnpm check
pnpm --filter @flaremo/domain test
```

## 内容

- `packages/contracts`：`importBundleSchema` 升到 version 3，新增 `memories` / `memory_revisions` / `memory_relations` / `memory_resource_links`；`importResultSchema` 增加 `imported_memories`。
- `packages/domain/src/import-export.ts`：`exportData` 增读 4 张 memory 表，`importData` 增写并保留命名空间 id、重置派生字段、支持 skip/overwrite。
- `packages/domain/src/memory.test.ts`：export → 清库 → import 往返测试。

Embedding / Vector 不导出，恢复后重建。

Closes #82

> 依赖 #88（memo×memory link）。