### PR TITLE
feat(worker): export createFlareMoApp factory and injectable PlanLimits

### DIFF
--- a/apps/worker/src/context.ts
+++ b/apps/worker/src/context.ts
@@ -3,6 +3,8 @@ import {
   ForbiddenError,
   getFlaremoUserByAuthSessionToken,
   getFlaremoUserByAuthUserId,
+  type PlanLimits,
+  SELF_HOST_UNLIMITED,
   UnauthorizedError,
 } from "@flaremo/domain";
 import type { Context } from "hono";
@@ -16,6 +18,14 @@ import { authenticateMemosAccessToken } from "./memos-native-auth";
 
 export type HonoBindings = {
   Bindings: FlareMoEnv;
+  Variables: {
+    /**
+     * Resolved once per request by createFlareMoApp's limits middleware.
+     * Self-hosted deployments always carry SELF_HOST_UNLIMITED; hosted
+     * shells swap in a subscription-backed resolver via factory options.
+     */
+    planLimits: PlanLimits;
+  };
 };
 
 export type RequestCredential = "session" | "pat";
@@ -42,6 +52,7 @@ export async function getRequestContext(c: Context<HonoBindings>) {
           bearerSession: false,
           nativeAccessToken: true,
           session: null,
+          limits: c.get("planLimits") ?? SELF_HOST_UNLIMITED,
         };
       }
 
@@ -56,6 +67,7 @@ export async function getRequestContext(c: Context<HonoBindings>) {
         bearerSession: true,
         nativeAccessToken: false,
         session: session.session,
+        limits: c.get("planLimits") ?? SELF_HOST_UNLIMITED,
       };
     }
     const verification = await auth.api.verifyApiKey({
@@ -82,6 +94,7 @@ export async function getRequestContext(c: Context<HonoBindings>) {
       bearerSession: false,
       nativeAccessToken: false,
       session: null,
+      limits: c.get("planLimits") ?? SELF_HOST_UNLIMITED,
     };
   }
 
@@ -111,6 +124,7 @@ export async function getOptionalRequestContext(c: Context<HonoBindings>) {
         bearerSession: false,
         nativeAccessToken: false,
         session: null,
+        limits: c.get("planLimits") ?? SELF_HOST_UNLIMITED,
       };
     }
     throw error;
@@ -148,6 +162,7 @@ export async function getBrowserRequestContext(
     bearerSession: false,
     nativeAccessToken: false,
     session: null,
+    limits: c.get("planLimits") ?? SELF_HOST_UNLIMITED,
   };
 }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -11,6 +11,8 @@ import {
   expireStaleDataTasks,
   finalizeAttachmentCleanup,
   listAttachmentCleanupCandidates,
+  type PlanLimits,
+  SELF_HOST_UNLIMITED,
 } from "@flaremo/domain";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -43,138 +45,169 @@ import { projectsApi } from "./routes/projects-api";
 import { publicApi } from "./routes/public-api";
 import { tasksApi } from "./routes/tasks-api";
 
-const app = new Hono<HonoBindings>();
+/**
+ * Kernel assembly entry. Every call returns a fresh Hono instance so hosts
+ * (the default worker, tests, or an external composition shell) can mount
+ * extra middleware/routes without mutating shared state.
+ *
+ * The default limits resolver is the self-hosted unlimited plan; an external
+ * composition shell may inject a subscription-backed resolver without this
+ * file knowing anything about billing.
+ */
+export type FlareMoAppOptions = {
+  resolvePlanLimits?: (env: FlareMoEnv) => Promise<PlanLimits> | PlanLimits;
+};
 
