### PR TITLE
fix(version): sync FLAREMO_API_VERSION to v0.8.0

### DIFF
--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -9,6 +9,7 @@ import type {
   RenameTagResponse,
   TagHierarchyResponse,
 } from "@flaremo/contracts";
+import { FLAREMO_API_VERSION } from "@flaremo/contracts";
 import { createDb, memos } from "@flaremo/db";
 import { eq } from "drizzle-orm";
 import { Miniflare } from "miniflare";
@@ -425,7 +426,7 @@ describe("FlareMo Worker API", () => {
     expect(health).toMatchObject({
       ok: true,
       product: "FlareMo",
-      version: "0.6.0",
+      version: FLAREMO_API_VERSION,
       update_repository: "example/flaremo",
       update_workflow_url:
         "https://github.com/example/flaremo/actions/workflows/flaremo-update.yml",

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -1,3 +1,4 @@
+import { FLAREMO_API_VERSION } from "@flaremo/contracts";
 import type { UserRow } from "@flaremo/db";
 import { createDb } from "@flaremo/db";
 import {
@@ -1041,7 +1042,7 @@ async function connectInstanceMethod(
       return connectValue(
         c,
         {
-          version: "0.6.0",
+          version: FLAREMO_API_VERSION,
           demo: false,
           instanceUrl: c.env.FLAREMO_PUBLIC_URL ?? new URL(c.req.url).origin,
           admin,

--- a/packages/contracts/src/openapi.ts
+++ b/packages/contracts/src/openapi.ts
@@ -21,7 +21,7 @@ import {
   updateMemoSchema,
 } from "./memos";
 
-export const FLAREMO_API_VERSION = "0.6.0";
+export const FLAREMO_API_VERSION = "0.8.0";
 
 type JsonSchema = Record<string, unknown>;
 

--- a/tests/e2e/memo-flow.spec.ts
+++ b/tests/e2e/memo-flow.spec.ts
@@ -360,19 +360,27 @@ test("loads notes beyond the first page", async ({ page }) => {
 
 test("shows the installed version and safe update fallback", async ({
   page,
+  request,
 }) => {
+  // Resolve the version from the same API the UI renders, so a release bump
+  // does not silently break this UI contract check.
+  const health = await (
+    await request.get(`${E2E_BASE_URL}/api/app/health`)
+  ).json<{ version: string }>();
+  const version = `v${health.version}`;
+
   await page.goto("/");
 
   const updateButton = page.getByRole("button", {
     name: /system update|系统更新/i,
   });
   await expect(updateButton).toBeVisible();
-  await expect(updateButton).toContainText("v0.6.0");
+  await expect(updateButton).toContainText(version);
   await updateButton.click();
 
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
-  await expect(dialog).toContainText("v0.6.0");
+  await expect(dialog).toContainText(version);
   await expect(
     dialog.getByRole("link", { name: /update guide|升级指南/i }),
   ).toHaveAttribute("href", /docs\/update\.md$/);


### PR DESCRIPTION
## Issue

Closes #95

## 变更

1. `packages/contracts/src/openapi.ts`: `FLAREMO_API_VERSION` 0.6.0 → 0.8.0（唯一版本源，`/api/app/health`、OpenAPI、MCP serverInfo 均引用它）。
2. `apps/worker/src/routes/memos-connect-api.ts`: Memos Connect server info 的 `version` 改为引用 `FLAREMO_API_VERSION`，消除第二个硬编码漂移点。
3. `apps/worker/src/api.test.ts`: health 断言改为引用常量，不再硬编码 0.6.0。
4. `tests/e2e/memo-flow.spec.ts`: 版本显示 e2e 改为先从 `/api/app/health` 解析真实版本再断言，发版不再需要同步改测试。

## 验证

`pnpm verify` 全绿（format:check + check + test + build + test:e2e，exit 0）。