### PR TITLE
chore(lint): fix biome warnings in worker routes and API tests

### DIFF
--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -664,7 +664,7 @@ describe("FlareMo Worker API", () => {
     // Hierarchical filter: `工作` matches its descendants too.
     const workTagged = await json<ListMemosResponse>(
       await fetchApp(
-        "http://flaremo.test/api/app/memos?tag=" + encodeURIComponent("工作"),
+        `http://flaremo.test/api/app/memos?tag=${encodeURIComponent("工作")}`,
       ),
     );
     expect(workTagged.memos.map((memo) => memo.id)).toEqual(
@@ -1388,9 +1388,16 @@ describe("FlareMo Worker API", () => {
       (chunk) => chunk.kind === "memos",
     );
     expect(memosChunk).toBeTruthy();
+    if (!memosChunk) {
+      throw new Error("expected a memos chunk in the export manifest");
+    }
+    const chunkFileName = memosChunk.key.split("/").at(-1);
+    if (!chunkFileName) {
+      throw new Error("expected the chunk key to end in a file name");
+    }
     const chunkResponse = await fetchApp(
       `http://flaremo.test/api/v1/export/tasks/${taskId}/data/${encodeURIComponent(
-        memosChunk!.key.split("/").at(-1)!,
+        chunkFileName,
       )}`,
     );
     expect(chunkResponse.ok).toBe(true);
@@ -1412,7 +1419,10 @@ describe("FlareMo Worker API", () => {
         body: formData,
       }),
     );
-    const attachmentId = uploaded.name.split("/").at(-1)!;
+    const attachmentId = uploaded.name.split("/").at(-1);
+    if (!attachmentId) {
+      throw new Error("expected the attachment name to end in an id");
+    }
 
     const created = await json<{ task: { id: string } }>(
       await fetchApp("http://flaremo.test/api/v1/export/tasks", {

--- a/apps/worker/src/routes/memos-api.ts
+++ b/apps/worker/src/routes/memos-api.ts
@@ -1,6 +1,5 @@
 import {
   bindMemoAttachmentsSchema,
-  createDataTaskResponseSchema,
   createImportTaskRequestSchema,
   createMemoSchema,
   createShareSchema,
@@ -699,7 +698,13 @@ memosApi.post("/export/tasks", async (c) => {
       progressTotal: chunkKeys.length,
       completedAt: new Date().toISOString(),
     });
-    return c.json({ task: dataTaskToDto(done!) }, 202);
+    if (!done) {
+      return c.json(
+        { error: "export task was not found after finalization" },
+        500,
+      );
+    }
+    return c.json({ task: dataTaskToDto(done) }, 202);
   } catch (error) {
     if (taskId) {
       const context = await getRequestContext(c).catch(() => undefined);


### PR DESCRIPTION
## 变更

清除 `pnpm format:check` 的全部既有 warning，恢复零告警状态：

- `memos-api.ts`：删除未使用的 `createDataTaskResponseSchema` import；导出任务收尾的 `done!` 改为显式空值守卫（task 不存在返回 500）。
- `api.test.ts`：tag 查询 URL 改 template literal；导出清单 chunk 文件名、附件 id 的 non-null assertion 改为显式 throw。

## 验证

`pnpm format:check` 零告警；`pnpm --filter @flaremo/worker test` 13 文件 85 测试全过。