-app.use(
-  "/api/*",
-  cors({
-    origin: (origin, c) => {
-      try {
-        return getTrustedOrigins(c.env).includes(origin) ? origin : undefined;
-      } catch {
-        return undefined;
-      }
-    },
-    credentials: true,
-    allowHeaders: [
-      "content-type",
-      "authorization",
-      // Access remains an optional outer policy during migration. Keep its
-      // established service-token headers available to trusted CORS origins;
-      // they never replace the FlareMo session/PAT check below the edge.
-      "cf-access-client-id",
-      "cf-access-client-secret",
-      "x-flaremo-bootstrap-secret",
-    ],
-    allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-  }),
-);
+export function createFlareMoApp(
+  options: FlareMoAppOptions = {},
+): Hono<HonoBindings> {
+  const resolvePlanLimits =
+    options.resolvePlanLimits ?? ((env: FlareMoEnv) => SELF_HOST_UNLIMITED);
+  const app = new Hono<HonoBindings>();
 
-app.use(
-  "/mcp",
-  cors({
-    origin: (origin, c) => {
-      try {
-        return getTrustedOrigins(c.env).includes(origin) ? origin : undefined;
-      } catch {
-        return undefined;
-      }
-    },
-    credentials: false,
-    allowHeaders: ["content-type", "authorization", "accept", "mcp-session-id"],
-    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
-  }),
-);
+  app.use("*", async (c, next) => {
+    c.set("planLimits", await resolvePlanLimits(c.env));
+    await next();
+  });
 
-app.use(
-  "/memos.api.v1.*",
-  cors({
-    origin: (origin, c) => {
-      try {
-        return getTrustedOrigins(c.env).includes(origin) ? origin : undefined;
-      } catch {
-        return undefined;
-      }
-    },
-    credentials: true,
-    allowHeaders: [
-      "content-type",
-      "authorization",
-      "accept",
-      "connect-protocol-version",
-      "grpc-accept-encoding",
-      "grpc-encoding",
-      "grpc-timeout",
-      "x-grpc-web",
-      "x-user-agent",
-    ],
-    exposeHeaders: ["grpc-status", "grpc-message", "grpc-status-details-bin"],
-    allowMethods: ["POST", "OPTIONS"],
-  }),
-);
+  app.use(
+    "/api/*",
+    cors({
+      origin: (origin, c) => {
+        try {
+          return getTrustedOrigins(c.env).includes(origin) ? origin : undefined;
+        } catch {
+          return undefined;
+        }
+      },
+      credentials: true,
+      allowHeaders: [
+        "content-type",
+        "authorization",
+        // Access remains an optional outer policy during migration. Keep its
+        // established service-token headers available to trusted CORS origins;
+        // they never replace the FlareMo session/PAT check below the edge.
+        "cf-access-client-id",
+        "cf-access-client-secret",
+        "x-flaremo-bootstrap-secret",
+      ],
+      allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    }),
+  );
 
-// Better Auth's own handler also mutates the browser session. Keep its
-// endpoints under the same exact-origin contract as the application routes;
-// the handler's trustedOrigins setting is not a substitute for requiring an
-// Origin header on unsafe cookie requests.
-app.use("/api/auth/*", async (c, next) => {
-  try {
-    assertTrustedCookieMutation(c);
-    return await next();
-  } catch (error) {
-    return jsonError(c, error);
-  }
-});
+  app.use(
+    "/mcp",
+    cors({
+      origin: (origin, c) => {
+        try {
+          return getTrustedOrigins(c.env).includes(origin) ? origin : undefined;
+        } catch {
+          return undefined;
+        }
+      },
+      credentials: false,
+      allowHeaders: [
+        "content-type",
+        "authorization",
+        "accept",
+        "mcp-session-id",
+      ],
+      allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    }),
+  );
 
-app.route("/api/auth/flaremo", authApi);
-app.all("/api/auth/*", (c) => createFlareMoAuth(c.env).handler(c.req.raw));
-app.route("/api/app/account", accountApi);
-app.route("/api/app/admin", adminApi);
-app.route("/api/app/memory", memoryApi);
-app.route("/api/app/projects", projectsApi);
-app.route("/api/app/tasks", tasksApi);
-app.route("/api/app", appApi);
-app.route("/api/public", publicApi);
-app.route("/file", memosFileApi);
-app.route("/mcp", mcpStreamableApi);
-app.route("/memory/mcp", memoryMcpApi);
-app.route("/", memosConnectApi);
-app.route("/", memosSseApi);
-app.route("/api/v1", memosSocialApi);
-app.route("/api/v1", memosCurrentApi);
-app.route("/api/v1", memosApi);
-app.route("/api/v1", mcpApi);
+  app.use(
+    "/memos.api.v1.*",
+    cors({
+      origin: (origin, c) => {
+        try {
+          return getTrustedOrigins(c.env).includes(origin) ? origin : undefined;
+        } catch {
+          return undefined;
+        }
+      },
+      credentials: true,
+      allowHeaders: [
+        "content-type",
+        "authorization",
+        "accept",
+        "connect-protocol-version",
+        "grpc-accept-encoding",
+        "grpc-encoding",
+        "grpc-timeout",
+        "x-grpc-web",
+        "x-user-agent",
+      ],
+      exposeHeaders: ["grpc-status", "grpc-message", "grpc-status-details-bin"],
+      allowMethods: ["POST", "OPTIONS"],
+    }),
+  );
 
-app.get("/openapi.json", (c) =>
-  c.json(
-    isLegacyWireRequest(c)
-      ? createOpenApiDocument()
-      : createCurrentOpenApiDocument(),
-  ),
-);
-app.get("/api/v1/openapi.json", async (c) => {
-  try {
-    await getRequestContext(c);
-    return c.json(
+  // Better Auth's own handler also mutates the browser session. Keep its
+  // endpoints under the same exact-origin contract as the application routes;
+  // the handler's trustedOrigins setting is not a substitute for requiring an
+  // Origin header on unsafe cookie requests.
+  app.use("/api/auth/*", async (c, next) => {
+    try {
+      assertTrustedCookieMutation(c);
+      return await next();
+    } catch (error) {
+      return jsonError(c, error);
+    }
+  });
+
+  app.route("/api/auth/flaremo", authApi);
+  app.all("/api/auth/*", (c) => createFlareMoAuth(c.env).handler(c.req.raw));
+  app.route("/api/app/account", accountApi);
+  app.route("/api/app/admin", adminApi);
+  app.route("/api/app/memory", memoryApi);
+  app.route("/api/app/projects", projectsApi);
+  app.route("/api/app/tasks", tasksApi);
+  app.route("/api/app", appApi);
+  app.route("/api/public", publicApi);
+  app.route("/file", memosFileApi);
+  app.route("/mcp", mcpStreamableApi);
+  app.route("/memory/mcp", memoryMcpApi);
+  app.route("/", memosConnectApi);
+  app.route("/", memosSseApi);
+  app.route("/api/v1", memosSocialApi);
+  app.route("/api/v1", memosCurrentApi);
+  app.route("/api/v1", memosApi);
+  app.route("/api/v1", mcpApi);
+
+  app.get("/openapi.json", (c) =>
+    c.json(
       isLegacyWireRequest(c)
         ? createOpenApiDocument()
         : createCurrentOpenApiDocument(),
-    );
-  } catch (error) {
-    return jsonError(c, error);
-  }
-});
+    ),
+  );
+  app.get("/api/v1/openapi.json", async (c) => {
+    try {
+      await getRequestContext(c);
+      return c.json(
+        isLegacyWireRequest(c)
+          ? createOpenApiDocument()
+          : createCurrentOpenApiDocument(),
+      );
+    } catch (error) {
+      return jsonError(c, error);
+    }
+  });
 
-app.notFound((c) => {
-  if (c.req.path.startsWith("/api/")) {
-    return c.json({ error: { message: "Not found" } }, 404);
-  }
-  return c.env.ASSETS.fetch(c.req.raw);
-});
+  app.notFound((c) => {
+    if (c.req.path.startsWith("/api/")) {
+      return c.json({ error: { message: "Not found" } }, 404);
+    }
+    return c.env.ASSETS.fetch(c.req.raw);
+  });
+
+  return app;
+}
 
 const handler = {
   async fetch(request: Request, env: FlareMoEnv, ctx?: ExecutionContext) {
-    const response = await app.fetch(request, env, ctx);
+    const response = await createFlareMoApp().fetch(request, env, ctx);
     ctx?.waitUntil(
       dispatchMemosWebhookOutbox(createDb(env.DB)).catch(() => undefined),
     );

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -53,6 +53,7 @@ import {
   replaceMemoRelations,
   revokeAuthSessionByToken,
   revokeMemoShare,
+  SELF_HOST_UNLIMITED,
   type UserNotificationDto,
   updateAttachmentMemo,
   updateFlaremoUserProfile,
@@ -2062,6 +2063,7 @@ async function getPublicInstanceContext(
     bearerSession: false,
     nativeAccessToken: false,
     session: null,
+    limits: SELF_HOST_UNLIMITED,
   };
 }
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -420,6 +420,17 @@ AI 工作流围绕个人知识库展开：
 9. 基于 OpenAPI 增加 MCP。
 10. 接入 Vectorize 和 AI 能力。
 
+## 组装入口与计划限额
+
+worker 的路由表不再挂在模块级常量上，而是由 `createFlareMoApp(options)` 工厂构建：每次调用返回全新 Hono 实例，default 导出的 `ExportedHandler` 只是该工厂的默认消费者。外部组合壳（未来 FlareMo 托管形态的私有入口）可以 import 同一工厂，追加自己的中间件与路由，不必复制或 patch 内核。
+
+计划限额以注入数据的形式进入请求上下文，而不是散落的条件分支：
+
+- domain 层的 `PlanLimits` 只包含「数字或 null」的字段；`SELF_HOST_UNLIMITED` 是自部署恒定值。domain 不知道订阅概念的存在。
+- `createFlareMoApp` 接受可选的 `resolvePlanLimits(env)`；默认实现恒返回 `SELF_HOST_UNLIMITED`，解析结果经每个请求首个中间件写入 Hono Variables（`planLimits`），`getRequestContext` 系列将其放入返回值的 `limits` 字段。
+- 超限场景使用 `QuotaExceededError`（HTTP 429），走既有 `DomainError` 映射。
+- 本仓库不实现任何订阅解析器；云端 resolver 属于私有控制面的注入物。
+
 ## 结论
 
 FlareMo 的架构核心是：

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -42,3 +42,10 @@ export class ForbiddenError extends DomainError {
     this.name = "ForbiddenError";
   }
 }
+
+export class QuotaExceededError extends DomainError {
+  constructor(message = "Plan quota exceeded") {
+    super(message, 429);
+    this.name = "QuotaExceededError";
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -6,6 +6,7 @@ export * from "./embedding-outbox";
 export * from "./errors";
 export * from "./ids";
 export * from "./import-export";
+export * from "./limits";
 export * from "./memo-context";
 export * from "./memo-filter";
 export * from "./memory";

--- a/packages/domain/src/limits.test.ts
+++ b/packages/domain/src/limits.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { SELF_HOST_UNLIMITED } from "./limits";
+
+describe("SELF_HOST_UNLIMITED", () => {
+  it("carries no limit on any dimension", () => {
+    for (const value of Object.values(SELF_HOST_UNLIMITED)) {
+      expect(value).toBeNull();
+    }
+  });
+
+  it("exposes exactly the documented plan-limit dimensions", () => {
+    expect(Object.keys(SELF_HOST_UNLIMITED).sort()).toEqual([
+      "aiEmbeddingTokensPerMonth",
+      "attachmentStorageBytes",
+      "maxMembersPerDeployment",
+      "semanticSearchQueriesPerMonth",
+    ]);
+  });
+});

--- a/packages/domain/src/limits.ts
+++ b/packages/domain/src/limits.ts
@@ -1,0 +1,25 @@
+/**
+ * Injectable plan limits. The domain layer only ever sees numbers-or-null:
+ * self-hosted deployments always run SELF_HOST_UNLIMITED, while a hosted
+ * shell supplies its own resolver, so subscription concepts never enter
+ * this package.
+ */
+export type PlanLimitValue = number | null;
+
+export type PlanLimits = {
+  /** Total attachment object storage across all users, in bytes. */
+  attachmentStorageBytes: PlanLimitValue;
+  /** Monthly embedding-token budget shared by semantic search and AI flows. */
+  aiEmbeddingTokensPerMonth: PlanLimitValue;
+  /** Monthly semantic-search query count. */
+  semanticSearchQueriesPerMonth: PlanLimitValue;
+  /** Maximum member accounts per deployment, owner included. */
+  maxMembersPerDeployment: PlanLimitValue;
+};
+
+export const SELF_HOST_UNLIMITED: PlanLimits = Object.freeze({
+  attachmentStorageBytes: null,
+  aiEmbeddingTokensPerMonth: null,
+  semanticSearchQueriesPerMonth: null,
+  maxMembersPerDeployment: null,
+});


### PR DESCRIPTION
## 背景

双仓架构（公开内核 + 私有控制面 flaremo-cloud）的第一个实体落地：给 hosted 薄壳提供可组合的接缝。全部改动落在公开内核，本仓库不出现任何订阅/计费概念。

Closes #104

## 变更

### 1. worker 组装工厂
- `apps/worker/src/index.ts`：模块级路由表收进 `createFlareMoApp(options)`，每次调用返回全新 Hono 实例；default 导出的 `ExportedHandler` 改为工厂的默认消费者，路由注册顺序与行为完全不变（全部既有测试直接消费 default 导出、零修改通过）。
- 可选 `resolvePlanLimits(env)` 选项：默认恒返回 `SELF_HOST_UNLIMITED`；私有壳未来注入订阅版 resolver 即可覆盖。

### 2. 计划限额注入缝
- `HonoBindings` 增加 `Variables.planLimits`；应用首个中间件每请求解析一次。
- `context.ts` 的三个 request-context 构造函数统一在返回值带 `limits` 字段（读 Variables、缺省兜底 `SELF_HOST_UNLIMITED`）。
- `memos-connect-api.ts` 内联的匿名公开上下文显式补 `SELF_HOST_UNLIMITED`。

### 3. domain 基础件
- 新增 `packages/domain/src/limits.ts`：`PlanLimits`（四维限额，值均为 `number | null`）与冻结的 `SELF_HOST_UNLIMITED`，含单测。
- 新增 `QuotaExceededError`（HTTP 429），复用现有 `jsonError` 的 `DomainError.status` 透传，无需改映射层。

### 4. 文档
- `docs/architecture-notes.md` 新增「组装入口与计划限额」章节。

## 明确不做

- 不实现任何订阅解析器或云端 resolver（私有仓的注入物）。
- 不加 env 开关、不加前端入口、不改既有 API 行为。
- `usage.ts` 既有的向量面板参数签名不动。

## 验证

```
pnpm format:check   # ✓ (via pnpm verify)
pnpm verify         # ✓ lint + typecheck + build + 190 unit tests + 24 e2e passed
```

不涉及 D1 migration、Memos 兼容 wire 变化、Cloudflare Access/D1/R2 配置。