### PR TITLE
docs(memory): document Agent Memory hub and sync stale docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@ FlareMo 使用 SemVer。每个 release 都要写清楚升级影响、Cloudflare 
 
 ## Unreleased
 
-flomo 回顾体系对齐（R3 第一批）与冗余文案清理。
+flomo 回顾体系对齐（R3 第一批）、Agent Memory 与冗余文案清理。
 
 ### 新增能力
 
 - 每日回顾：新增 `/review/daily` 页面，按「N 年前的今天」分组展示往年今日创建的 memo；后端 `GET /api/app/review/daily?date=YYYY-MM-DD`（时区由前端传本地日期规避）。
 - 随机漫步：新增 `/review/walk` 页面，从随机 memo 出发沿共享标签、引用关系游走（无关联时大跨越），支持漫步历史回看；「结束漫步」输出明信片式总结（经过条数、总字数、时间跨度）；后端 `GET /api/app/review/random`、`GET /api/app/review/walk`，返回 `via`（tag/relation/jump）标记路径来源。
 - 侧边栏 explorer 新增「回顾」区，含每日回顾与随机漫步入口。
+- Agent Memory（AI 长期记忆）：新增 `memory_items` / `memory_revisions` / `memory_relations` / `memory_resource_links` 四张 D1 表，配 `memory_fts` FTS5 虚表（trigram 分词）与增删改触发器。D1 仍是唯一事实源，FTS 只作检索索引，可随时重建。
+- 记忆写入门禁：内容归一化、SHA-256 指纹精确去重、4000 字上限、凭据安全检测（命中 `Authorization`/`cookie`/`memos_pat_`/私钥/密码直接拒绝）。Agent 只能以 `observed`/`inferred` 写入，永远不能覆盖用户 `confirmed`/`locked` 的记忆，冲突进入 Review。
+- 记忆召回：scope 隔离（global + 当前 workspace/project + 当前 agent，禁止跨 project）+ FTS5 + 权威/重要度/置信度/recency 排序；episodic 记忆随时间衰减，semantic/procedural/decision 不衰减。
+- Agent Memory MCP：新增 `/memory/mcp` 无状态 Streamable HTTP 端点，暴露 `memory_bootstrap` / `memory_recall` / `memory_remember` / `memory_checkpoint` / `memory_link` / `memory_forget` 六个 tool，policy 内联进 tool description，复用 `memos_pat_` PAT 认证。
+- Memory 管理 UI：新增 `/memory` 页面（Core / Projects / Recent / Review / Archive 分栏），支持查看、确认、锁定、归档、删除、历史版本与来源展示。
+- Memo ↔ Memory 双向连接：memo 详情可「记为 Memory」（`derived_from`），memory 可「转为记录」（`promoted_to`），memo 上下文与导出均返回相关 memory。
+- 导出导入纳入：导入导出 bundle 升到 version 3，纳入 memory 四表；fingerprint、access counter 与 embedding 派生字段不导出，导入时重置为 `not_indexed`。
 
 ### 修复与清理
 
@@ -22,9 +29,11 @@ flomo 回顾体系对齐（R3 第一批）与冗余文案清理。
 
 ### Cloudflare、数据库与兼容影响
 
