### PR TITLE
test(memory): apply memory migration and fix memory E2E

### DIFF
--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -123,6 +123,10 @@ describe("FlareMo Worker API", () => {
       resolve(import.meta.dirname, "../../../migrations/0010_deep_gateway.sql"),
       "utf8",
     );
+    const memorySchema = await readFile(
+      resolve(import.meta.dirname, "../../../migrations/0011_daffy_ultron.sql"),
+      "utf8",
+    );
     await applyMigration(db, migration);
     await applyMigration(db, cleanup);
     await applyMigration(db, v020);
@@ -133,6 +137,7 @@ describe("FlareMo Worker API", () => {
     await applyMigration(db, userServiceParity);
     await applyMigration(db, webhookOutbox);
     await applyMigration(db, dataTasks);
+    await applyMigration(db, memorySchema);
     sessionCookie = await bootstrapAndSignIn();
   });
 

--- a/apps/worker/src/memos-compatibility.test.ts
+++ b/apps/worker/src/memos-compatibility.test.ts
@@ -1377,6 +1377,7 @@ async function createTestRuntime(suffix: string) {
     "0008_legal_scarecrow.sql",
     "0009_neat_iron_fist.sql",
     "0010_deep_gateway.sql",
+    "0011_daffy_ultron.sql",
   ]) {
     await applyMigration(
       db,

--- a/tests/e2e/memory-flow.spec.ts
+++ b/tests/e2e/memory-flow.spec.ts
@@ -1,15 +1,21 @@
 import { expect, test } from "@playwright/test";
 
-test("creates a memory, confirms it, and locks it", async ({ page }) => {
+test("creates a memory and locks it", async ({ page }) => {
   const content = `FlareMo 使用 D1 作为事实源 #mem${Date.now()}`;
 
   await page.goto("/memory");
 
   await page.getByRole("button", { name: /add memory|添加记忆/i }).click();
-  const contentField = page.getByRole("textbox").first();
-  await contentField.fill(content);
-  await page.getByRole("button", { name: /save|保存/i }).click();
 
+  // The dialog's content textarea is identified by its placeholder so it
+  // cannot be confused with the page-level search input.
+  const dialog = page.getByRole("dialog");
+  await dialog.getByPlaceholder("FlareMo 使用 D1 作为事实源").fill(content);
+  await dialog.getByRole("button", { name: /save|保存/i }).click();
+
+  // The memory starts confirmed, so it is a normal-tier memory and surfaces in
+  // the Recent tab (Core only shows tier=core).
+  await page.getByRole("tab", { name: /recent|最近/i }).click();
   await expect(page.getByText(content)).toBeVisible();
 
   // A user-created memory starts confirmed, so it offers "lock" but not


### PR DESCRIPTION
## 验证

```bash
pnpm verify
```

全绿：format:check → check → test（85 单测）→ build → test:e2e（23 通过）。

## 内容

合并 memory 功能后，`pnpm verify` 暴露了两处测试层遗漏：

1. `exportData` 和 `getMemoContextData` 现在会查 memory 表，但 `api.test.ts` 和 `memos-compatibility.test.ts` 的 Miniflare 运行时只应用 migration 到 0010，缺 0011（memory 表），导致 export/memo-context 请求 500。补上 0011。
2. 新增的 memory E2E 用 `getByRole("textbox").first()` 定位到了页面顶部搜索框而非创建对话框里的 content 输入框，且 normal-tier 记忆不会出现在 Core tab。改为用 placeholder 定位对话框输入框，并在 Recent tab 断言。

Refs #82