### PR TITLE
feat(auth): add email change with current-password verification

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -690,6 +690,16 @@ export async function revokePersonalAccessToken(id: string) {
   );
 }
 
+export async function changeEmail(input: {
+  current_password: string;
+  new_email: string;
+}) {
+  return apiRequest<{ ok: true }>("/api/app/account/email", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
 export async function createMemo(input: CreateMemoRequest) {
   return apiRequest<Memo>("/api/app/memos", {
     method: "POST",

--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -198,6 +198,10 @@ const messages = {
     "auth.newPassword": "新密码",
     "auth.changePassword": "修改密码",
     "auth.passwordUpdateFailed": "无法修改密码。请确认当前密码后重试。",
+    "auth.emailTitle": "修改邮箱",
+    "auth.newEmail": "新邮箱",
+    "auth.changeEmail": "修改邮箱",
+    "auth.emailUpdateFailed": "无法修改邮箱。请确认当前密码后重试。",
     "auth.tokensTitle": "个人访问令牌",
     "auth.tokenShownOnce": "请立即安全保存这个令牌",
     "auth.tokenShownOnceDescription":
@@ -646,6 +650,11 @@ const messages = {
     "auth.changePassword": "Change password",
     "auth.passwordUpdateFailed":
       "Could not change the password. Check the current password and try again.",
+    "auth.emailTitle": "Change email",
+    "auth.newEmail": "New email",
+    "auth.changeEmail": "Change email",
+    "auth.emailUpdateFailed":
+      "Could not change the email. Check the current password and try again.",
     "auth.tokensTitle": "Personal access tokens",
     "auth.tokenShownOnce": "Save this token securely now",
     "auth.tokenShownOnceDescription":

--- a/apps/web/src/pages/account-page.tsx
+++ b/apps/web/src/pages/account-page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
+  changeEmail,
   createPersonalAccessToken,
   getCurrentFlareMoUser,
   getVectorUsage,
@@ -46,11 +47,14 @@ export function AccountPage() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [newPasswordConfirmation, setNewPasswordConfirmation] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+  const [emailCurrentPassword, setEmailCurrentPassword] = useState("");
   const [tokenName, setTokenName] = useState("");
   const [tokenExpiryDays, setTokenExpiryDays] = useState("");
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const [accountError, setAccountError] = useState<string | null>(null);
   const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -95,6 +99,12 @@ export function AccountPage() {
         revokeOtherSessions: true,
       });
       if (result.error) throw result.error;
+    },
+  });
+  const changeEmailMutation = useMutation({
+    mutationFn: changeEmail,
+    onSuccess: async () => {
+      await session.refetch();
     },
   });
   const createTokenMutation = useMutation({
@@ -147,6 +157,20 @@ export function AccountPage() {
       setNewPasswordConfirmation("");
     } catch (error) {
       setPasswordError(errorMessage(error, t("auth.passwordUpdateFailed")));
+    }
+  };
+
+  const handleEmailSubmit = async () => {
+    setEmailError(null);
+    try {
+      await changeEmailMutation.mutateAsync({
+        current_password: emailCurrentPassword,
+        new_email: newEmail.trim(),
+      });
+      setNewEmail("");
+      setEmailCurrentPassword("");
+    } catch (error) {
+      setEmailError(errorMessage(error, t("auth.emailUpdateFailed")));
     }
   };
 
@@ -369,6 +393,70 @@ export function AccountPage() {
                       {changePasswordMutation.isPending
                         ? t("auth.saving")
                         : t("auth.changePassword")}
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>{t("auth.emailTitle")}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <form
+                  className="grid gap-3 sm:grid-cols-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleEmailSubmit();
+                  }}
+                >
+                  <label
+                    className="flex flex-col gap-1.5 text-sm font-medium sm:col-span-2"
+                    htmlFor="account-new-email"
+                  >
+                    {t("auth.newEmail")}
+                    <Input
+                      autoCapitalize="none"
+                      autoComplete="email"
+                      disabled={changeEmailMutation.isPending}
+                      id="account-new-email"
+                      required
+                      type="email"
+                      value={newEmail}
+                      onChange={(event) => setNewEmail(event.target.value)}
+                    />
+                  </label>
+                  <label
+                    className="flex flex-col gap-1.5 text-sm font-medium sm:col-span-2"
+                    htmlFor="account-email-current-password"
+                  >
+                    {t("auth.currentPassword")}
+                    <Input
+                      autoComplete="current-password"
+                      disabled={changeEmailMutation.isPending}
+                      id="account-email-current-password"
+                      required
+                      type="password"
+                      value={emailCurrentPassword}
+                      onChange={(event) =>
+                        setEmailCurrentPassword(event.target.value)
+                      }
+                    />
+                  </label>
+                  {emailError && (
+                    <p className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive sm:col-span-2">
+                      {emailError}
+                    </p>
+                  )}
+                  <div className="sm:col-span-2">
+                    <Button
+                      disabled={changeEmailMutation.isPending}
+                      type="submit"
+                    >
+                      <RefreshCcwIcon data-icon="inline-start" />
+                      {changeEmailMutation.isPending
+                        ? t("auth.saving")
+                        : t("auth.changeEmail")}
                     </Button>
                   </div>
                 </form>

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -64,6 +64,15 @@ export type FlareMoAuth = {
     newPassword: string;
   }) => Promise<void>;
   /**
+   * Change a Better Auth identity's login email and mark it verified. The
+   * caller is responsible for prior password/identity verification and for
+   * keeping the FlareMo domain `users` row in sync.
+   */
+  changeEmail: (input: {
+    currentEmail: string;
+    newEmail: string;
+  }) => Promise<void>;
+  /**
    * Mint a single-use, expiring password-reset token for a Better Auth
    * identity. The token is stored in `auth_verifications` under the same
    * `reset-password:` namespace Better Auth's reset-password endpoint already
@@ -123,6 +132,10 @@ export type FlareMoAuth = {
         enabled: boolean;
       };
     }) => Promise<MemosApiKey>;
+    verifyPassword: (input: {
+      body: { password: string };
+      headers: Headers;
+    }) => Promise<{ status: boolean }>;
     verifyApiKey: (input: {
       body: {
         configId: string;
@@ -226,6 +239,16 @@ export function createFlareMoAuth(
         expiresAt: new Date(Date.now() + 60 * 60 * 1_000),
       });
       return token;
+    },
+    changeEmail: async ({ currentEmail, newEmail }) => {
+      const authContext = await auth.$context;
+      // Better Auth lowercases the email and refreshes the caller's own
+      // session so subsequent requests observe the new login identity.
+      await authContext.internalAdapter.updateUserByEmail(currentEmail, {
+        email: newEmail,
+        emailVerified: true,
+        updatedAt: new Date(),
+      });
     },
     operatorResetPassword: async ({ authUserId, newPassword }) => {
       // Better Auth's resetPassword API owns password validation, hashing,

--- a/apps/worker/src/routes/account-api.ts
+++ b/apps/worker/src/routes/account-api.ts
@@ -2,6 +2,8 @@ import {
   getMemosPersonalAccessToken,
   listMemosPersonalAccessTokens,
   NotFoundError,
+  updateFlaremoUserEmail,
+  ValidationError,
 } from "@flaremo/domain";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -15,6 +17,11 @@ export const accountApi = new Hono<HonoBindings>();
 const createPersonalAccessTokenSchema = z.object({
   name: z.string().trim().min(1).max(32),
   expires_in_days: z.number().int().min(1).max(365).nullable().optional(),
+});
+
+const changeEmailSchema = z.object({
+  current_password: z.string().min(1).max(128),
+  new_email: z.string().trim().email().max(320),
 });
 
 accountApi.get("/personal-access-tokens", async (c) => {
@@ -87,6 +94,42 @@ accountApi.post("/personal-access-tokens/:id/revoke", async (c) => {
       },
     });
     return c.json({ personal_access_token: toPersonalAccessTokenDto(updated) });
+  } catch (error) {
+    return jsonError(c, error);
+  }
+});
+
+accountApi.post("/email", zValidator("json", changeEmailSchema), async (c) => {
+  try {
+    const context = await getBrowserRequestContext(c);
+    const input = c.req.valid("json");
+    const newEmail = input.new_email.trim();
+    const auth = createFlareMoAuth(c.env, context.db);
+
+    // Changing the login identity re-authenticates the caller with their
+    // current password before touching any credential. Better Auth raises an
+    // error (rather than returning status:false) on a mismatch, so a thrown
+    // result here is a plain "bad password", not a server fault.
+    try {
+      await auth.api.verifyPassword({
+        body: { password: input.current_password },
+        headers: c.req.raw.headers,
+      });
+    } catch {
+      throw new ValidationError("The current password is incorrect.");
+    }
+
+    // The auth credential is updated first so a failed domain write cannot
+    // leave a login identity pointing at a stale address.
+    await auth.changeEmail({
+      currentEmail: context.user.email,
+      newEmail,
+    });
+    await updateFlaremoUserEmail(context.db, context.user, newEmail);
+
+    const response = c.json({ ok: true });
+    response.headers.set("cache-control", "no-store");
+    return response;
   } catch (error) {
     return jsonError(c, error);
   }

--- a/packages/domain/src/users.test.ts
+++ b/packages/domain/src/users.test.ts
@@ -1,0 +1,104 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { UserRow } from "@flaremo/db";
+import { createDb } from "@flaremo/db";
+import { Miniflare } from "miniflare";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ConflictError, ValidationError } from "./errors";
+import {
+  createFlaremoMember,
+  ensureSingleUser,
+  updateFlaremoUserEmail,
+} from "./users";
+
+let mf: Miniflare;
+let db: ReturnType<typeof createDb>;
+let user: UserRow;
+
+async function applyMigration(
+  database: Awaited<ReturnType<Miniflare["getD1Database"]>>,
+  sql: string,
+) {
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  for (const statement of statements) {
+    await database.prepare(statement).run();
+  }
+}
+
+describe("updateFlaremoUserEmail", () => {
+  beforeEach(async () => {
+    mf = new Miniflare({
+      script: "export default { fetch() { return new Response('ok') } }",
+      modules: true,
+      compatibilityDate: "2026-07-10",
+      compatibilityFlags: ["nodejs_compat"],
+      d1Databases: { DB: "flaremo-users-test" },
+    });
+    const database = await mf.getD1Database("DB");
+    db = createDb(database);
+    const migrationNames = [
+      "0000_illegal_inhumans.sql",
+      "0001_familiar_morph.sql",
+      "0002_wooden_professor_monster.sql",
+      "0003_equal_maximus.sql",
+      "0004_complex_the_enforcers.sql",
+      "0005_confused_masque.sql",
+      "0006_silent_kylun.sql",
+      "0007_flat_phil_sheldon.sql",
+      "0008_legal_scarecrow.sql",
+      "0009_neat_iron_fist.sql",
+      "0010_deep_gateway.sql",
+      "0011_daffy_ultron.sql",
+      "0012_slow_nick_fury.sql",
+      "0013_nosy_luke_cage.sql",
+    ];
+    for (const name of migrationNames) {
+      const sql = await readFile(
+        resolve(import.meta.dirname, `../../../migrations/${name}`),
+        "utf8",
+      );
+      await applyMigration(database, sql);
+    }
+    user = await ensureSingleUser(db, {
+      email: "owner@example.com",
+      name: "Owner",
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+  });
+
+  it("updates the domain user's email and normalizes it to lowercase", async () => {
+    const updated = await updateFlaremoUserEmail(
+      db,
+      user,
+      "New.Owner@Example.com",
+    );
+    expect(updated.email).toBe("new.owner@example.com");
+  });
+
+  it("rejects an invalid email address", async () => {
+    await expect(
+      updateFlaremoUserEmail(db, user, "not-an-email"),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("rejects an email already taken by another user", async () => {
+    await createFlaremoMember(db, {
+      email: "other@example.com",
+      name: "Other",
+    });
+    await expect(
+      updateFlaremoUserEmail(db, user, "other@example.com"),
+    ).rejects.toThrow(ConflictError);
+  });
+
+  it("allows re-using the current email value", async () => {
+    const updated = await updateFlaremoUserEmail(db, user, "owner@example.com");
+    expect(updated.email).toBe("owner@example.com");
+  });
+});

--- a/packages/domain/src/users.ts
+++ b/packages/domain/src/users.ts
@@ -1,7 +1,12 @@
 import type { FlareMoDb, UserRow } from "@flaremo/db";
 import { authUserLinks, authUsers, users } from "@flaremo/db";
 import { asc, eq } from "drizzle-orm";
-import { ForbiddenError, NotFoundError } from "./errors";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "./errors";
 
 export type SingleUserConfig = {
   email: string;
@@ -150,6 +155,37 @@ export async function deleteFlaremoUser(
     await db.delete(authUsers).where(eq(authUsers.id, link.authUserId));
   }
   await db.delete(users).where(eq(users.id, userId));
+}
+
+/**
+ * Update the FlareMo domain user's email in the business `users` table. The
+ * caller is responsible for updating the Better Auth `auth_users` credential
+ * and for any prior identity verification; this service only keeps the domain
+ * copy in sync and enforces the table's unique-email constraint. The email is
+ * normalized to lowercase so the two unique email columns stay comparable.
+ */
+export async function updateFlaremoUserEmail(
+  db: FlareMoDb,
+  user: UserRow,
+  newEmail: string,
+): Promise<UserRow> {
+  const email = newEmail.trim().toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new ValidationError("A valid email address is required.");
+  }
+  const taken = await db.query.users.findFirst({
+    where: eq(users.email, email),
+  });
+  if (taken && taken.id !== user.id) {
+    throw new ConflictError("That email is already in use.");
+  }
+  await db
+    .update(users)
+    .set({ email, updatedAt: new Date().toISOString() })
+    .where(eq(users.id, user.id));
+  return (
+    (await db.query.users.findFirst({ where: eq(users.id, user.id) })) ?? user
+  );
 }
 
 export async function updateFlaremoUserProfile(


### PR DESCRIPTION
## 变更内容
为账户设置页新增"修改邮箱"能力。个人单用户系统当前无邮件基础设施，采用**验证当前密码 → 直接改邮箱**的方案，不引入邮件服务；密码验证步骤封装在 route 层，未来接入邮件 OTP 时可替换而不改路由契约。

## 技术实现
- **domain**：`updateFlaremoUserEmail` 同步业务 `users` 表的 email（lowercase + 唯一性冲突检查）。
- **worker**：`POST /api/app/account/email`，经 `getBrowserRequestContext` 校验 session + Origin allowlist；用 `auth.api.verifyPassword` 校验当前密码，再 `auth.changeEmail` 更新 `auth_users` 登录凭据（标记 verified、刷新当前会话），最后同步 domain 表。
- **web**：security tab 新增改邮箱卡片，复用现有内联表单 + 内联错误模式。
- **tests**：`updateFlaremoUserEmail` 单测（更新、大小写归一、非法邮箱、重复邮箱、重复当前值）。

## 验证
- `pnpm verify`（含 typecheck、vitest 单测、24 个 playwright e2e）通过。

## Issue 关系
无关联 issue（直接需求）。