### PR TITLE
feat(worker): enforce injectable PlanLimits across kernel execution points

### DIFF
--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -227,6 +227,11 @@ const messages = {
     "usage.vectors": "向量数",
     "usage.stored": "存储维度",
     "usage.queried": "本月查询维度",
+    "usage.planTitle": "计划限额",
+    "usage.planStorage": "附件存储",
+    "usage.planEmbeddingTokens": "本月 Embedding Tokens",
+    "usage.planSearchQueries": "本月语义搜索",
+    "usage.planMembers": "成员数",
     "usage.disclaimer":
       "以上为自测估算，非 Cloudflare 官方账单；最终计费以 Cloudflare Dashboard 为准。",
     "auth.unnamedToken": "未命名令牌",
@@ -682,6 +687,11 @@ const messages = {
     "usage.vectors": "Vectors",
     "usage.stored": "Stored dimensions",
     "usage.queried": "Queried dimensions this month",
+    "usage.planTitle": "Plan quota",
+    "usage.planStorage": "Attachment storage",
+    "usage.planEmbeddingTokens": "Embedding tokens this month",
+    "usage.planSearchQueries": "Semantic searches this month",
+    "usage.planMembers": "Members",
     "usage.disclaimer":
       "Self-measured estimate, not Cloudflare's official bill; final billing is per the Cloudflare Dashboard.",
     "auth.unnamedToken": "Unnamed token",

--- a/apps/web/src/pages/account-page.tsx
+++ b/apps/web/src/pages/account-page.tsx
@@ -670,27 +670,103 @@ function VectorUsagePanel({
         used={report.queried_dimensions_this_month}
         limit={report.queried_limit}
       />
+      {report.plan && <PlanQuotaBars plan={report.plan} t={t} />}
       <p className="text-xs text-muted-foreground">{t("usage.disclaimer")}</p>
     </div>
   );
+}
+
+// Used-vs-limit rows for the injectable plan quotas. Rows with a null limit
+// (self-hosted default) stay hidden so the panel stays noise-free; when every
+// limit is null there is nothing to render.
+function PlanQuotaBars({
+  plan,
+  t,
+}: {
+  plan: NonNullable<VectorUsageReport["plan"]>;
+  t: (key: TranslationKey) => string;
+}) {
+  const rows: Array<{
+    key: TranslationKey;
+    used: number;
+    limit: number | null;
+    format: (value: number) => string;
+  }> = [
+    {
+      key: "usage.planStorage",
+      used: plan.usage.attachmentStorageBytes,
+      limit: plan.limits.attachmentStorageBytes,
+      format: formatBytes,
+    },
+    {
+      key: "usage.planEmbeddingTokens",
+      used: plan.usage.aiEmbeddingTokensPerMonth,
+      limit: plan.limits.aiEmbeddingTokensPerMonth,
+      format: (value) => value.toLocaleString(),
+    },
+    {
+      key: "usage.planSearchQueries",
+      used: plan.usage.semanticSearchQueriesPerMonth,
+      limit: plan.limits.semanticSearchQueriesPerMonth,
+      format: (value) => value.toLocaleString(),
+    },
+    {
+      key: "usage.planMembers",
+      used: plan.usage.maxMembersPerDeployment,
+      limit: plan.limits.maxMembersPerDeployment,
+      format: (value) => value.toLocaleString(),
+    },
+  ];
+  const limited = rows.filter((row) => row.limit !== null);
+  if (limited.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-3 border-t pt-4">
+      <p className="text-sm font-medium">{t("usage.planTitle")}</p>
+      {limited.map((row) => (
+        <UsageBar
+          key={row.key}
+          label={t(row.key)}
+          used={row.used}
+          limit={row.limit as number}
+          formatValue={row.format}
+        />
+      ))}
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) {
+    return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+  }
+  if (bytes >= 1024 ** 2) {
+    return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
 }
 
 function UsageBar({
   label,
   used,
   limit,
+  formatValue,
 }: {
   label: string;
   used: number;
   limit: number;
+  formatValue?: (value: number) => string;
 }) {
+  const format = formatValue ?? ((value: number) => value.toLocaleString());
   const percent = limit > 0 ? Math.min(100, (used / limit) * 100) : 0;
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-baseline justify-between text-sm">
         <span>{label}</span>
         <span className="text-muted-foreground tabular-nums">
-          {used.toLocaleString()} / {limit.toLocaleString()}
+          {format(used)} / {format(limit)}
         </span>
       </div>
       <div className="h-2 w-full overflow-hidden rounded-full bg-muted">

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -11,10 +11,11 @@ import type {
 } from "@flaremo/contracts";
 import { FLAREMO_API_VERSION } from "@flaremo/contracts";
 import { createDb, memos } from "@flaremo/db";
+import { SELF_HOST_UNLIMITED } from "@flaremo/domain";
 import { eq } from "drizzle-orm";
 import { Miniflare } from "miniflare";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import app from "./index";
+import app, { createFlareMoApp } from "./index";
 
 let mf: Miniflare;
 let env: Env;
@@ -1497,6 +1498,96 @@ describe("FlareMo Worker API", () => {
     }>(await fetchApp("http://flaremo.test/api/v1/memos?q=imported+via+task"));
     expect(listed.memos).toHaveLength(1);
     expect(listed.memos[0].name).toBe("memos/import-task-memo");
+  });
+
+  it("reports the plan usage section on the vector usage endpoint", async () => {
+    const report = await json<{
+      plan?: {
+        limits: Record<string, number | null>;
+        usage: Record<string, number>;
+      };
+    }>(await fetchApp("http://flaremo.test/api/app/usage/vector"));
+    // The kernel default is SELF_HOST_UNLIMITED: all limits null, counters at 0.
+    expect(report.plan).toBeDefined();
+    expect(report.plan?.limits).toEqual({
+      attachmentStorageBytes: null,
+      aiEmbeddingTokensPerMonth: null,
+      semanticSearchQueriesPerMonth: null,
+      maxMembersPerDeployment: null,
+    });
+    expect(report.plan?.usage.maxMembersPerDeployment).toBe(1);
+  });
+
+  it("rejects an attachment upload over the storage quota with 429", async () => {
+    const quotaApp = createFlareMoApp({
+      resolvePlanLimits: () => ({
+        ...SELF_HOST_UNLIMITED,
+        attachmentStorageBytes: 10,
+      }),
+    });
+
+    const formData = new FormData();
+    formData.set(
+      "file",
+      new File(["inline attachment"], "inline.txt", { type: "text/plain" }),
+    );
+    const response = await quotaApp.fetch(
+      new Request("http://flaremo.test/api/v1/attachments", {
+        method: "POST",
+        headers: {
+          cookie: sessionCookie,
+          "x-flaremo-wire": "legacy",
+          origin: "http://flaremo.test",
+        },
+        body: formData,
+      }),
+      env,
+    );
+    expect(response.status).toBe(429);
+    const body = await response.json<{ error: { message: string } }>();
+    expect(body.error.message).toContain("storage quota");
+  });
+
+  it("rejects a registration over the member cap with 429", async () => {
+    const quotaApp = createFlareMoApp({
+      resolvePlanLimits: () => ({
+        ...SELF_HOST_UNLIMITED,
+        maxMembersPerDeployment: 1,
+      }),
+    });
+
+    const open = await quotaApp.fetch(
+      new Request("http://flaremo.test/api/app/admin/settings", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          cookie: sessionCookie,
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ registration_open: true }),
+      }),
+      env,
+    );
+    expect(open.status).toBe(200);
+
+    const response = await quotaApp.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/register", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          name: "Member",
+          email: "member@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      env,
+    );
+    expect(response.status).toBe(429);
+    const body = await response.json<{ error: { message: string } }>();
+    expect(body.error.message).toContain("Member limit");
   });
 });
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -216,6 +216,7 @@ const handler = {
         provider: createEmbeddingProvider(env),
         memosIndex: createVectorIndex(env, "memo"),
         memoriesIndex: createVectorIndex(env, "memory"),
+        limits: SELF_HOST_UNLIMITED,
       }).catch(() => undefined),
     );
     return response;