-- 无新增 D1 migration、无 R2 命名空间变化、无 Cloudflare 配置变化。
-- 仅 `/api/app/*` 新增三个端点（均需认证）；`/api/v1/*` Memos 兼容面不变。
-- 认证与 Origin 校验语义不变。
+- 新增 D1 migration `0011_daffy_ultron.sql`：新增 `memory_items`、`memory_revisions`、`memory_relations`、`memory_resource_links` 四张表及 `memory_fts` FTS5 虚拟表与增删改触发器；全部是新增表，向后兼容上一正式版本，不需要回填。
+- Worker 路由新增 `/memory/mcp`（Agent 无状态 MCP，PAT 认证）与 `/api/app/memory`（浏览器 cookie session 管理面）；`assets.run_worker_first` 增加 `/memory/*`。
+- 无 R2 命名空间变化、无 cron 变化、无 Cloudflare 资源绑定变化。
+- `/api/v1/*` Memos 兼容面不变：`/mcp`、`/api/v1/mcp` 行为与 v0.6.0 一致，memory 走独立的 `/memory/mcp` 前缀，不撞既有 MCP。
+- 认证与 Origin 校验语义不变：memory 复用 Better Auth cookie session 与 `memos_pat_` PAT，不新增第二套令牌。
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ FlareMo 想回答另一个问题：**能不能只用一个免费 Cloudflare 账�
 - Memos current camelCase / protobuf-JSON 风格的 `/api/v1` memo、attachment、relation、share、social、auth facade 和 PAT 资源子集；Connect JSON/protobuf/gRPC-Web 还覆盖单用户 UserService 的 webhook CRUD/signing-secret 与 notification list/update/delete（含 comment/mention payload）；旧 snake_case wire 通过显式 header 保留。
 - OpenAPI 输出。
 - MCP 端点。
+- Agent Memory：AI 长期记忆中枢，Agent 通过 `/memory/mcp` 读写跨 session 的长期记忆（偏好、决策、约束、教训），`/memory` 界面可查看、确认、锁定、纠正。
 - 中英文界面。
 
 前端只保留当前已经接上能力的入口。AI 回顾、语义搜索、随机漫步、微信输入这类功能还没实现，就不会挂在界面里占位置。
@@ -110,6 +111,8 @@ FlareMo 的部署被刻意做得很轻。两种方式，挑一种就行。
 仓库里带了一份 [docs/agent-deploy.md](./docs/agent-deploy.md)，是写给 Codex / Claude Code / Cursor 这类 Agent 用的部署 runbook。把仓库交给一个能跑命令的 Agent，它就能按 runbook 创建 D1 / R2 资源、填写 `database_id`、跑迁移、部署。你不用记命令，Agent 自己按步骤来。
 
 需要让 Agent、Telegram 或其他 IM 渠道直接写入笔记时，参考 [Agent 与 IM 渠道写入](./docs/agent-ingestion.md)。仓库提供一个经过测试的独立 Telegram Worker 示例，不会把渠道密钥或平台逻辑塞进 FlareMo 主 Worker。
+
+需要让 Agent 读写跨 session 的长期记忆（用户偏好、项目决策、约束、教训）时，参考 [Agent Memory](./docs/agent-memory.md)：统一 `/memory/mcp` 端点 + 六个工具，记忆归用户所有、可随时查看和纠正。
 
 **手动部署**（想自己一步步来的话）先创建资源：
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@
 - Memos 兼容：核心 `/api/v1` 子集稳定，当前包含有限 social、UserService webhook/notification 资源生命周期，以及四类 memo 事件的有界异步 webhook outbox 投递/重试；完整 Memos Server parity、完整上游 webhook 事件语义和完整多用户 ACL 仍未完成。导入导出保持可靠。
 - Cloudflare 原生部署：一键部署、D1/R2 自动 provision、Access 保护、可审查的升级 PR、Agent runbook。
 - 个人知识管理：引用关系、附件、公开分享、语义检索和 AI 工作流。
+- Agent Memory：AI 长期记忆中枢，Agent 通过 `/memory/mcp` 读写跨 session 记忆，用户可查看、确认、锁定、纠正；语义召回与自动固化作为后续方向。
 
 ## 工程主线
 
@@ -25,6 +26,7 @@
 
 - 扩大真实 Memos 客户端兼容矩阵，并补每个已验证客户端的配置示例。
 - 增加语义搜索：按 `docs/semantic-search.md` 实现；D1 仍是事实源，Vectorize 只存派生索引。
