### PR TITLE
feat(site): add app sign-in CTA to site nav

### DIFF
--- a/apps/site/src/components/site-nav.tsx
+++ b/apps/site/src/components/site-nav.tsx
@@ -61,6 +61,13 @@ export function SiteNav({ locale, currentPath }: SiteNavProps) {
         </nav>
         <div className="flex items-center gap-2">
           <a
+            className="inline-flex items-center rounded-md bg-brand-gradient px-3 py-1.5 text-sm font-medium text-primary-foreground shadow-sm transition-[filter,transform] hover:brightness-105 active:translate-y-px"
+            href="https://app.flaremo.app"
+            rel="noopener noreferrer"
+          >
+            {locale === "zh-CN" ? "登录 / 注册" : "Sign in"}
+          </a>
+          <a
             className="hidden items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground sm:inline-flex"
             href="https://github.com/realchendahuang/FlareMo"
             rel="noopener noreferrer"


### PR DESCRIPTION
Closes #112

公开 SaaS 实例 app.flaremo.app 已上线（开放注册）。SiteNav 右侧新增品牌渐变按钮：zh「登录 / 注册」/ en「Sign in」→ https://app.flaremo.app，全页面全断点可见。

验证：`pnpm format:check` ✅；`pnpm build:site` ✅（zh/en 首页 + 定价页产出均含链接）。