### PR TITLE
feat(auth): switch web sign-in to email, keep username for Memos

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ pnpm deploy
 
 ## 登录：Better Auth 原生认证，Access 可选
 
-FlareMo 的应用层认证由 Better Auth 提供。第一次部署时由部署者在生产 HTTPS 的 `/setup` 页面手动输入一次性 bootstrap secret、用户名、显示名、邮箱和密码，创建唯一初始 owner；成功后公共 signup 默认关闭，owner 可在后台开启开放注册。开启后，任何人都能通过 `/register` 页或 Memos 兼容客户端的 `signup` 创建普通成员账户。`FLAREMO_SINGLE_USER_EMAIL` 和 `FLAREMO_SINGLE_USER_NAME` 只是既有 `users/owner` domain metadata 的 legacy 变量，不是登录凭据或 bootstrap 输入。
+FlareMo 的应用层认证由 Better Auth 提供。第一次部署时由部署者在生产 HTTPS 的 `/setup` 页面手动输入一次性 bootstrap secret、显示名、邮箱和密码，创建唯一初始 owner；成功后公共 signup 默认关闭，owner 可在后台开启开放注册。开启后，任何人都能通过 `/register` 页或 Memos 兼容客户端的 `signup` 创建普通成员账户。`FLAREMO_SINGLE_USER_EMAIL` 和 `FLAREMO_SINGLE_USER_NAME` 只是既有 `users/owner` domain metadata 的 legacy 变量，不是登录凭据或 bootstrap 输入。
+
+- Web 端使用**邮箱 + 密码**登录（`/login`）；注册、管理员建号、初始化都以邮箱为登录凭证。Memos 兼容客户端仍使用**用户名 + 密码**登录——用户名由邮箱自动生成（可复制、可在账户页修改），协议上无法用邮箱登录。
 
 - 浏览器登录后使用 `HttpOnly`、`SameSite=Lax` cookie session。
 - 脚本、Memos-compatible 客户端和 MCP 使用账户创建的 `memos_pat_` Personal Access Token。

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -542,9 +542,8 @@ export async function getRegistrationStatus() {
 }
 
 export async function registerAccount(input: {
-  username: string;
   name: string;
-  email?: string;
+  email: string;
   password: string;
 }) {
   return apiRequest<{ ok: true }>(
@@ -579,9 +578,8 @@ export async function listAdminUsers() {
 }
 
 export async function createAdminUser(input: {
-  username: string;
   name: string;
-  email?: string;
+  email: string;
   password: string;
 }) {
   return apiRequest<AdminUser>("/api/app/admin/users", {
@@ -644,7 +642,6 @@ export async function recoverOwner(input: {
 }
 
 export async function bootstrapOwner(input: {
-  username: string;
   name: string;
   email: string;
   password: string;
@@ -658,7 +655,6 @@ export async function bootstrapOwner(input: {
         "x-flaremo-bootstrap-secret": input.bootstrapSecret,
       },
       body: JSON.stringify({
-        username: input.username,
         name: input.name,
         email: input.email,
         password: input.password,

--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -186,8 +186,10 @@ const messages = {
     "auth.accountTitle": "账户与访问",
     "auth.backToWorkspace": "返回工作区",
     "auth.signOut": "退出登录",
-    "auth.profileTitle": "用户名",
-    "auth.profileDescription": "用户名用于后续登录；修改后立即生效。",
+    "auth.profileTitle": "登录名（Memos 用户名）",
+    "auth.profileDescription":
+      "Web 登录使用邮箱；这里的用户名仅供 Memos 兼容客户端登录和展示，可自行修改。",
+    "auth.usernameHandle": "Memos 用户名",
     "auth.saveUsername": "保存用户名",
     "auth.saving": "正在保存…",
     "auth.usernameUpdateFailed": "无法更新用户名。",
@@ -248,7 +250,6 @@ const messages = {
     "auth.registerSuccess": "注册成功，请登录。",
     "auth.registrationStatusUnavailable":
       "无法读取注册状态，请检查网络后重试。",
-    "auth.emailOptional": "邮箱（可选）",
     "reset.title": "重设密码",
     "reset.description": "设置一个新密码。完成后用新密码登录。",
     "reset.missingToken": "缺少重置令牌，请使用管理员提供的完整链接。",
@@ -641,9 +642,10 @@ const messages = {
     "auth.accountTitle": "Account and access",
     "auth.backToWorkspace": "Back to workspace",
     "auth.signOut": "Sign out",
-    "auth.profileTitle": "Username",
+    "auth.profileTitle": "Sign-in name (Memos username)",
     "auth.profileDescription":
-      "Your username is used for future sign-ins and takes effect immediately when changed.",
+      "You sign in to the web with your email. This username is only used by Memos-compatible clients and can be changed here.",
+    "auth.usernameHandle": "Memos username",
     "auth.saveUsername": "Save username",
     "auth.saving": "Saving…",
     "auth.usernameUpdateFailed": "Could not update the username.",
@@ -710,7 +712,6 @@ const messages = {
     "auth.registerSuccess": "Account created. You can now sign in.",
     "auth.registrationStatusUnavailable":
       "FlareMo could not read the registration status. Check your connection and try again.",
-    "auth.emailOptional": "Email (optional)",
     "reset.title": "Reset password",
     "reset.description": "Choose a new password, then sign in with it.",
     "reset.missingToken":

--- a/apps/web/src/pages/account-page.tsx
+++ b/apps/web/src/pages/account-page.tsx
@@ -251,7 +251,7 @@ export function AccountPage() {
                 className="flex min-w-0 flex-1 flex-col gap-1.5 text-sm font-medium"
                 htmlFor="account-username"
               >
-                {t("auth.username")}
+                {t("auth.usernameHandle")}
                 <Input
                   autoCapitalize="none"
                   autoComplete="username"

--- a/apps/web/src/pages/admin-page.tsx
+++ b/apps/web/src/pages/admin-page.tsx
@@ -38,7 +38,6 @@ const MIN_PASSWORD_LENGTH = 12;
 export function AdminPage() {
   const { t } = useI18n();
   const queryClient = useQueryClient();
-  const [username, setUsername] = useState("");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -66,7 +65,6 @@ export function AdminPage() {
   const createUserMutation = useMutation({
     mutationFn: createAdminUser,
     onSuccess: () => {
-      setUsername("");
       setName("");
       setEmail("");
       setPassword("");
@@ -88,9 +86,8 @@ export function AdminPage() {
     setCreateError(null);
     try {
       await createUserMutation.mutateAsync({
-        username: username.trim(),
         name: name.trim(),
-        email: email.trim() || undefined,
+        email: email.trim(),
         password,
       });
     } catch (error) {
@@ -218,24 +215,6 @@ export function AdminPage() {
             >
               <label
                 className="flex flex-col gap-1.5 text-sm font-medium"
-                htmlFor="admin-username"
-              >
-                {t("auth.username")}
-                <Input
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  disabled={createUserMutation.isPending}
-                  id="admin-username"
-                  maxLength={30}
-                  minLength={3}
-                  pattern="[A-Za-z0-9_]+"
-                  required
-                  value={username}
-                  onChange={(event) => setUsername(event.target.value)}
-                />
-              </label>
-              <label
-                className="flex flex-col gap-1.5 text-sm font-medium"
                 htmlFor="admin-name"
               >
                 {t("auth.displayName")}
@@ -253,12 +232,13 @@ export function AdminPage() {
                 className="flex flex-col gap-1.5 text-sm font-medium"
                 htmlFor="admin-email"
               >
-                {t("auth.emailOptional")}
+                {t("auth.email")}
                 <Input
                   autoComplete="off"
                   disabled={createUserMutation.isPending}
                   id="admin-email"
                   maxLength={320}
+                  required
                   type="email"
                   value={email}
                   onChange={(event) => setEmail(event.target.value)}

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -22,7 +22,7 @@ export function LoginPage() {
     queryFn: getRegistrationStatus,
     retry: false,
   });
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -54,9 +54,9 @@ export function LoginPage() {
     setFormError(null);
     setIsSubmitting(true);
     try {
-      const result = await authClient.signIn.username({
+      const result = await authClient.signIn.email({
         password,
-        username: username.trim(),
+        email: email.trim(),
       });
       if (result.error) {
         throw result.error;
@@ -103,19 +103,20 @@ export function LoginPage() {
       >
         <label
           className="flex flex-col gap-1.5 text-sm font-medium"
-          htmlFor="login-username"
+          htmlFor="login-email"
         >
-          {t("auth.username")}
+          {t("auth.email")}
           <Input
             autoCapitalize="none"
-            autoComplete="username"
+            autoComplete="email"
             disabled={isSubmitting}
-            id="login-username"
-            maxLength={30}
-            name="username"
+            id="login-email"
+            maxLength={320}
+            name="email"
             required
-            value={username}
-            onChange={(event) => setUsername(event.target.value)}
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
           />
         </label>
         <label

--- a/apps/web/src/pages/register-page.tsx
+++ b/apps/web/src/pages/register-page.tsx
@@ -28,7 +28,6 @@ export function RegisterPage() {
     queryFn: getRegistrationStatus,
     retry: false,
   });
-  const [username, setUsername] = useState("");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -70,9 +69,8 @@ export function RegisterPage() {
     setIsSubmitting(true);
     try {
       await registerAccount({
-        username: username.trim(),
         name: name.trim(),
-        email: email.trim() || undefined,
+        email: email.trim(),
         password,
       });
       setPassword("");
@@ -112,54 +110,34 @@ export function RegisterPage() {
           void handleSubmit();
         }}
       >
-        <div className="grid gap-4 sm:grid-cols-2">
-          <label
-            className="flex flex-col gap-1.5 text-sm font-medium"
-            htmlFor="register-username"
-          >
-            {t("auth.username")}
-            <Input
-              autoCapitalize="none"
-              autoComplete="username"
-              disabled={isSubmitting}
-              id="register-username"
-              maxLength={30}
-              minLength={3}
-              name="username"
-              pattern="[A-Za-z0-9_]+"
-              required
-              value={username}
-              onChange={(event) => setUsername(event.target.value)}
-            />
-          </label>
-          <label
-            className="flex flex-col gap-1.5 text-sm font-medium"
-            htmlFor="register-name"
-          >
-            {t("auth.displayName")}
-            <Input
-              autoComplete="name"
-              disabled={isSubmitting}
-              id="register-name"
-              maxLength={80}
-              name="name"
-              required
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-            />
-          </label>
-        </div>
+        <label
+          className="flex flex-col gap-1.5 text-sm font-medium"
+          htmlFor="register-name"
+        >
+          {t("auth.displayName")}
+          <Input
+            autoComplete="name"
+            disabled={isSubmitting}
+            id="register-name"
+            maxLength={80}
+            name="name"
+            required
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </label>
         <label
           className="flex flex-col gap-1.5 text-sm font-medium"
           htmlFor="register-email"
         >
-          {t("auth.emailOptional")}
+          {t("auth.email")}
           <Input
             autoComplete="email"
             disabled={isSubmitting}
             id="register-email"
             maxLength={320}
             name="email"
+            required
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}

--- a/apps/web/src/pages/setup-page.tsx
+++ b/apps/web/src/pages/setup-page.tsx
@@ -18,7 +18,6 @@ export function SetupPage() {
     queryFn: getBootstrapStatus,
     retry: false,
   });
-  const [username, setUsername] = useState("");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -49,7 +48,6 @@ export function SetupPage() {
         email: email.trim(),
         name: name.trim(),
         password,
-        username: username.trim(),
       });
       setBootstrapSecret("");
       setPassword("");
@@ -117,43 +115,22 @@ export function SetupPage() {
               onChange={(event) => setBootstrapSecret(event.target.value)}
             />
           </label>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label
-              className="flex flex-col gap-1.5 text-sm font-medium"
-              htmlFor="setup-username"
-            >
-              {t("auth.username")}
-              <Input
-                autoCapitalize="none"
-                autoComplete="username"
-                disabled={isSubmitting}
-                id="setup-username"
-                maxLength={30}
-                minLength={3}
-                name="username"
-                pattern="[A-Za-z0-9_]+"
-                required
-                value={username}
-                onChange={(event) => setUsername(event.target.value)}
-              />
-            </label>
-            <label
-              className="flex flex-col gap-1.5 text-sm font-medium"
-              htmlFor="setup-name"
-            >
-              {t("auth.displayName")}
-              <Input
-                autoComplete="name"
-                disabled={isSubmitting}
-                id="setup-name"
-                maxLength={80}
-                name="name"
-                required
-                value={name}
-                onChange={(event) => setName(event.target.value)}
-              />
-            </label>
-          </div>
+          <label
+            className="flex flex-col gap-1.5 text-sm font-medium"
+            htmlFor="setup-name"
+          >
+            {t("auth.displayName")}
+            <Input
+              autoComplete="name"
+              disabled={isSubmitting}
+              id="setup-name"
+              maxLength={80}
+              name="name"
+              required
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </label>
           <label
             className="flex flex-col gap-1.5 text-sm font-medium"
             htmlFor="setup-email"

--- a/apps/worker/src/routes/admin-api.ts
+++ b/apps/worker/src/routes/admin-api.ts
@@ -1,6 +1,7 @@
 import {
   createFlaremoMemberWithLink,
   deleteFlaremoUser,
+  deriveUniqueUsername,
   ForbiddenError,
   getAuthUserById,
   getAuthUserIdByFlaremoUserId,
@@ -23,17 +24,8 @@ const updateSettingsSchema = z.object({
 });
 
 const createUserSchema = z.object({
-  username: z
-    .string()
-    .trim()
-    .min(3)
-    .max(30)
-    .regex(
-      /^[A-Za-z0-9_]+$/,
-      "Username may contain letters, numbers, and underscores.",
-    ),
   name: z.string().trim().min(1).max(80),
-  email: z.string().trim().email().max(320).optional(),
+  email: z.string().trim().email().max(320),
   password: z.string().min(12).max(128),
 });
 
@@ -103,7 +95,8 @@ adminApi.post("/users", zValidator("json", createUserSchema), async (c) => {
   try {
     const context = await ownerContext(c);
     const input = c.req.valid("json");
-    const email = input.email ?? `${input.username}@flaremo.local`;
+    const email = input.email;
+    const username = await deriveUniqueUsername(context.db, email);
     const auth = createFlareMoAuth(c.env, context.db, {
       allowBootstrapSignUp: true,
     });
@@ -112,8 +105,8 @@ adminApi.post("/users", zValidator("json", createUserSchema), async (c) => {
         email,
         name: input.name,
         password: input.password,
-        username: input.username,
-        displayUsername: input.username,
+        username,
+        displayUsername: input.name,
       },
     });
     const user = await createFlaremoMemberWithLink(context.db, {
@@ -126,7 +119,7 @@ adminApi.post("/users", zValidator("json", createUserSchema), async (c) => {
         id: user.id,
         email,
         name: user.name,
-        username: input.username,
+        username,
         role: user.role,
         created_at: user.createdAt,
       },

--- a/apps/worker/src/routes/auth-api.ts
+++ b/apps/worker/src/routes/auth-api.ts
@@ -3,6 +3,7 @@ import {
   claimOwnerBootstrap,
   completeOwnerBootstrap,
   createFlaremoMemberWithLink,
+  deriveUniqueUsername,
   getAuthBootstrapStatus,
   getOwnerAuthUserId,
   getUserRegistrationAllowed,
@@ -24,15 +25,6 @@ import { jsonError } from "../http";
 export const authApi = new Hono<HonoBindings>();
 
 const bootstrapSchema = z.object({
-  username: z
-    .string()
-    .trim()
-    .min(3)
-    .max(30)
-    .regex(
-      /^[A-Za-z0-9_]+$/,
-      "Username may contain letters, numbers, and underscores.",
-    ),
   name: z.string().trim().min(1).max(80),
   email: z.string().trim().email().max(320),
   password: z.string().min(12).max(128),
@@ -43,17 +35,8 @@ const operatorRecoverySchema = z.object({
 });
 
 const registerSchema = z.object({
-  username: z
-    .string()
-    .trim()
-    .min(3)
-    .max(30)
-    .regex(
-      /^[A-Za-z0-9_]+$/,
-      "Username may contain letters, numbers, and underscores.",
-    ),
   name: z.string().trim().min(1).max(80),
-  email: z.string().trim().email().max(320).optional(),
+  email: z.string().trim().email().max(320),
   password: z.string().min(12).max(128),
 });
 
@@ -104,7 +87,8 @@ authApi.post("/register", zValidator("json", registerSchema), async (c) => {
   }
 
   const input = c.req.valid("json");
-  const email = input.email?.trim() || `${input.username}@flaremo.local`;
+  const email = input.email.trim();
+  const username = await deriveUniqueUsername(db, email);
   let auth: ReturnType<typeof createFlareMoAuth>;
   try {
     auth = createFlareMoAuth(c.env, db, { allowBootstrapSignUp: true });
@@ -121,8 +105,8 @@ authApi.post("/register", zValidator("json", registerSchema), async (c) => {
         email,
         name: input.name,
         password: input.password,
-        username: input.username,
-        displayUsername: input.username,
+        username,
+        displayUsername: input.name,
       },
     });
     await createFlaremoMemberWithLink(db, {
@@ -190,13 +174,14 @@ authApi.post("/bootstrap", zValidator("json", bootstrapSchema), async (c) => {
   }
   const input = c.req.valid("json");
   try {
+    const username = await deriveUniqueUsername(db, input.email);
     const result = await auth.api.signUpEmail({
       body: {
         email: input.email,
         name: input.name,
         password: input.password,
-        username: input.username,
-        displayUsername: input.username,
+        username,
+        displayUsername: input.name,
       },
     });
     await completeOwnerBootstrap(db, {

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -2881,7 +2881,7 @@ async function connectAuthSignUp(
       );
     }
 
-    const email = `${username}@flaremo.local`;
+    const email = optionalString(body.email) ?? `${username}@flaremo.local`;
     const { authUserId, user, dto } = await createConnectUser(c, db, {
       username,
       password,

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -101,6 +101,7 @@ const currentSignupSchema = z.object({
   username: z.string().min(1),
   password: z.string().min(12).max(128),
   displayName: z.string().trim().max(80).optional(),
+  email: z.string().trim().email().max(320).optional(),
 });
 
 const currentRelationBodySchema = z.object({
@@ -246,7 +247,7 @@ memosCurrentApi.post("/auth/signup", async (c, next) => {
     const input = currentSignupSchema.parse(await c.req.json());
     await assertRegistrationOpen(c);
     const username = input.username.trim();
-    const email = `${username}@flaremo.local`;
+    const email = input.email?.trim() || `${username}@flaremo.local`;
     const dbContext = await createAuthContext(c);
     const auth = createFlareMoAuth(c.env, dbContext.db, {
       allowBootstrapSignUp: true,

--- a/docs/memos-compatibility.md
+++ b/docs/memos-compatibility.md
@@ -47,8 +47,8 @@ Better Auth 是应用层认证事实源，Cloudflare Access 只能作为可选�
 
 | 入口 | 当前认证方式 | 兼容说明 |
 | --- | --- | --- |
-| Web / Better Auth | 用户名 + 密码，登录后使用 `HttpOnly` cookie session | owner 通过一次性 bootstrap 创建；开放注册开关由 owner 在后台控制，开启后 `POST /api/auth/flaremo/register` 与 Memos `signup` 可创建普通成员。认证表和 `auth_user_links` 支撑多用户映射。 |
-| current auth facade | `POST /api/v1/auth/signin`、`signup`、`refresh`、`signout`，以及 `GET /api/v1/auth/me` | Better Auth 提供身份和账户事实源；signin 返回 FlareMo 生成的 Memos 风格 HS256 access JWT，并设置轮换的 `memos_refresh` HttpOnly cookie。signup 受开放注册开关约束，成功即创建成员并签发 native token。旧 Better Auth session bearer 仍保留兼容。 |
+| Web / Better Auth | Web 端邮箱 + 密码登录，登录后使用 `HttpOnly` cookie session | owner 通过一次性 bootstrap 创建；开放注册开关由 owner 在后台控制，开启后 `POST /api/auth/flaremo/register` 与 Memos `signup` 可创建普通成员。用户名由邮箱自动生成，仅供 Memos 兼容客户端登录，可在账户页修改。 |
+| current auth facade | `POST /api/v1/auth/signin`、`signup`、`refresh`、`signout`，以及 `GET /api/v1/auth/me` | Better Auth 提供身份和账户事实源；signin 用 `username + password`（Memos 协议无 email 字段），返回 FlareMo 生成的 Memos 风格 HS256 access JWT，并设置轮换的 `memos_refresh` HttpOnly cookie。signup 受开放注册开关约束，接受可选 `email` 字段，成功即创建成员并签发 native token。旧 Better Auth session bearer 仍保留兼容。 |
 | `/api/v1/*` 私有 API | cookie session，或 `Authorization: Bearer memos_pat_...` | PAT 由已登录账户创建、只在创建时显示一次、可撤销，并由 Better Auth API key/plugin 数据承载。native JWT 和 PAT 是两种明确的应用凭据。 |
 | current PAT 资源 | `/api/v1/users/{user}/personalAccessTokens` | 提供当前用户的 list/create/revoke 基础；`memos_pat_` 本身不能管理 PAT。 |
 | 根 `/mcp` | cookie session、Better Auth session bearer、FlareMo native access JWT，或 `memos_pat_` PAT | Streamable HTTP 是无状态 JSON 子集，不创建 MCP session。 |

--- a/packages/domain/src/users.ts
+++ b/packages/domain/src/users.ts
@@ -100,6 +100,35 @@ export async function listFlaremoUsers(db: FlareMoDb): Promise<UserRow[]> {
 }
 
 /**
+ * Derive a legal, unique Better Auth username from an email address. Web
+ * signup and admin-created accounts log in with email; the username is kept
+ * only because the Memos-compatible wire (signin and user resources) still
+ * identifies users by username, and it is editable from the account page.
+ */
+export async function deriveUniqueUsername(
+  db: FlareMoDb,
+  email: string,
+): Promise<string> {
+  const base =
+    email
+      .split("@")[0]
+      ?.toLowerCase()
+      .replace(/[^a-z0-9_]/g, "")
+      .slice(0, 30) || "user";
+  let candidate = base;
+  let suffix = 0;
+  for (;;) {
+    const existing = await db.query.authUsers.findFirst({
+      where: eq(authUsers.username, candidate),
+    });
+    if (!existing) return candidate;
+    suffix += 1;
+    const suffixText = String(suffix);
+    candidate = `${base.slice(0, 30 - suffixText.length)}${suffixText}`;
+  }
+}
+
+/**
  * Delete a non-owner user. The auth identity is removed first so its sessions,
  * accounts, and API keys cascade, then the domain row is removed so memos and
  * other owned resources cascade. The owner bootstrap identity is immutable.

--- a/tests/e2e/auth-fixture.ts
+++ b/tests/e2e/auth-fixture.ts
@@ -11,7 +11,9 @@ export const E2E_BOOTSTRAP_SECRET =
   "flaremo-e2e-bootstrap-secret-never-use-in-production-2026";
 export const E2E_USERNAME = "e2e_owner";
 export const E2E_UPDATED_USERNAME = "e2e_owner_updated";
-export const E2E_EMAIL = "e2e-owner@example.test";
+// The username is derived from the email's local part, so keep it identical
+// to E2E_USERNAME (only [a-z0-9_] survive the derivation).
+export const E2E_EMAIL = "e2e_owner@example.test";
 export const E2E_NAME = "FlareMo E2E Owner";
 export const E2E_INITIAL_PASSWORD =
   "flaremo-e2e-initial-password-never-use-in-production-2026";
@@ -20,7 +22,6 @@ export const E2E_UPDATED_PASSWORD =
 export const E2E_AUTH_STATE = resolve("test-results/.auth/owner.json");
 
 export const E2E_BOOTSTRAP_INPUT = {
-  username: E2E_USERNAME,
   name: E2E_NAME,
   email: E2E_EMAIL,
   password: E2E_INITIAL_PASSWORD,

--- a/tests/e2e/auth-ui-flow.spec.ts
+++ b/tests/e2e/auth-ui-flow.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
-import { E2E_AUTH_STATE } from "./auth-fixture";
+import { E2E_AUTH_STATE, E2E_EMAIL } from "./auth-fixture";
 
-const TEST_USERNAME = "e2e_owner";
 const TEST_PASSWORD =
   "flaremo-e2e-initial-password-never-use-in-production-2026";
 
@@ -15,13 +14,11 @@ test("keeps setup one-time, logs in, and manages a PAT from the account UI", asy
   await page.goto("/setup");
   await expect(page).toHaveURL(/\/login$/);
 
-  const username = page.getByRole("textbox", {
-    name: /用户名|Username/i,
-  });
+  const email = page.getByRole("textbox", { name: /^邮箱$|^Email$/i });
   const password = page.getByRole("textbox", {
     name: /^密码$|^Password$/i,
   });
-  await username.fill(TEST_USERNAME);
+  await email.fill(E2E_EMAIL);
   await password.fill(TEST_PASSWORD);
   await page.getByRole("button", { name: /^登录$|^Sign in$/i }).click();
 


### PR DESCRIPTION
## 验证命令

```bash
pnpm verify
pnpm deploy:dry-run
```

## 变更内容

- Web 端登录/注册/初始化/管理员建号全部改为**邮箱 + 密码**（Better Auth `signIn.email`）。
- 用户名由邮箱自动派生（只保留 `[a-z0-9_]`，冲突时加数字后缀保证唯一），作为 Memos 兼容客户端的登录名，可在账户页修改。
- Memos 协议无 email 字段，`signin`/`signup` 继续用 username + password（兼容不受影响）；`signup` 额外接受可选 `email` 字段。
- e2e 夹具与 UI 测试更新为邮箱登录。

## 范围外

- 不做邮箱验证（保持免费、无 SMTP 依赖）；email 是登录凭证但不做所有权验证。