+- Agent Memory 后续：语义召回（与语义搜索共用 Vectorize）与自动固化（会话/工作完成后 LLM 提炼）。
 - 增加 AI 回顾：Workers AI 或外部模型只做派生能力。
 - 为超过内联上限的大型导入导出增加异步对象包和校验清单。
 - 增加附件生命周期观测面：清理计数、缺失对象报告和可控重试。

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -1,0 +1,99 @@
+# Agent Memory：AI 长期记忆中枢
+
+FlareMo 除了记录「你写过什么」（Memo），还提供一套独立的 **Agent Memory**，回答「AI 应该长期记住什么」：让 Claude Code / Codex / Pi / DeepSeek Harness 等 Agent 通过一个统一的 MCP 端点读写跨 session、跨 Agent 共享的长期记忆（用户偏好、项目决策、约束、经验、流程），而你在 FlareMo Web 界面随时能查看、确认、锁定、纠正、删除 AI 记下的每一条。
+
+定位是 **FlareMo = Human Knowledge (Memo) + Agent Memory**：记忆归用户所有，Agent 只是读者和贡献者。
+
+## 与 Memo 的边界
+
+- **Memo** 是时间线上的记录，可长可短，属于「事件流」。
+- **Memory** 是原子结论，一条记忆表达一个稳定事实（例如「FlareMo 用 D1 作为事实源」），上限 4000 字；长内容存 Memo，Memory 只存结论。
+- 两者通过 `derived_from` / `promoted_to` 双向连接：memo 可以提炼为 memory，memory 可以展开为 memo。
+
+## 认证
+
+Agent Memory 复用 FlareMo 的 Better Auth 应用层认证，**不新增第二套令牌**。Agent 通过可撤销的 `memos_pat_` Personal Access Token 访问；浏览器管理界面走 HttpOnly cookie session。若生产仍启用 Cloudflare Access，再附加成对的 Access Service Token，但 Access Service Token 单独不能成为 FlareMo 身份。
+
+先在 Web 界面创建一个有明确用途和过期时间的 PAT，然后连接 `/memory/mcp`（无状态 Streamable HTTP MCP）。它和既有的 `/mcp`、`/api/v1/mcp`（memo 工具子集）是**不同端点**，互不干扰。
+
+## 快速连接
+
+```bash
+curl "$FLAREMO_URL/memory/mcp" \
+  -H "content-type: application/json" \
+  -H "accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}'
+```
+
+工具发现：
+
+```bash
+curl "$FLAREMO_URL/memory/mcp" \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
+  --data '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+## 六个工具
+
+| 工具 | 作用 | 调用时机 |
+| --- | --- | --- |
+| `memory_bootstrap` | 恢复全局 + 项目的 core 记忆、重要决策/约束、近期教训 | 进入新项目或重要会话时调用一次，不要每轮都调 |
+| `memory_recall` | 按自然语言查询召回相关记忆 | 任务涉及历史决策、偏好、约束、过往失败时 |
+| `memory_remember` | 存一条原子长期事实 | 发现跨 session 有价值的稳定结论时 |
+| `memory_checkpoint` | 把一段完成的工作提炼为 1 条 episodic 摘要 + 若干原子记忆 | 完成重要功能、设计、调研、决策后 |
+| `memory_link` | 建记忆间或记忆到资源的关系（`supersedes`/`contradicts`/`supports` 等） | 发现新旧记忆矛盾、替代、支撑关系时 |
+| `memory_forget` | 归档或替代一条已不正确的记忆 | 发现记忆已错、已过时、已无关时 |
+
+每个工具的 description 已经内联了调用策略，任何 MCP 客户端连上即可获得一致行为，无需额外 system prompt。
+
+### 关键参数
+
+- **scope**：记忆按 `global` / `workspace` / `project` / `agent` 分域。召回与 bootstrap 默认覆盖 `global` + 当前 `project_key`（如 `github:owner/repo`）+ 当前 `agent`，**禁止跨 project 召回**。
+- **type**：`semantic`（事实/知识）、`episodic`（事件/经历）、`procedural`（流程/方法）。
+- **kind**：`preference` / `fact` / `decision` / `constraint` / `entity` / `event` / `outcome` / `lesson` / `procedure`。
+
+### 典型调用
+
+```bash
+# 进入项目时恢复上下文（一次）
+curl "$FLAREMO_URL/memory/mcp" \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
+  --data '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"memory_bootstrap","arguments":{"agent":"codex","project_key":"github:owner/repo"}}}'
+
+# 记一条决策
+curl "$FLAREMO_URL/memory/mcp" \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer $FLAREMO_MEMOS_PAT" \
+  --data '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"memory_remember","arguments":{"content":"FlareMo 用 D1 作为业务数据事实源","type":"semantic","kind":"decision","scope_type":"project","scope_key":"github:owner/repo"}}}'
+```
+
+## 权限模型
+
+用户权限永远高于 Agent：
+
+```
+locked > confirmed > observed > inferred
+```
+
+- Agent 只能以 `observed` / `inferred` 写入，**永远不能 lock 或 confirm** 一条记忆。
+- Agent 不能覆盖用户 `confirmed` / `locked` 的记忆；遇到矛盾时应改用 `memory_link` 提出 `contradicts` 关系，或让用户处理。
+- Agent 从不硬删除；`memory_forget` 只会归档或标记替代，历史保留。只有用户能在 UI 里物理删除。
+- 写入门禁会拒绝凭据（`Authorization` / `cookie` / `memos_pat_` / 私钥 / 密码），并做 SHA-256 指纹精确去重。
+
+## 当前边界（P0）
+
+这些是刻意后置、不是缺陷，设计上已预留扩展位：
+
+- **召回是关键词（FTS5 trigram）不是语义**：schema 已预留 `embedding_status` 等向量字段，但 P0 恒为 `not_indexed`，不接 Vectorize / Workers AI。语义召回见 [语义搜索](./semantic-search.md) 的同一套基础设施规划。
+- **不自动固化**：Agent 需要主动调用 `remember` / `checkpoint`；P0 不会在会话结束后自动调 LLM 提炼。
+- **`source_agent` 是字符串**：用于来源标注和按 agent scope 隔离，不是注册的身份系统。
+- **单用户**：所有查询都带 `user_id`，多用户协作不在当前范围。
+
+## 管理界面
+
+Web 的 `/memory` 页面提供 Core / Projects / Recent / Review / Archive 分栏：查看 AI 记下的每条记忆的来源与可信度，确认、锁定、纠正、归档或删除；Review 分栏汇总 `inferred` 待确认与 `disputed` 冲突项。memo 详情页可「记为 Memory」，memory 卡片可「转为记录」。
+
+导出时 memory 四表纳入 bundle（version 3），fingerprint、访问计数与 embedding 派生字段不导出，导入时重建。

--- a/docs/product-requirements.md
+++ b/docs/product-requirements.md
@@ -29,7 +29,7 @@ flomo 的核心闭环是「持续记录 → 意义浮现」，产品能力可以
 | 公开分享 | 已实现：share token + `/share/{token}` | 基本对齐 |
 | 引用/反向链接 | 部分：memo relations 已存在，前端可添加关系 | 无反向链接回顾面板、无关系图 |
 | 多渠道输入 | 部分：Memos 兼容 API、MCP、Telegram bot 示例 | Telegram bot 未升级为完整输入通道 |
-| AI 读写笔记 | 已实现：`/mcp` 无状态 Streamable HTTP 子集 | 无 flomo Agent 式对话、无 AI 洞察 |
+| AI 读写笔记 / 记忆 | 已实现：Agent Memory（`/memory/mcp` 六工具 + `/memory` 管理 UI），与 `/mcp` memo 工具子集并行 | 无 flomo Agent 式对话、无 AI 洞察；记忆召回仍为关键词（无语义 embedding） |
 | 数据导出 | 已实现：内联导出（≤32 MiB）+ 大型导出任务（分页 NDJSON + R2 清单 + 附件下载端点） | 无浏览器端「导出集打包为单个归档」体验 |
 | 每日回顾/随机漫步 | 已实现：`/review/daily`（那年今日分组）+ `/review/walk`（标签/引用游走 + 明信片总结） | 无定时推送触达渠道 |
 | 相关笔记/认知地图 | 未实现 | 认知地图依赖语义检索 |
@@ -125,6 +125,25 @@ flomo 的核心闭环是「持续记录 → 意义浮现」，产品能力可以
 - **成本**：中（需要真实客户端验证）。
 - **依赖**：无。
 - **ROADMAP 关系**：公开任务池「扩大真实 Memos 客户端兼容矩阵」。
+
+## Agent Memory（对标 flomo「AI 记忆档案」）
+
+flomo 的「AI 记忆档案」对应 FlareMo 的 Agent Memory：让 AI 通过统一 MCP 端点读写跨 session、跨 Agent 共享的长期记忆，用户随时可查看、确认、纠正。定位是 **Human Knowledge (Memo) + Agent Memory**，记忆归用户所有，Agent 只是读者和贡献者。
+
+### 现状（P0 已完成）
+
+- 四张 D1 表（`memory_items` / `memory_revisions` / `memory_relations` / `memory_resource_links`）+ `memory_fts` FTS5 检索索引；D1 是唯一事实源。
+- `/memory/mcp` 无状态 Streamable HTTP MCP，六个工具：`memory_bootstrap` / `memory_recall` / `memory_remember` / `memory_checkpoint` / `memory_link` / `memory_forget`。
+- `/api/app/memory` 管理 API + `/memory` Web 管理界面（Core / Projects / Recent / Review / Archive）。
+- 权限层级 `locked > confirmed > observed > inferred`：Agent 永不覆盖用户确认/锁定的记忆，冲突进 Review；写入门禁含指纹去重与凭据安全检测。
+- Memo ↔ Memory 双向连接（`derived_from` / `promoted_to`），导出导入纳入（bundle v3）。
+- 接入说明见 [docs/agent-memory.md](./agent-memory.md)。
+
+### 后续（按投入产出比）
+
+- **语义召回**：P0 是 FTS5 关键词召回；接 Vectorize embedding 后升级为自然语言召回，schema 已预留 `embedding_*` 字段，与 memo 的「找一找」共用同一套基础设施。
+- **自动固化**：P0 依赖 Agent 主动调用 `remember` / `checkpoint`；后续在会话/工作完成后自动调 LLM 提炼关键决策与教训。
+- **agent 身份与可观测**：`source_agent` 目前是来源字符串；后续可做 agent 注册与召回命中率/质量度量。
 
 ## 建议的开发顺序
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,7 @@ FlareMo 是 Cloudflare 原生的个人知识管理系统，提供 Memos 兼容 A
 - 架构: ./docs/architecture-notes.md
 - 部署: ./docs/deploy.md
 - Agent 部署: ./docs/agent-deploy.md
+- Agent Memory: ./docs/agent-memory.md
 - 发版: ./docs/release.md
 - 维护: ./docs/maintenance.md
 - Memos 兼容矩阵: ./docs/memos-compatibility.md


### PR DESCRIPTION
## 变更

- 新增 `docs/agent-memory.md`：Agent Memory 接入 runbook（`/memory/mcp` 六工具、认证、权限层级、P0 边界）。
- CHANGELOG Unreleased 补 Agent Memory 段，修正数据库影响描述（`0011_daffy_ultron.sql` 四张表 + FTS5）。
- `docs/product-requirements.md` 新增 Agent Memory 章节，更新现状对照表过时描述。
- ROADMAP 产品主线补 Agent Memory；README 能力与文档入口补全；llms.txt 加索引。

## 验证

`pnpm format:check` 退出码 0（本次改动仅 markdown，无新增告警）。