@@ -226,6 +227,7 @@ const handler = {
       provider: createEmbeddingProvider(env),
       memosIndex: createVectorIndex(env, "memo"),
       memoriesIndex: createVectorIndex(env, "memory"),
+      limits: SELF_HOST_UNLIMITED,
     });
     const db = createDb(env.DB);
     const cutoff = new Date(

--- a/apps/worker/src/routes/admin-api.ts
+++ b/apps/worker/src/routes/admin-api.ts
@@ -1,4 +1,5 @@
 import {
+  assertMemberQuota,
   createFlaremoMemberWithLink,
   deleteFlaremoUser,
   deriveUniqueUsername,
@@ -97,6 +98,9 @@ adminApi.post("/users", zValidator("json", createUserSchema), async (c) => {
     const input = c.req.valid("json");
     const email = input.email;
     const username = await deriveUniqueUsername(context.db, email);
+    // Pre-check before the Better Auth identity exists so a spent member
+    // quota cannot orphan an auth user.
+    await assertMemberQuota(context.db, context.limits);
     const auth = createFlareMoAuth(c.env, context.db, {
       allowBootstrapSignUp: true,
     });
@@ -109,11 +113,15 @@ adminApi.post("/users", zValidator("json", createUserSchema), async (c) => {
         displayUsername: input.name,
       },
     });
-    const user = await createFlaremoMemberWithLink(context.db, {
-      authUserId: result.user.id,
-      email,
-      name: input.name,
-    });
+    const user = await createFlaremoMemberWithLink(
+      context.db,
+      {
+        authUserId: result.user.id,
+        email,
+        name: input.name,
+      },
+      context.limits,
+    );
     return c.json(
       {
         id: user.id,

--- a/apps/worker/src/routes/app-api.ts
+++ b/apps/worker/src/routes/app-api.ts
@@ -17,10 +17,12 @@ import {
 import type { FlareMoDb, MemoRow, UserRow } from "@flaremo/db";
 import { memos as memosTable } from "@flaremo/db";
 import {
+  assertMonthlyQuota,
   createMemo,
   createMemoryFromMemo,
   createMemoryFromMemoInputToWrite,
   deleteTag,
+  estimateTokenCount,
   getAuthUserById,
   getMemoById,
   getMemoStats,
@@ -38,7 +40,9 @@ import {
   moveMemoToTrash,
   NotFoundError,
   renameTag,
+  reportPlanUsage,
   reportVectorUsage,
+  SELF_HOST_UNLIMITED,
   semanticSearchMemos,
   type UserNotificationDto,
   updateMemo,
@@ -142,13 +146,19 @@ appApi.get(
   zValidator("query", semanticMemoSearchQuerySchema),
   async (c) => {
     try {
-      const { db, user } = await getRequestContext(c);
+      const { db, user, limits } = await getRequestContext(c);
       const provider = createEmbeddingProvider(c.env);
       const index = createVectorIndex(c.env, "memo");
       if (!provider || !index) {
         return c.json({ memos: [], degraded: true });
       }
       const query = c.req.valid("query");
+      await assertMonthlyQuota(
+        db,
+        limits.semanticSearchQueriesPerMonth,
+        "search_queries",
+        "Monthly semantic search quota exceeded",
+      );
       const hits = await semanticSearchMemos(
         db,
         user,
@@ -157,12 +167,23 @@ appApi.get(
         query.limit,
       );
       c.executionCtx.waitUntil(
-        incrementUsageCounter(
-          db,
-          user,
-          "queried_dims",
-          provider.dimensions,
-        ).catch(() => undefined),
+        Promise.all([
+          incrementUsageCounter(
+            db,
+            user,
+            "queried_dims",
+            provider.dimensions,
+          ).catch(() => undefined),
+          incrementUsageCounter(db, user, "search_queries", 1).catch(
+            () => undefined,
+          ),
+          incrementUsageCounter(
+            db,
+            user,
+            "embedding_tokens",
+            estimateTokenCount([query.q]),
+          ).catch(() => undefined),
+        ]),
       );
       const rows = await db
         .select()
@@ -189,7 +210,7 @@ appApi.get(
 
 appApi.get("/usage/vector", async (c) => {
   try {
-    const { db, user } = await getRequestContext(c);
+    const { db, user, limits } = await getRequestContext(c);
     const config = resolveEmbeddingConfig(c.env);
     const storedLimit = Number.parseInt(
       c.env.FLAREMO_VECTORIZE_STORED_LIMIT?.trim() || "5000000",
@@ -214,7 +235,8 @@ appApi.get("/usage/vector", async (c) => {
         memoriesIndex: createVectorIndex(c.env, "memory"),
       },
     );
-    return c.json(report);
+    const plan = await reportPlanUsage(db, limits);
+    return c.json({ ...report, plan });
   } catch (error) {
     return jsonError(c, error);
   }

--- a/apps/worker/src/routes/auth-api.ts
+++ b/apps/worker/src/routes/auth-api.ts
@@ -1,5 +1,6 @@
 import { createDb } from "@flaremo/db";
 import {
+  assertMemberQuota,
   claimOwnerBootstrap,
   completeOwnerBootstrap,
   createFlaremoMemberWithLink,
@@ -9,7 +10,9 @@ import {
   getUserRegistrationAllowed,
   listMemosPersonalAccessTokens,
   markOwnerBootstrapRecoveryRequired,
+  QuotaExceededError,
   reconcileOwnerBootstrap,
+  SELF_HOST_UNLIMITED,
 } from "@flaremo/domain";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -89,6 +92,16 @@ authApi.post("/register", zValidator("json", registerSchema), async (c) => {
   const input = c.req.valid("json");
   const email = input.email.trim();
   const username = await deriveUniqueUsername(db, email);
+  // Pre-check before the Better Auth identity exists: failing only at link
+  // time would orphan an auth user on a spent member quota.
+  try {
+    await assertMemberQuota(db, c.get("planLimits") ?? SELF_HOST_UNLIMITED);
+  } catch (error) {
+    if (error instanceof QuotaExceededError) {
+      return c.json({ error: { message: error.message } }, 429);
+    }
+    throw error;
+  }
   let auth: ReturnType<typeof createFlareMoAuth>;
   try {
     auth = createFlareMoAuth(c.env, db, { allowBootstrapSignUp: true });
@@ -109,13 +122,22 @@ authApi.post("/register", zValidator("json", registerSchema), async (c) => {
         displayUsername: input.name,
       },
     });
-    await createFlaremoMemberWithLink(db, {
-      authUserId: result.user.id,
-      email,
-      name: input.name,
-    });
+    await createFlaremoMemberWithLink(
+      db,
+      {
+        authUserId: result.user.id,
+        email,
+        name: input.name,
+      },
+      c.get("planLimits") ?? SELF_HOST_UNLIMITED,
+    );
     return c.json({ ok: true }, 201);
-  } catch {
+  } catch (error) {
+    // A spent member quota must surface as its own status, not drown in the
+    // generic "registration failed" path that hides Better Auth internals.
+    if (error instanceof QuotaExceededError) {
+      return c.json({ error: { message: error.message } }, 429);
+    }
     return c.json(
       { error: { message: "Registration could not be completed." } },
       400,

--- a/apps/worker/src/routes/memory-mcp.ts
+++ b/apps/worker/src/routes/memory-mcp.ts
@@ -8,9 +8,11 @@ import {
   rememberInputSchema,
 } from "@flaremo/contracts";
 import {
+  assertMonthlyQuota,
   bootstrapMemory,
   checkpointMemory,
   createMemory,
+  estimateTokenCount,
   forgetMemory,
   incrementUsageCounter,
   linkMemory,
@@ -420,13 +422,33 @@ async function callMemoryTool(
       const provider = createEmbeddingProvider(c.env);
       const index = createVectorIndex(c.env, "memory");
       if (provider && index) {
+        await assertMonthlyQuota(
+          context.db,
+          context.limits.semanticSearchQueriesPerMonth,
+          "search_queries",
+          "Monthly semantic search quota exceeded",
+        );
         c.executionCtx.waitUntil(
-          incrementUsageCounter(
-            db,
-            user,
-            "queried_dims",
-            provider.dimensions,
-          ).catch(() => undefined),
+          Promise.all([
+            incrementUsageCounter(
+              context.db,
+              context.user,
+              "queried_dims",
+              provider.dimensions,
+            ).catch(() => undefined),
+            incrementUsageCounter(
+              context.db,
+              context.user,
+              "search_queries",
+              1,
+            ).catch(() => undefined),
+            incrementUsageCounter(
+              context.db,
+              context.user,
+              "embedding_tokens",
+              estimateTokenCount([input.query]),
+            ).catch(() => undefined),
+          ]),
         );
       }
       return recallMemories(

--- a/apps/worker/src/routes/memos-api.ts
+++ b/apps/worker/src/routes/memos-api.ts
@@ -12,6 +12,7 @@ import {
   updateMemoSchema,
 } from "@flaremo/contracts";
 import {
+  assertAttachmentStorageQuota,
   bindMemoAttachments,
   createAttachmentMetadata,
   createDataTask,
@@ -346,7 +347,7 @@ memosApi.get(
 
 memosApi.post("/attachments", async (c) => {
   try {
-    const { db, user } = await getRequestContext(c);
+    const { db, user, limits } = await getRequestContext(c);
     const formData = await c.req.formData();
     const file = formData.get("file");
     const memo = formData.get("memo");
@@ -365,6 +366,8 @@ memosApi.post("/attachments", async (c) => {
       const existing = await getAttachmentByClientId(db, user, clientId);
       if (existing) return c.json(attachmentToDto(existing));
     }
+
+    await assertAttachmentStorageQuota(db, limits, file.size);
 
     const objectKey = createAttachmentObjectKey(user.id, file.name);
     const object = await c.env.ATTACHMENTS.put(objectKey, file, {
@@ -525,8 +528,13 @@ memosApi.post(
   async (c) => {
     const writtenKeys: string[] = [];
     try {
-      const { db, user } = await getRequestContext(c);
+      const { db, user, limits } = await getRequestContext(c);
       const bundle = c.req.valid("json");
+      await assertAttachmentStorageQuota(
+        db,
+        limits,
+        bundleAttachmentBytes(bundle.attachments),
+      );
       const r2Keys = new Map<string, string>();
       const r2Etags = new Map<string, string | null>();
       for (const attachment of bundle.attachments) {
@@ -829,11 +837,16 @@ memosApi.post(
     let taskId: string | undefined;
     const writtenKeys: string[] = [];
     try {
-      const { db, user } = await getRequestContext(c);
+      const { db, user, limits } = await getRequestContext(c);
       const body = c.req.valid("json");
       const task = await createDataTask(db, user, { kind: "import" });
       taskId = task.id;
 
+      await assertAttachmentStorageQuota(
+        db,
+        limits,
+        bundleAttachmentBytes(body.bundle.attachments),
+      );
       const r2Keys = new Map<string, string>();
       const r2Etags = new Map<string, string | null>();
       for (const attachment of body.bundle.attachments) {
@@ -911,6 +924,18 @@ function sanitizeFilename(filename: string) {
 
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+// Decoded-size estimate for a base64 attachment list; used to pre-check the
+// storage quota before any object of the bundle is written to R2.
+function bundleAttachmentBytes(attachments: { data_base64?: string }[]) {
+  return attachments.reduce(
+    (sum, attachment) =>
+      attachment.data_base64
+        ? sum + Math.ceil((attachment.data_base64.length * 3) / 4)
+        : sum,
+    0,
+  );
 }
 
 function estimateBundleJsonBytes(bundle: {

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -2,6 +2,7 @@ import { FLAREMO_API_VERSION } from "@flaremo/contracts";
 import type { UserRow } from "@flaremo/db";
 import { createDb } from "@flaremo/db";
 import {
+  assertAttachmentStorageQuota,
   bindMemoAttachments,
   compileAttachmentFilter,
   createAttachmentMetadata,
@@ -50,6 +51,7 @@ import {
   listUserWebhooks,
   markAttachmentDeleting,
   markMemoAttachmentsDeleting,
+  type PlanLimits,
   replaceMemoRelations,
   revokeAuthSessionByToken,
   revokeMemoShare,
@@ -579,6 +581,11 @@ async function createConnectAttachment(
   if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
     throw new ConnectInputError("Attachment exceeds the 25 MiB limit");
   }
+  await assertAttachmentStorageQuota(
+    context.db,
+    context.limits,
+    bytes.byteLength,
+  );
   const objectKey = createAttachmentObjectKey(
     context.user.id,
     filename,
@@ -698,12 +705,17 @@ async function connectUserMethod(
         optionalString(user.nickname) ??
         username;
       const email = `${username}@flaremo.local`;
-      const created = await createConnectUser(c, context.db, {
-        username,
-        password,
-        displayName,
-        email,
-      });
+      const created = await createConnectUser(
+        c,
+        context.db,
+        {
+          username,
+          password,
+          displayName,
+          email,
+        },
+        context.limits,
+      );
       return connectValue(c, created.dto, transport);
     }
     case "DeleteUser": {
@@ -2681,7 +2693,7 @@ function connectError(
   c: ConnectContext,
   code: string,
   message: string,
-  status: 400 | 401 | 403 | 404 | 409 | 415 | 500 | 501,
+  status: 400 | 401 | 403 | 404 | 409 | 415 | 429 | 500 | 501,
 ) {
   return c.json({ code, message }, status, {
     "content-type": "application/json",
@@ -2819,6 +2831,7 @@ async function createConnectUser(
     displayName: string;
     email: string;
   },
+  limits: PlanLimits,
 ) {
   const auth = createFlareMoAuth(c.env, db, {
     allowBootstrapSignUp: true,
@@ -2832,11 +2845,15 @@ async function createConnectUser(
       displayUsername: input.username,
     },
   });
-  const user = await createFlaremoMemberWithLink(db, {
-    authUserId: result.user.id,
-    email: input.email,
-    name: input.displayName,
-  });
+  const user = await createFlaremoMemberWithLink(
+    db,
+    {
+      authUserId: result.user.id,
+      email: input.email,
+      name: input.displayName,
+    },
+    limits,
+  );
   return {
     authUserId: result.user.id,
     user,
@@ -2884,12 +2901,17 @@ async function connectAuthSignUp(
     }
 
     const email = optionalString(body.email) ?? `${username}@flaremo.local`;
-    const { authUserId, user, dto } = await createConnectUser(c, db, {
-      username,
-      password,
-      displayName,
-      email,
-    });
+    const { authUserId, user, dto } = await createConnectUser(
+      c,
+      db,
+      {
+        username,
+        password,
+        displayName,
+        email,
+      },
+      c.get("planLimits") ?? SELF_HOST_UNLIMITED,
+    );
     const nativeTokens = await issueMemosNativeTokens({
       db,
       env: c.env,
@@ -2926,7 +2948,11 @@ function connectDomainError(c: ConnectContext, error: unknown) {
       c,
       domainCode(status),
       error.message,
-      status === 401 || status === 403 || status === 404 || status === 409
+      status === 401 ||
+        status === 403 ||
+        status === 404 ||
+        status === 409 ||
+        status === 429
         ? status
         : status >= 500
           ? 500
@@ -2951,6 +2977,7 @@ function domainCode(status: number) {
   if (status === 403) return "permission_denied";
   if (status === 404) return "not_found";
   if (status === 409) return "already_exists";
+  if (status === 429) return "resource_exhausted";
   return "invalid_argument";
 }
 

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -1,5 +1,7 @@
 import { createDb, type UserRow } from "@flaremo/db";
 import {
+  assertAttachmentStorageQuota,
+  assertMemberQuota,
   bindMemoAttachments,
   createAttachmentMetadata,
   createFlaremoMemberWithLink,
@@ -33,6 +35,7 @@ import {
   replaceMemoRelations,
   revokeAuthSessionByToken,
   revokeMemoShare,
+  SELF_HOST_UNLIMITED,
   updateMemo,
 } from "@flaremo/domain";
 import {
@@ -249,6 +252,12 @@ memosCurrentApi.post("/auth/signup", async (c, next) => {
     const username = input.username.trim();
     const email = input.email?.trim() || `${username}@flaremo.local`;
     const dbContext = await createAuthContext(c);
+    // Pre-check before the Better Auth identity exists so a spent member
+    // quota cannot orphan an auth user.
+    await assertMemberQuota(
+      dbContext.db,
+      c.get("planLimits") ?? SELF_HOST_UNLIMITED,
+    );
     const auth = createFlareMoAuth(c.env, dbContext.db, {
       allowBootstrapSignUp: true,
     });
@@ -261,11 +270,15 @@ memosCurrentApi.post("/auth/signup", async (c, next) => {
         displayUsername: username,
       },
     });
-    const user = await createFlaremoMemberWithLink(dbContext.db, {
-      authUserId: result.user.id,
-      email,
-      name: input.displayName?.trim() || username,
-    });
+    const user = await createFlaremoMemberWithLink(
+      dbContext.db,
+      {
+        authUserId: result.user.id,
+        email,
+        name: input.displayName?.trim() || username,
+      },
+      c.get("planLimits") ?? SELF_HOST_UNLIMITED,
+    );
     const nativeTokens = await issueMemosNativeTokens({
       db: dbContext.db,
       env: c.env,
@@ -749,6 +762,11 @@ memosCurrentApi.post("/attachments", async (c, next) => {
       );
     }
     const context = await getRequestContext(c);
+    await assertAttachmentStorageQuota(
+      context.db,
+      context.limits,
+      bytes.byteLength,
+    );
     const objectKey = createAttachmentObjectKey(
       context.user.id,
       filename,
@@ -876,6 +894,7 @@ memosCurrentApi.post("/users", async (c, next) => {
     const body = currentSignupSchema.parse(await c.req.json());
     const username = body.username.trim();
     const email = `${username}@flaremo.local`;
+    await assertMemberQuota(context.db, context.limits);
     const auth = createFlareMoAuth(c.env, context.db, {
       allowBootstrapSignUp: true,
     });
@@ -888,11 +907,15 @@ memosCurrentApi.post("/users", async (c, next) => {
         displayUsername: username,
       },
     });
-    const user = await createFlaremoMemberWithLink(context.db, {
-      authUserId: result.user.id,
-      email,
-      name: body.displayName?.trim() || username,
-    });
+    const user = await createFlaremoMemberWithLink(
+      context.db,
+      {
+        authUserId: result.user.id,
+        email,
+        name: body.displayName?.trim() || username,
+      },
+      context.limits,
+    );
     return c.json(
       await currentUserForContext({
         db: context.db,
@@ -1511,6 +1534,7 @@ function currentErrorCode(status: number) {
   if (status === 404) return 5;
   if (status === 409) return 6;
   if (status === 413) return 8;
+  if (status === 429) return 8;
   return 13;
 }
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -431,6 +431,15 @@ worker 的路由表不再挂在模块级常量上，而是由 `createFlareMoApp(
 - 超限场景使用 `QuotaExceededError`（HTTP 429），走既有 `DomainError` 映射。
 - 本仓库不实现任何订阅解析器；云端 resolver 属于私有控制面的注入物。
 
+限额不只是被注入，还在内核的四个执行点被真正执行（`packages/domain/src/quotas.ts`）：
+
+1. **附件存储总量**：三条上传路径与两条导入路径在写入 R2 前调用 `assertAttachmentStorageQuota`（对 `attachments` 表 `state='ready'` 求和，部署级）。
+2. **月度 embedding tokens**：outbox 每次 embed 成功后按 `estimateTokenCount`（`ceil(chars/4)` 估算）写入 `usage_counters`；预算耗尽时 sweep 暂停认领（任务保持 pending、不消耗重试次数，次月自动恢复）。全量重建只计量不阻断（恢复路径）。`dispatchEmbeddingOutbox` 的 `limits` 来自调用方——default handler 传 `SELF_HOST_UNLIMITED`，托管壳可在自己的 scheduled 入口注入真实限额。
+3. **月度语义搜索次数**：`/api/app/search/semantic` 与 `memory_recall` 语义路径在 embed 前检查 `search_queries` 月度计数（部署级求和），超限抛 429；成功后计入 `search_queries` 与查询 token 估算。
+4. **成员数上限**：`createFlaremoMemberWithLink` 接受可选 `limits`，Web 注册 / 管理员建号 / Memos 注册路径统一预检（注册路径在 Better Auth 身份创建**之前**预检，避免超限时产生孤儿身份）；`ensureSingleUser` bootstrap 永不受限。
+
+`/api/app/usage/vector` 响应附带 `plan`（`PlanUsageReport`：四维度的 used/limit），前端用量面板据此渲染限额进度条；limit 为 null（自托管）的行不渲染。限额为 null 时所有检查旁路，自托管行为零变化。
+
 ## 结论
 
 FlareMo 的架构核心是：

--- a/packages/contracts/src/embedding.ts
+++ b/packages/contracts/src/embedding.ts
@@ -48,6 +48,28 @@ export const semanticRecallQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).default(10),
 });
 
+// Plan limits mirror the kernel's PlanLimits shape (numbers-or-null; null =
+// unlimited). They ride along on the usage report so the panel can render
+// used-vs-limit without a second request.
+export const planLimitValueSchema = z.number().int().nullable();
+
+export const planUsageReportSchema = z.object({
+  limits: z.object({
+    attachmentStorageBytes: planLimitValueSchema,
+    aiEmbeddingTokensPerMonth: planLimitValueSchema,
+    semanticSearchQueriesPerMonth: planLimitValueSchema,
+    maxMembersPerDeployment: planLimitValueSchema,
+  }),
+  usage: z.object({
+    attachmentStorageBytes: z.number().int(),
+    aiEmbeddingTokensPerMonth: z.number().int(),
+    semanticSearchQueriesPerMonth: z.number().int(),
+    maxMembersPerDeployment: z.number().int(),
+  }),
+});
+
+export type PlanUsageReport = z.infer<typeof planUsageReportSchema>;
+
 // Vector usage panel DTO. Stored dimensions are read from the Vectorize index
 // `describe()`; queried dimensions and embedding counters come from the D1
 // `usage_counters` table. These are self-measured, not Cloudflare's bill.
@@ -68,6 +90,7 @@ export const vectorUsageReportSchema = z.object({
   embedding_tokens_this_month: z.number().int(),
   stored_limit: z.number().int(),
   queried_limit: z.number().int(),
+  plan: planUsageReportSchema.optional(),
 });
 
 export type EmbeddingProvider = z.infer<typeof embeddingProviderSchema>;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -931,7 +931,12 @@ export const usageCounters = sqliteTable(
       .references(() => users.id, { onDelete: "cascade" }),
     month: text("month").notNull(),
     metric: text("metric", {
-      enum: ["queried_dims", "embedding_tokens", "embedding_calls"],
+      enum: [
+        "queried_dims",
+        "embedding_tokens",
+        "embedding_calls",
+        "search_queries",
+      ],
     }).notNull(),
     count: integer("count").notNull().default(0),
     updatedAt: text("updated_at").notNull(),

--- a/packages/domain/src/embedding-outbox.test.ts
+++ b/packages/domain/src/embedding-outbox.test.ts
@@ -16,8 +16,11 @@ import {
   dispatchEmbeddingOutbox,
   rebuildEmbeddingIndexes,
 } from "./embedding-outbox";
+import { SELF_HOST_UNLIMITED } from "./limits";
 import { createMemory, type MemoryActor } from "./memory";
 import { createMemo, hardDeleteMemo } from "./memos";
+import { readMonthlyUsageTotal } from "./quotas";
+import { incrementUsageCounter } from "./usage";
 import { ensureSingleUser } from "./users";
 
 const USER_ACTOR: MemoryActor = { type: "user" };
@@ -230,5 +233,76 @@ describe("embedding outbox", () => {
     expect(result.memoriesIndexed).toBe(1);
     expect(memosIndex.store.size).toBe(1);
     expect(memoriesIndex.store.size).toBe(1);
+  });
+
+  it("meters tokens and calls after a successful embed", async () => {
+    await createMemo(db, user, {
+      content: "计量这条笔记的 embedding 用量",
+      visibility: "private",
+      source: "web",
+    });
+    await dispatchEmbeddingOutbox(db, {
+      provider: fakeProvider(),
+      memosIndex: new FakeVectorIndex(),
+      memoriesIndex: null,
+    });
+
+    expect(await readMonthlyUsageTotal(db, "embedding_tokens")).toBeGreaterThan(
+      0,
+    );
+    expect(await readMonthlyUsageTotal(db, "embedding_calls")).toBe(1);
+  });
+
+  it("pauses when the monthly budget is spent and resumes later", async () => {
+    const memo = await createMemo(db, user, {
+      content: "预算耗尽时这条不会被索引",
+      visibility: "private",
+      source: "web",
+    });
+    await incrementUsageCounter(db, user, "embedding_tokens", 100);
+    const limits = { ...SELF_HOST_UNLIMITED, aiEmbeddingTokensPerMonth: 100 };
+
+    let embedCalls = 0;
+    const provider: EmbeddingProvider = {
+      ...fakeProvider(),
+      async embed(texts) {
+        embedCalls += 1;
+        return fakeProvider().embed(texts);
+      },
+    };
+    await dispatchEmbeddingOutbox(db, {
+      provider,
+      memosIndex: new FakeVectorIndex(),
+      memoriesIndex: null,
+      limits,
+    });
+
+    // The budget is spent: nothing embeds, the task stays pending with its
+    // retry budget intact, and the memo is not marked as failed.
+    expect(embedCalls).toBe(0);
+    const pending = await db.select().from(embeddingTasks);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.status).toBe("pending");
+    expect(pending[0]?.attempts).toBe(0);
+    const untouched = await db
+      .select()
+      .from(memos)
+      .where(eq(memos.id, memo.id))
+      .get();
+    expect(untouched?.embeddingStatus).not.toBe("indexed");
+
+    // A later sweep with budget available picks the task back up.
+    await dispatchEmbeddingOutbox(db, {
+      provider,
+      memosIndex: new FakeVectorIndex(),
+      memoriesIndex: null,
+    });
+    expect(embedCalls).toBe(1);
+    const indexed = await db
+      .select()
+      .from(memos)
+      .where(eq(memos.id, memo.id))
+      .get();
+    expect(indexed?.embeddingStatus).toBe("indexed");
   });
 });

--- a/packages/domain/src/embedding-outbox.ts
+++ b/packages/domain/src/embedding-outbox.ts
@@ -13,6 +13,9 @@ import {
   embeddingVersion,
   type VectorIndex,
 } from "./embedding";
+import type { PlanLimits } from "./limits";
+import { estimateTokenCount, readMonthlyUsageTotal } from "./quotas";
+import { incrementUsageCounter } from "./usage";
 
 export type EmbeddingResourceType = "memo" | "memory";
 export type EmbeddingTaskOperation = "index" | "reindex" | "delete";
@@ -33,6 +36,12 @@ export type EmbeddingDispatchDeps = {
   provider: EmbeddingProvider | null;
   memosIndex: VectorIndex | null;
   memoriesIndex: VectorIndex | null;
+  /**
+   * Monthly embedding-token budget. When set and exhausted, the sweep pauses:
+   * claimed tasks are released back to pending and resume on a later sweep
+   * (next month, or after a plan raise) instead of failing into retries.
+   */
+  limits?: PlanLimits;
 };
 
 /**
@@ -81,6 +90,8 @@ export async function dispatchEmbeddingOutbox(
   const nowIso = now.toISOString();
   await recoverExpiredEmbeddingLeases(db, nowIso);
 
+  if (!(await embeddingBudgetAvailable(db, deps.limits))) return;
+
   const tasks = await listClaimableEmbeddingTasks(db, nowIso);
   const claimed: EmbeddingTaskRow[] = [];
   for (const task of tasks) {
@@ -89,6 +100,12 @@ export async function dispatchEmbeddingOutbox(
   }
 
   for (const task of claimed) {
+    // Re-check inside the batch: earlier embeds in this sweep may have spent
+    // the remaining budget, so release the rest rather than overshooting.
+    if (!(await embeddingBudgetAvailable(db, deps.limits))) {
+      await unclaimEmbeddingTask(db, task, nowIso);
+      continue;
+    }
     try {
       await processEmbeddingTask(db, deps, task, nowIso);
       await markEmbeddingTaskSucceeded(db, task.id, nowIso);
@@ -103,6 +120,51 @@ export async function dispatchEmbeddingOutbox(
   }
 
   await pruneEmbeddingOutbox(db, new Date(now.getTime() - RETENTION_MS));
+}
+
+async function embeddingBudgetAvailable(
+  db: FlareMoDb,
+  limits?: PlanLimits,
+): Promise<boolean> {
+  const limit = limits?.aiEmbeddingTokensPerMonth;
+  if (limit === null || limit === undefined) return true;
+  const used = await readMonthlyUsageTotal(db, "embedding_tokens");
+  return used < limit;
+}
+
+/** Release a claimed task without consuming a retry attempt. */
+async function unclaimEmbeddingTask(
+  db: FlareMoDb,
+  task: EmbeddingTaskRow,
+  nowIso: string,
+) {
+  await db
+    .update(embeddingTasks)
+    .set({
+      status: "pending",
+      attempts: task.attempts,
+      leaseUntil: null,
+      updatedAt: nowIso,
+    })
+    .where(eq(embeddingTasks.id, task.id));
+}
+
+/**
+ * Attribute a successful embed call to the deployment's monthly budget.
+ * Best-effort: metering failures must never fail the indexing task itself.
+ */
+function recordEmbeddingUsage(db: FlareMoDb, userId: string, texts: string[]) {
+  return Promise.all([
+    incrementUsageCounter(
+      db,
+      { id: userId },
+      "embedding_tokens",
+      estimateTokenCount(texts),
+    ).catch(() => undefined),
+    incrementUsageCounter(db, { id: userId }, "embedding_calls", 1).catch(
+      () => undefined,
+    ),
+  ]);
 }
 
 async function processEmbeddingTask(
@@ -174,6 +236,7 @@ async function processMemoEmbeddingTask(
   }
 
   const vectors = await provider.embed(chunks);
+  await recordEmbeddingUsage(db, task.userId, chunks);
   const ids = chunkVectorIds(memo.id, chunks.length);
   await index.upsert(
     ids.map((id, index_) => ({
@@ -225,6 +288,7 @@ async function processMemoryEmbeddingTask(
   }
 
   const vectors = await provider.embed([memory.content]);
+  await recordEmbeddingUsage(db, task.userId, [memory.content]);
   await index.upsert([
     {
       id: memoryIdVector(memory.id),
@@ -462,6 +526,9 @@ export async function rebuildEmbeddingIndexes(
       const chunks = chunkText(memo.content);
       if (chunks.length > 0) {
         const vectors = await deps.provider.embed(chunks);
+        // Rebuild is a recovery path and is metered but never blocked: a
+        // spent budget pauses background indexing, not index repair.
+        await recordEmbeddingUsage(db, memo.userId, chunks);
         const ids = chunkVectorIds(memo.id, chunks.length);
         await deps.memosIndex.upsert(
           ids.map((id, index_) => ({
@@ -492,6 +559,7 @@ export async function rebuildEmbeddingIndexes(
     .where(eq(memoryItems.status, "active"));
   for (const memory of activeMemories) {
     const vectors = await deps.provider.embed([memory.content]);
+    await recordEmbeddingUsage(db, memory.userId, [memory.content]);
     await deps.memoriesIndex.upsert([
       {
         id: memory.id,

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -16,6 +16,7 @@ export * from "./memos-sse";
 export * from "./memos-user";
 export * from "./memos-webhooks";
 export * from "./projects";
+export * from "./quotas";
 export * from "./registration";
 export * from "./relations";
 export * from "./review";

--- a/packages/domain/src/quotas.test.ts
+++ b/packages/domain/src/quotas.test.ts
@@ -1,0 +1,182 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { UserRow } from "@flaremo/db";
+import { attachments, createDb } from "@flaremo/db";
+import { Miniflare } from "miniflare";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { QuotaExceededError } from "./errors";
+import { SELF_HOST_UNLIMITED } from "./limits";
+import {
+  assertAttachmentStorageQuota,
+  assertMemberQuota,
+  assertMonthlyQuota,
+  countFlaremoUsers,
+  estimateTokenCount,
+  getAttachmentStorageBytes,
+  readMonthlyUsageTotal,
+  reportPlanUsage,
+} from "./quotas";
+import { incrementUsageCounter } from "./usage";
+import { createFlaremoMember, ensureSingleUser } from "./users";
+
+let mf: Miniflare;
+let db: ReturnType<typeof createDb>;
+let owner: UserRow;
+
+async function applyMigration(
+  database: Awaited<ReturnType<Miniflare["getD1Database"]>>,
+  sql: string,
+) {
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  for (const statement of statements) {
+    await database.prepare(statement).run();
+  }
+}
+
+async function insertAttachment(
+  userId: string,
+  size: number,
+  state: "ready" | "deleting" | "missing" = "ready",
+) {
+  const now = new Date().toISOString();
+  await db.insert(attachments).values({
+    id: `attachments/${crypto.randomUUID()}`,
+    userId,
+    r2Key: `r2/${crypto.randomUUID()}`,
+    filename: "file.bin",
+    size,
+    state,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+describe("plan quota checks", () => {
+  beforeEach(async () => {
+    mf = new Miniflare({
+      script: "export default { fetch() { return new Response('ok') } }",
+      modules: true,
+      compatibilityDate: "2026-07-10",
+      compatibilityFlags: ["nodejs_compat"],
+      d1Databases: { DB: "flaremo-quotas-test" },
+    });
+    const database = await mf.getD1Database("DB");
+    db = createDb(database);
+    const migrationNames = [
+      "0000_illegal_inhumans.sql",
+      "0001_familiar_morph.sql",
+      "0002_wooden_professor_monster.sql",
+      "0003_equal_maximus.sql",
+      "0004_complex_the_enforcers.sql",
+      "0005_confused_masque.sql",
+      "0007_flat_phil_sheldon.sql",
+      "0008_legal_scarecrow.sql",
+      "0009_neat_iron_fist.sql",
+      "0010_deep_gateway.sql",
+      "0011_daffy_ultron.sql",
+      "0012_slow_nick_fury.sql",
+    ];
+    for (const name of migrationNames) {
+      const sql = await readFile(
+        resolve(import.meta.dirname, `../../../migrations/${name}`),
+        "utf8",
+      );
+      await applyMigration(database, sql);
+    }
+    owner = await ensureSingleUser(db, {
+      email: "owner@example.com",
+      name: "Owner",
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+  });
+
+  it("estimates tokens from input characters", () => {
+    expect(estimateTokenCount([])).toBe(0);
+    expect(estimateTokenCount(["abcd"])).toBe(1);
+    expect(estimateTokenCount(["abcd", "ef"])).toBe(2);
+    expect(estimateTokenCount(["中文文本！"])).toBe(2);
+  });
+
+  it("sums monthly usage across users", async () => {
+    const member = await createFlaremoMember(db, {
+      email: "member@example.com",
+      name: "Member",
+    });
+    await incrementUsageCounter(db, owner, "search_queries", 3);
+    await incrementUsageCounter(db, member, "search_queries", 4);
+
+    expect(await readMonthlyUsageTotal(db, "search_queries")).toBe(7);
+  });
+
+  it("throws at the monthly limit and passes below it", async () => {
+    await incrementUsageCounter(db, owner, "search_queries", 10);
+    await expect(
+      assertMonthlyQuota(db, 10, "search_queries", "over"),
+    ).rejects.toThrow(QuotaExceededError);
+    await expect(
+      assertMonthlyQuota(db, 11, "search_queries", "over"),
+    ).resolves.toBeUndefined();
+    // null limit = unlimited, even far past any number.
+    await assertMonthlyQuota(db, null, "search_queries", "over");
+  });
+
+  it("counts only ready attachments when checking storage", async () => {
+    await insertAttachment(owner.id, 100);
+    await insertAttachment(owner.id, 200);
+    await insertAttachment(owner.id, 5_000, "deleting");
+    await insertAttachment(owner.id, 5_000, "missing");
+    expect(await getAttachmentStorageBytes(db)).toBe(300);
+
+    const limits = { ...SELF_HOST_UNLIMITED, attachmentStorageBytes: 400 };
+    await expect(
+      assertAttachmentStorageQuota(db, limits, 100),
+    ).resolves.toBeUndefined();
+    await expect(assertAttachmentStorageQuota(db, limits, 101)).rejects.toThrow(
+      QuotaExceededError,
+    );
+    await assertAttachmentStorageQuota(
+      db,
+      SELF_HOST_UNLIMITED,
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  it("enforces the member cap across the deployment", async () => {
+    await createFlaremoMember(db, {
+      email: "member@example.com",
+      name: "Member",
+    });
+    expect(await countFlaremoUsers(db)).toBe(2);
+
+    const limits = { ...SELF_HOST_UNLIMITED, maxMembersPerDeployment: 2 };
+    await expect(assertMemberQuota(db, limits)).rejects.toThrow(
+      QuotaExceededError,
+    );
+    const raised = { ...SELF_HOST_UNLIMITED, maxMembersPerDeployment: 3 };
+    await expect(assertMemberQuota(db, raised)).resolves.toBeUndefined();
+    await assertMemberQuota(db, SELF_HOST_UNLIMITED);
+  });
+
+  it("reports used values for every plan dimension", async () => {
+    const member = await createFlaremoMember(db, {
+      email: "member@example.com",
+      name: "Member",
+    });
+    await insertAttachment(owner.id, 512);
+    await incrementUsageCounter(db, member, "embedding_tokens", 20);
+    await incrementUsageCounter(db, owner, "search_queries", 2);
+
+    const report = await reportPlanUsage(db, SELF_HOST_UNLIMITED);
+    expect(report.limits).toEqual(SELF_HOST_UNLIMITED);
+    expect(report.usage.attachmentStorageBytes).toBe(512);
+    expect(report.usage.aiEmbeddingTokensPerMonth).toBe(20);
+    expect(report.usage.semanticSearchQueriesPerMonth).toBe(2);
+    expect(report.usage.maxMembersPerDeployment).toBe(2);
+  });
+});

--- a/packages/domain/src/quotas.ts
+++ b/packages/domain/src/quotas.ts
@@ -1,0 +1,154 @@
+import type { FlareMoDb } from "@flaremo/db";
+import { attachments, usageCounters, users } from "@flaremo/db";
+import { and, eq, sql } from "drizzle-orm";
+import { QuotaExceededError } from "./errors";
+import type { PlanLimits, PlanLimitValue } from "./limits";
+import type { UsageMetric } from "./usage";
+import { currentMonthKey } from "./usage";
+
+/**
+ * Quota enforcement primitives shared by the kernel's execution points. Every
+ * check treats a `null` limit as unlimited, so self-hosted deployments running
+ * SELF_HOST_UNLIMITED bypass the whole module. Plan budgets are deployment-wide
+ * (each FlareMo deployment owns its D1), while usage_counters rows are
+ * per-user — the reads below therefore sum across users.
+ */
+
+export function isWithinLimit(used: number, limit: PlanLimitValue): boolean {
+  return limit === null || used < limit;
+}
+
+/**
+ * Rough input-size estimate for providers that do not report token counts
+ * (Workers AI embeddings return vectors only). Four characters per token is
+ * the conventional heuristic for mixed-language text.
+ */
+export function estimateTokenCount(texts: string[]): number {
+  const chars = texts.reduce((sum, text) => sum + text.length, 0);
+  return Math.ceil(chars / 4);
+}
+
+/** Deployment-wide monthly usage for one counter metric, summed over users. */
+export async function readMonthlyUsageTotal(
+  db: FlareMoDb,
+  metric: UsageMetric,
+): Promise<number> {
+  const row = await db
+    .select({
+      total: sql<number>`coalesce(sum(${usageCounters.count}), 0)`,
+    })
+    .from(usageCounters)
+    .where(
+      and(
+        eq(usageCounters.month, currentMonthKey()),
+        eq(usageCounters.metric, metric),
+      ),
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/** Throws QuotaExceededError when the deployment's monthly budget is spent. */
+export async function assertMonthlyQuota(
+  db: FlareMoDb,
+  limit: PlanLimitValue,
+  metric: UsageMetric,
+  message: string,
+): Promise<void> {
+  if (limit === null) return;
+  const used = await readMonthlyUsageTotal(db, metric);
+  if (used >= limit) {
+    throw new QuotaExceededError(message);
+  }
+}
+
+/** Total bytes of live attachment objects recorded in D1, across all users. */
+export async function getAttachmentStorageBytes(
+  db: FlareMoDb,
+): Promise<number> {
+  const row = await db
+    .select({
+      total: sql<number>`coalesce(sum(${attachments.size}), 0)`,
+    })
+    .from(attachments)
+    .where(eq(attachments.state, "ready"))
+    .get();
+  return row?.total ?? 0;
+}
+
+export async function assertAttachmentStorageQuota(
+  db: FlareMoDb,
+  limits: PlanLimits,
+  incomingBytes: number,
+): Promise<void> {
+  const limit = limits.attachmentStorageBytes;
+  if (limit === null) return;
+  const stored = await getAttachmentStorageBytes(db);
+  if (stored + incomingBytes > limit) {
+    throw new QuotaExceededError(
+      `Attachment storage quota exceeded (${formatBytes(limit)} plan limit)`,
+    );
+  }
+}
+
+export async function countFlaremoUsers(db: FlareMoDb): Promise<number> {
+  const row = await db
+    .select({ total: sql<number>`count(*)` })
+    .from(users)
+    .get();
+  return row?.total ?? 0;
+}
+
+export async function assertMemberQuota(
+  db: FlareMoDb,
+  limits: PlanLimits,
+): Promise<void> {
+  const limit = limits.maxMembersPerDeployment;
+  if (limit === null) return;
+  const count = await countFlaremoUsers(db);
+  if (count >= limit) {
+    throw new QuotaExceededError(
+      `Member limit reached (${limit} per deployment)`,
+    );
+  }
+}
+
+export type PlanUsageReport = {
+  limits: PlanLimits;
+  usage: {
+    attachmentStorageBytes: number;
+    aiEmbeddingTokensPerMonth: number;
+    semanticSearchQueriesPerMonth: number;
+    maxMembersPerDeployment: number;
+  };
+};
+
+/** Used-vs-limit snapshot for the account usage panel. */
+export async function reportPlanUsage(
+  db: FlareMoDb,
+  limits: PlanLimits,
+): Promise<PlanUsageReport> {
+  return {
+    limits,
+    usage: {
+      attachmentStorageBytes: await getAttachmentStorageBytes(db),
+      aiEmbeddingTokensPerMonth: await readMonthlyUsageTotal(
+        db,
+        "embedding_tokens",
+      ),
+      semanticSearchQueriesPerMonth: await readMonthlyUsageTotal(
+        db,
+        "search_queries",
+      ),
+      maxMembersPerDeployment: await countFlaremoUsers(db),
+    },
+  };
+}
+
+function formatBytes(bytes: number): string {
+  const gb = bytes / 1024 ** 3;
+  if (gb >= 1) return `${Number.isInteger(gb) ? gb : gb.toFixed(1)} GB`;
+  const mb = bytes / 1024 ** 2;
+  if (mb >= 1) return `${Number.isInteger(mb) ? mb : mb.toFixed(1)} MB`;
+  return `${bytes} B`;
+}

--- a/packages/domain/src/usage.ts
+++ b/packages/domain/src/usage.ts
@@ -35,14 +35,15 @@ export type VectorUsageReportResult = {
   queried_limit: number;
 };
 
-function currentMonth(): string {
+export function currentMonthKey(): string {
   return new Date().toISOString().slice(0, 7);
 }
 
 export type UsageMetric =
   | "queried_dims"
   | "embedding_tokens"
-  | "embedding_calls";
+  | "embedding_calls"
+  | "search_queries";
 
 async function readCounter(
   db: FlareMoDb,
@@ -55,7 +56,7 @@ async function readCounter(
     .where(
       and(
         eq(usageCounters.userId, user.id),
-        eq(usageCounters.month, currentMonth()),
+        eq(usageCounters.month, currentMonthKey()),
         eq(usageCounters.metric, metric),
       ),
     )
@@ -122,15 +123,16 @@ export async function reportVectorUsage(
 /**
  * Bump a month-bucketed counter atomically (upsert by user/month/metric).
  * Called fire-and-forget from the semantic search paths so usage tracking
- * never blocks or fails a query.
+ * never blocks or fails a query. Accepts a bare `{ id }` so outbox workers
+ * can attribute usage from a stored user id without re-reading the row.
  */
 export async function incrementUsageCounter(
   db: FlareMoDb,
-  user: UserRow,
+  user: Pick<UserRow, "id">,
   metric: UsageMetric,
   amount: number,
 ) {
-  const month = currentMonth();
+  const month = currentMonthKey();
   const now = new Date().toISOString();
   const existing = await db
     .select({ id: usageCounters.id })

--- a/packages/domain/src/users.ts
+++ b/packages/domain/src/users.ts
@@ -7,6 +7,8 @@ import {
   NotFoundError,
   ValidationError,
 } from "./errors";
+import type { PlanLimits } from "./limits";
+import { assertMemberQuota } from "./quotas";
 
 export type SingleUserConfig = {
   email: string;
@@ -82,12 +84,18 @@ export async function createFlaremoMember(
 /**
  * Create a member and bind it to an existing Better Auth identity in one
  * ownership boundary. Registration and admin creation both reach this path so
- * the auth-to-domain link is never written from an HTTP adapter.
+ * the auth-to-domain link is never written from an HTTP adapter. When a member
+ * cap is supplied (hosted plans), the deployment-wide headcount is checked
+ * first; bootstrap (`ensureSingleUser`) intentionally bypasses this.
  */
 export async function createFlaremoMemberWithLink(
   db: FlareMoDb,
   input: { authUserId: string; email: string; name: string },
+  limits?: PlanLimits,
 ): Promise<UserRow> {
+  if (limits) {
+    await assertMemberQuota(db, limits);
+  }
   const user = await createFlaremoMember(db, {
     email: input.email,
     name: input.name,


### PR DESCRIPTION
Closes #108

## 变更

#105 预留的 PlanLimits 接缝此前只被注入和展示，没有任何执行点。本 PR 把四个限额维度接进内核真实路径，使「自托管 = 不限量」与「托管 = 按计划限量」成为同一套内核的纯数据差异，订阅概念继续留在内核之外：

1. **附件存储总量**（`attachmentStorageBytes`）：三条上传路径（/api/v1、/api/v2 current、Connect）与两条导入路径在写入 R2 前调用 `assertAttachmentStorageQuota`（`state='ready'` 部署级求和，导入按 bundle 解码体积预检），超限 `QuotaExceededError` → 429。
2. **月度 embedding tokens**（`aiEmbeddingTokensPerMonth`）：outbox 每次 embed 成功后按 `estimateTokenCount`（`ceil(chars/4)`）写入 `usage_counters`（`embedding_tokens`/`embedding_calls` 此前定义了但无人写入）；预算耗尽时 sweep 暂停认领——任务保持 pending、不消耗重试次数，次月或提额后自动恢复。全量重建只计量不阻断（恢复路径）。
3. **月度语义搜索**（`semanticSearchQueriesPerMonth`）：`usage_counters` 新增 `search_queries` 指标；`/api/app/search/semantic` 与 `memory_recall` 语义路径在 embed 前检查部署级月度计数，成功后计入查询数与查询 token。
4. **成员数上限**（`maxMembersPerDeployment`）：`createFlaremoMemberWithLink` 接受可选 `limits`；Web 注册 / 管理员建号 / Memos current+Connect 注册路径统一预检，注册路径在 Better Auth 身份创建**之前**预检避免孤儿身份；429 在 auth/jsonError/current（code 8）/connect（`resource_exhausted`）四套错误映射中透传。

配套：`/api/app/usage/vector` 响应新增 `plan` 段（contracts `PlanUsageReport`），账户用量面板渲染四维度 used/limit 进度条（zh/en i18n，limit 为 null 不渲染）；`docs/architecture-notes.md「组装入口与计划限额」补充执行点说明。

## 自托管行为

`SELF_HOST_UNLIMITED` 全 null → 所有检查旁路、面板限额行不渲染，行为与此前完全一致。kernel-boundary 架构测试继续保证无支付依赖进入内核。

## 验证

- `pnpm verify` 全绿（typecheck + 单测 + build + Playwright E2E 24 用例）
- 新增：domain `quotas.test.ts` 6 用例、outbox 计量/暂停恢复 2 用例、worker storage 429 / member cap 429 / plan 段 3 用例
- 自检：无 Stripe/支付相关代码；域层只见「数字或 null」

## Issue 关系

Closes #108（P1 接缝的行为化收尾，为私有控制面 SaaS 差异化铺平）