### PR TITLE
feat(domain): per-user stock count quotas for memos and memories

### DIFF
--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -232,6 +232,8 @@ const messages = {
     "usage.planStorage": "附件存储",
     "usage.planEmbeddingTokens": "本月 Embedding Tokens",
     "usage.planSearchQueries": "本月语义搜索",
+    "usage.planMemos": "笔记条数",
+    "usage.planMemories": "Agent 记忆条数",
     "usage.planMembers": "成员数",
     "usage.disclaimer":
       "以上为自测估算，非 Cloudflare 官方账单；最终计费以 Cloudflare Dashboard 为准。",
@@ -693,6 +695,8 @@ const messages = {
     "usage.planStorage": "Attachment storage",
     "usage.planEmbeddingTokens": "Embedding tokens this month",
     "usage.planSearchQueries": "Semantic searches this month",
+    "usage.planMemos": "Notes",
+    "usage.planMemories": "Agent memories",
     "usage.planMembers": "Members",
     "usage.disclaimer":
       "Self-measured estimate, not Cloudflare's official bill; final billing is per the Cloudflare Dashboard.",

--- a/apps/web/src/pages/account-page.tsx
+++ b/apps/web/src/pages/account-page.tsx
@@ -715,6 +715,18 @@ function PlanQuotaBars({
           limit: plan.user.limits.semanticSearchQueriesPerMonth,
           format: localeFormat,
         },
+        {
+          key: "usage.planMemos",
+          used: plan.user.usage.maxMemosPerUser,
+          limit: plan.user.limits.maxMemosPerUser,
+          format: localeFormat,
+        },
+        {
+          key: "usage.planMemories",
+          used: plan.user.usage.maxMemoryItemsPerUser,
+          limit: plan.user.limits.maxMemoryItemsPerUser,
+          format: localeFormat,
+        },
       ]
     : null;
   const userLimited = userRows?.filter((row) => row.limit !== null) ?? [];

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -1581,6 +1581,44 @@ describe("FlareMo Worker API", () => {
     expect(response.status).toBe(429);
   });
 
+  it("rejects memo creation over the per-user count cap with 429", async () => {
+    const cappedApp = createFlareMoApp({
+      resolveUserPlanLimits: (_env, userId) =>
+        userId === "users/owner"
+          ? {
+              attachmentStorageBytes: null,
+              aiEmbeddingTokensPerMonth: null,
+              semanticSearchQueriesPerMonth: null,
+              maxMemosPerUser: 1,
+              maxMemoryItemsPerUser: null,
+            }
+          : null,
+    });
+
+    const createMemoRequest = () =>
+      cappedApp.fetch(
+        new Request("http://flaremo.test/api/v1/memos", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            cookie: sessionCookie,
+            "x-flaremo-wire": "legacy",
+            origin: "http://flaremo.test",
+          },
+          body: JSON.stringify({ content: "count cap probe" }),
+        }),
+        env,
+      );
+
+    const first = await createMemoRequest();
+    expect(first.status).toBe(201);
+    // The owner is now at the 1-memo cap; the next write must 429.
+    const second = await createMemoRequest();
+    expect(second.status).toBe(429);
+    const body = (await second.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("Memo count quota");
+  });
+
   it("reports the per-user section on the usage endpoint when configured", async () => {
     const userLimitsApp = createFlareMoApp({
       resolveUserPlanLimits: () => ({

--- a/apps/worker/src/routes/app-api.ts
+++ b/apps/worker/src/routes/app-api.ts
@@ -357,8 +357,11 @@ appApi.get("/memos/:id", async (c) => {
 
 appApi.post("/memos", zValidator("json", createMemoSchema), async (c) => {
   try {
-    const { db, user } = await getRequestContext(c);
-    const memo = await createMemo(db, user, c.req.valid("json"));
+    const { db, user, userLimits } = await getRequestContext(c);
+    const memo = await createMemo(db, user, c.req.valid("json"), {
+      userLimits,
+      userId: user.id,
+    });
     return c.json(memoToDto(memo, user), 201);
   } catch (error) {
     return jsonError(c, error);
@@ -385,7 +388,7 @@ appApi.post(
   zValidator("json", createMemoryFromMemoSchema),
   async (c) => {
     try {
-      const { db, user } = await getRequestContext(c);
+      const { db, user, userLimits } = await getRequestContext(c);
       const memoId = `memos/${c.req.param("id")}`;
       const memo = await getMemoById(db, user, memoId);
       if (!memo) throw new NotFoundError("Memo not found");
@@ -395,6 +398,7 @@ appApi.post(
         { type: "user" },
         createMemoryFromMemoInputToWrite(c.req.valid("json"), memo.content),
         memoId,
+        { userLimits, userId: user.id },
       );
       return c.json(result, result.duplicate ? 200 : 201);
     } catch (error) {

--- a/apps/worker/src/routes/mcp.ts
+++ b/apps/worker/src/routes/mcp.ts
@@ -230,7 +230,10 @@ async function callTool(
       ...args,
       source: args.source ?? "mcp",
     }) as CreateMemoInput;
-    const memo = await createMemo(db, user, input);
+    const memo = await createMemo(db, user, input, {
+      userLimits: context.userLimits,
+      userId: user.id,
+    });
     return memoToDto(memo, user);
   }
 
@@ -1025,7 +1028,10 @@ async function streamableCreateMemo(
     payload: memoPayloadFromInput(input),
     source: optionalString(input, "source") ?? "mcp",
   }) as CreateMemoInput;
-  let memo = await createMemo(context.db, context.user, createInput);
+  let memo = await createMemo(context.db, context.user, createInput, {
+    userLimits: context.userLimits,
+    userId: context.user.id,
+  });
 
   const followUp: Parameters<typeof updateMemo>[3] = {};
   const state = normalizeMemoState(

--- a/apps/worker/src/routes/memory-api.ts
+++ b/apps/worker/src/routes/memory-api.ts
@@ -72,12 +72,13 @@ memoryApi.get("/review", async (c) => {
 
 memoryApi.post("/", zValidator("json", createMemorySchema), async (c) => {
   try {
-    const { db, user } = await getBrowserRequestContext(c);
+    const { db, user, userLimits } = await getBrowserRequestContext(c);
     const result = await createMemory(
       db,
       user,
       USER_ACTOR,
       createMemoryInputToWrite(c.req.valid("json")),
+      { userLimits, userId: user.id },
     );
     return c.json(result, result.duplicate ? 200 : 201);
   } catch (error) {
@@ -193,12 +194,13 @@ memoryApi.post("/:id/archive", async (c) => {
 
 memoryApi.post("/:id/promote", async (c) => {
   try {
-    const { db, user } = await getBrowserRequestContext(c);
+    const { db, user, userLimits } = await getBrowserRequestContext(c);
     const result = await promoteMemoryToMemo(
       db,
       user,
       USER_ACTOR,
       parseMemoryId(c.req.param("id")),
+      { userLimits, userId: user.id },
     );
     return c.json(result, 201);
   } catch (error) {

--- a/apps/worker/src/routes/memory-mcp.ts
+++ b/apps/worker/src/routes/memory-mcp.ts
@@ -474,12 +474,16 @@ async function callMemoryTool(
         user,
         resolveAgent(args),
         rememberInputToWrite(input),
+        { userLimits: context.userLimits, userId: user.id },
       );
       return result;
     }
     case "memory_checkpoint": {
       const input = checkpointInputSchema.parse(args);
-      return checkpointMemory(db, user, resolveAgent(args), input);
+      return checkpointMemory(db, user, resolveAgent(args), input, {
+        userLimits: context.userLimits,
+        userId: user.id,
+      });
     }
     case "memory_link": {
       const input = linkInputSchema.parse(args);

--- a/apps/worker/src/routes/memos-api.ts
+++ b/apps/worker/src/routes/memos-api.ts
@@ -13,6 +13,7 @@ import {
 } from "@flaremo/contracts";
 import {
   assertAttachmentStorageQuota,
+  assertMemoCountQuota,
   bindMemoAttachments,
   createAttachmentMetadata,
   createDataTask,
@@ -84,8 +85,11 @@ memosApi.get("/memos", zValidator("query", listMemosQuerySchema), async (c) => {
 
 memosApi.post("/memos", zValidator("json", createMemoSchema), async (c) => {
   try {
-    const { db, user } = await getRequestContext(c);
-    const memo = await createMemo(db, user, c.req.valid("json"));
+    const { db, user, userLimits } = await getRequestContext(c);
+    const memo = await createMemo(db, user, c.req.valid("json"), {
+      userLimits,
+      userId: user.id,
+    });
     return c.json(memoToDto(memo, user), 201);
   } catch (error) {
     return jsonError(c, error);
@@ -539,6 +543,7 @@ memosApi.post(
         bundleAttachmentBytes(bundle.attachments),
         { userLimits, userId: user.id },
       );
+      await assertMemoCountQuota(db, userLimits, user.id, bundle.memos.length);
       const r2Keys = new Map<string, string>();
       const r2Etags = new Map<string, string | null>();
       for (const attachment of bundle.attachments) {
@@ -851,6 +856,12 @@ memosApi.post(
         limits,
         bundleAttachmentBytes(body.bundle.attachments),
         { userLimits, userId: user.id },
+      );
+      await assertMemoCountQuota(
+        db,
+        userLimits,
+        user.id,
+        body.bundle.memos.length,
       );
       const r2Keys = new Map<string, string>();
       const r2Etags = new Map<string, string | null>();

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -1676,12 +1676,17 @@ async function createConnectMemo(
 ) {
   const body = record(value);
   const memo = record(body.memo);
-  const created = await createMemo(context.db, context.user, {
-    content: requiredString(memo.content, "memo.content"),
-    visibility: visibilityToLegacy(memo.visibility),
-    payload: currentPayload(memo),
-    source: "memos-connect",
-  });
+  const created = await createMemo(
+    context.db,
+    context.user,
+    {
+      content: requiredString(memo.content, "memo.content"),
+      visibility: visibilityToLegacy(memo.visibility),
+      payload: currentPayload(memo),
+      source: "memos-connect",
+    },
+    { userLimits: context.userLimits, userId: context.user.id },
+  );
   return connectMemoWithDetails(context, created.id);
 }
 

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -492,12 +492,17 @@ memosCurrentApi.post("/memos", async (c, next) => {
       throw new ValidationCurrentError("Memo content is required");
     }
     const context = await getRequestContext(c);
-    const memo = await createMemo(context.db, context.user, {
-      content: body.content.trim(),
-      visibility: currentVisibilityToLegacy(body.visibility),
-      payload: currentPayload(body),
-      source: "memos-api",
-    });
+    const memo = await createMemo(
+      context.db,
+      context.user,
+      {
+        content: body.content.trim(),
+        visibility: currentVisibilityToLegacy(body.visibility),
+        payload: currentPayload(body),
+        source: "memos-api",
+      },
+      { userLimits: context.userLimits, userId: context.user.id },
+    );
     return c.json(await currentMemoWithDetails(context, memo));
   } catch (error) {
     return currentJsonError(c, error);

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -442,6 +442,8 @@ worker 的路由表不再挂在模块级常量上，而是由 `createFlareMoApp(
 
 **Per-user 限额（共享 SaaS 实例）**：部署级限额对「公开注册、多用户共享一个部署」的形态会锁死全体，因此内核还接受一层 per-user 限额（`UserPlanLimits`，只有存储/tokens/搜索三个维度——成员数天然是部署级，不做 per-user 形态）。注入途径：`createFlareMoApp` 的 `resolveUserPlanLimits(env, userId)` 选项，或 `FLAREMO_USER_LIMITS_JSON` 环境变量（用户无关的静态配置）。生效优先级 per-user → 部署级 → 不限量；per-user 生效时用量按该 user 读取（`usage_counters` 本就按 user 分桶，附件存储按 userId 过滤求和），outbox 也按任务归属用户判断预算。`plan` 响应在配置了 per-user 限额时附带 `user` 段，面板渲染「个人限额」分组。
 
+**存量条数维度**：`UserPlanLimits` 另有 `maxMemosPerUser` / `maxMemoryItemsPerUser`（共享实例按条计费的主货币）。条数是存量口径——memo 按 `normal + archived` 计（回收站不算），memory 按 `active + archived` 计。检查在 domain `createMemo` / `createMemory` 内部执行（可选 `scope` 参数沿调用链透传），导入路径以 bundle 条数预检；`additionalCount` 默认 1 表示「一次写入即将发生」，恰好满额允许、超出才 429。Projects/Tasks/引用关系/回顾/导入导出/MCP 接入是零边际成本能力，**不设限**。
+
 ## 结论
 
 FlareMo 的架构核心是：

--- a/packages/contracts/src/embedding.ts
+++ b/packages/contracts/src/embedding.ts
@@ -75,11 +75,15 @@ export const planUsageReportSchema = z.object({
         attachmentStorageBytes: planLimitValueSchema,
         aiEmbeddingTokensPerMonth: planLimitValueSchema,
         semanticSearchQueriesPerMonth: planLimitValueSchema,
+        maxMemosPerUser: planLimitValueSchema,
+        maxMemoryItemsPerUser: planLimitValueSchema,
       }),
       usage: z.object({
         attachmentStorageBytes: z.number().int(),
         aiEmbeddingTokensPerMonth: z.number().int(),
         semanticSearchQueriesPerMonth: z.number().int(),
+        maxMemosPerUser: z.number().int(),
+        maxMemoryItemsPerUser: z.number().int(),
       }),
     })
     .optional(),

--- a/packages/domain/src/embedding-outbox.test.ts
+++ b/packages/domain/src/embedding-outbox.test.ts
@@ -273,6 +273,8 @@ describe("embedding outbox", () => {
       aiEmbeddingTokensPerMonth: 100,
       attachmentStorageBytes: null,
       semanticSearchQueriesPerMonth: null,
+      maxMemosPerUser: null,
+      maxMemoryItemsPerUser: null,
     };
 
     let embedCalls = 0;

--- a/packages/domain/src/limits.test.ts
+++ b/packages/domain/src/limits.test.ts
@@ -28,6 +28,17 @@ describe("parseUserPlanLimits", () => {
       attachmentStorageBytes: 1073741824,
       aiEmbeddingTokensPerMonth: 200000,
       semanticSearchQueriesPerMonth: null,
+      maxMemosPerUser: null,
+      maxMemoryItemsPerUser: null,
+    });
+    // A partial payload fills missing dimensions with null (fall through to
+    // the deployment limit) — null never means "unlimited".
+    expect(parseUserPlanLimits('{"maxMemosPerUser":500}')).toEqual({
+      attachmentStorageBytes: null,
+      aiEmbeddingTokensPerMonth: null,
+      semanticSearchQueriesPerMonth: null,
+      maxMemosPerUser: 500,
+      maxMemoryItemsPerUser: null,
     });
   });
 
@@ -37,11 +48,7 @@ describe("parseUserPlanLimits", () => {
     expect(parseUserPlanLimits("not json")).toBeNull();
     expect(parseUserPlanLimits("42")).toBeNull();
     expect(parseUserPlanLimits("{}")).toBeNull();
-    expect(
-      parseUserPlanLimits(
-        '{"attachmentStorageBytes":1,"aiEmbeddingTokensPerMonth":2}',
-      ),
-    ).toBeNull();
+    expect(parseUserPlanLimits("{}")).toBeNull();
     expect(
       parseUserPlanLimits(
         '{"attachmentStorageBytes":-5,"aiEmbeddingTokensPerMonth":2,"semanticSearchQueriesPerMonth":3}',

--- a/packages/domain/src/limits.ts
+++ b/packages/domain/src/limits.ts
@@ -35,6 +35,10 @@ export type UserPlanLimits = {
   attachmentStorageBytes: PlanLimitValue;
   aiEmbeddingTokensPerMonth: PlanLimitValue;
   semanticSearchQueriesPerMonth: PlanLimitValue;
+  /** Stock count of living memos (normal + archived; trash excluded). */
+  maxMemosPerUser: PlanLimitValue;
+  /** Stock count of living memories (active + archived). */
+  maxMemoryItemsPerUser: PlanLimitValue;
 };
 
 /**
@@ -55,8 +59,14 @@ export function parseUserPlanLimits(
   }
   if (typeof parsed !== "object" || parsed === null) return null;
   const record = parsed as Record<string, unknown>;
+  // A missing key is safe to treat as null: null means "fall through to the
+  // deployment-level limit for this dimension", never "unlimited". Only a
+  // payload with no valid dimension at all counts as not-configured.
+  let known = 0;
   const read = (key: string): PlanLimitValue | undefined => {
     const value = record[key];
+    if (value === undefined) return null;
+    known += 1;
     if (value === null) return null;
     if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
       return value;
@@ -66,10 +76,15 @@ export function parseUserPlanLimits(
   const attachmentStorageBytes = read("attachmentStorageBytes");
   const aiEmbeddingTokensPerMonth = read("aiEmbeddingTokensPerMonth");
   const semanticSearchQueriesPerMonth = read("semanticSearchQueriesPerMonth");
+  const maxMemosPerUser = read("maxMemosPerUser");
+  const maxMemoryItemsPerUser = read("maxMemoryItemsPerUser");
   if (
+    known === 0 ||
     attachmentStorageBytes === undefined ||
     aiEmbeddingTokensPerMonth === undefined ||
-    semanticSearchQueriesPerMonth === undefined
+    semanticSearchQueriesPerMonth === undefined ||
+    maxMemosPerUser === undefined ||
+    maxMemoryItemsPerUser === undefined
   ) {
     return null;
   }
@@ -77,5 +92,7 @@ export function parseUserPlanLimits(
     attachmentStorageBytes,
     aiEmbeddingTokensPerMonth,
     semanticSearchQueriesPerMonth,
+    maxMemosPerUser,
+    maxMemoryItemsPerUser,
   };
 }

--- a/packages/domain/src/memory.ts
+++ b/packages/domain/src/memory.ts
@@ -30,6 +30,7 @@ import {
 } from "./errors";
 import { createResourceId } from "./ids";
 import { createMemo } from "./memos";
+import { assertMemoryCountQuota, type QuotaScope } from "./quotas";
 
 export const MEMORY_MAX_CONTENT_LENGTH = 4_000;
 export const MEMORY_DEFAULT_RECALL_LIMIT = 8;
@@ -337,7 +338,9 @@ export async function createMemory(
   user: UserRow,
   actor: MemoryActor,
   input: MemoryWriteInput,
+  scope?: QuotaScope,
 ) {
+  await assertMemoryCountQuota(db, scope?.userLimits, user.id);
   const content = normalizeMemoryContent(input.content);
   if (!content) throw new ValidationError("Memory content cannot be empty.");
   assertMemoryContentLength(content);
@@ -1024,20 +1027,27 @@ export async function checkpointMemory(
   user: UserRow,
   actor: MemoryActor,
   input: CheckpointInput,
+  scope?: QuotaScope,
 ) {
   const scopeKey = input.scope_key ?? input.project_key ?? null;
-  const episode = await createMemory(db, user, actor, {
-    content: input.summary,
-    type: "episodic",
-    kind: "event",
-    scopeType: input.scope_type,
-    scopeKey,
-    tier: "normal",
-    importance: 50,
-    confidence: actor.type === "user" ? 100 : 50,
-    verification: actor.type === "user" ? "confirmed" : "observed",
-    sourceAgent: actor.type === "agent" ? actor.name : null,
-  });
+  const episode = await createMemory(
+    db,
+    user,
+    actor,
+    {
+      content: input.summary,
+      type: "episodic",
+      kind: "event",
+      scopeType: input.scope_type,
+      scopeKey,
+      tier: "normal",
+      importance: 50,
+      confidence: actor.type === "user" ? 100 : 50,
+      verification: actor.type === "user" ? "confirmed" : "observed",
+      sourceAgent: actor.type === "agent" ? actor.name : null,
+    },
+    scope,
+  );
 
   if (episode.duplicate) {
     throw new ConflictError("This checkpoint already exists.");
@@ -1046,18 +1056,24 @@ export async function checkpointMemory(
   const episodeId = episode.memory.id;
   const createdIds: string[] = [];
   for (const item of input.items) {
-    const result = await createMemory(db, user, actor, {
-      content: item.content,
-      type: item.type,
-      kind: item.kind,
-      scopeType: input.scope_type,
-      scopeKey,
-      tier: "normal",
-      importance: item.importance,
-      confidence: actor.type === "user" ? 100 : 50,
-      verification: actor.type === "user" ? "confirmed" : "observed",
-      sourceAgent: actor.type === "agent" ? actor.name : null,
-    });
+    const result = await createMemory(
+      db,
+      user,
+      actor,
+      {
+        content: item.content,
+        type: item.type,
+        kind: item.kind,
+        scopeType: input.scope_type,
+        scopeKey,
+        tier: "normal",
+        importance: item.importance,
+        confidence: actor.type === "user" ? 100 : 50,
+        verification: actor.type === "user" ? "confirmed" : "observed",
+        sourceAgent: actor.type === "agent" ? actor.name : null,
+      },
+      scope,
+    );
     const itemId = result.memory.id;
     createdIds.push(itemId);
     await db
@@ -1250,8 +1266,9 @@ export async function createMemoryFromMemo(
   actor: MemoryActor,
   input: MemoryWriteInput,
   memoId: string,
+  scope?: QuotaScope,
 ) {
-  const result = await createMemory(db, user, actor, input);
+  const result = await createMemory(db, user, actor, input, scope);
   if (result.duplicate) {
     // The same conclusion already exists; still record the derivation link if
     // this exact memo is not already linked.
@@ -1291,15 +1308,21 @@ export async function promoteMemoryToMemo(
   user: UserRow,
   actor: MemoryActor,
   memoryId: string,
+  scope?: QuotaScope,
 ): Promise<{ memory: MemoryDto; memo: string }> {
   const memory = await requireMemory(db, user, memoryId);
   assertAgentCanMutate(actor, memory);
 
-  const memo = await createMemo(db, user, {
-    content: memory.content,
-    visibility: "private",
-    source: "memory",
-  });
+  const memo = await createMemo(
+    db,
+    user,
+    {
+      content: memory.content,
+      visibility: "private",
+      source: "memory",
+    },
+    scope,
+  );
 
   await db.insert(memoryResourceLinks).values({
     id: createResourceId("memories"),

--- a/packages/domain/src/memos.ts
+++ b/packages/domain/src/memos.ts
@@ -17,6 +17,7 @@ import { compileMemoFilter } from "./memo-filter";
 import { insertMemosSseEvent } from "./memos-sse";
 import { findMentionedUsers, insertMemoNotification } from "./memos-user";
 import { insertMemosWebhookEvent } from "./memos-webhooks";
+import { assertMemoCountQuota, type QuotaScope } from "./quotas";
 import { extractTags, normalizeMemoTags } from "./tags";
 
 export type MemoListResult = {
@@ -35,7 +36,9 @@ export async function createMemo(
   db: FlareMoDb,
   user: UserRow,
   input: CreateMemoInput,
+  scope?: QuotaScope,
 ): Promise<MemoRow> {
+  await assertMemoCountQuota(db, scope?.userLimits, user.id);
   const now = new Date().toISOString();
   const payload = normalizeMemoPayload(input.payload);
   const clientId = normalizeMemoClientId(payload.client_id);

--- a/packages/domain/src/quotas.test.ts
+++ b/packages/domain/src/quotas.test.ts
@@ -6,9 +6,13 @@ import { Miniflare } from "miniflare";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { QuotaExceededError } from "./errors";
 import { SELF_HOST_UNLIMITED, type UserPlanLimits } from "./limits";
+import { createMemory } from "./memory";
+import { createMemo } from "./memos";
 import {
   assertAttachmentStorageQuota,
   assertMemberQuota,
+  assertMemoCountQuota,
+  assertMemoryCountQuota,
   assertMonthlyQuota,
   countFlaremoUsers,
   estimateTokenCount,
@@ -176,6 +180,8 @@ describe("plan quota checks", () => {
       attachmentStorageBytes: 500,
       aiEmbeddingTokensPerMonth: null,
       semanticSearchQueriesPerMonth: null,
+      maxMemosPerUser: null,
+      maxMemoryItemsPerUser: null,
     };
 
     // The member is within their own 500-byte quota despite the deployment
@@ -215,6 +221,73 @@ describe("plan quota checks", () => {
     ).rejects.toThrow(QuotaExceededError);
   });
 
+  it("enforces per-user memo and memory stock caps", async () => {
+    const member = await createFlaremoMember(db, {
+      email: "member@example.com",
+      name: "Member",
+    });
+    // Owner owns one living memo; member none.
+    await createMemo(db, owner, {
+      content: "owner memo",
+      visibility: "private",
+      source: "web",
+    });
+    const ownerLimits: UserPlanLimits = {
+      attachmentStorageBytes: null,
+      aiEmbeddingTokensPerMonth: null,
+      semanticSearchQueriesPerMonth: null,
+      maxMemosPerUser: 1,
+      maxMemoryItemsPerUser: null,
+    };
+
+    await expect(
+      assertMemoCountQuota(db, ownerLimits, member.id),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertMemoCountQuota(db, ownerLimits, owner.id),
+    ).rejects.toThrow(QuotaExceededError);
+    // Imports pre-check the bundle size against remaining headroom:
+    // member has 0 memos and a cap of 1, so a bundle of 2 must be rejected
+    // while exactly 1 (reaching the cap) is allowed.
+    await expect(
+      assertMemoCountQuota(db, ownerLimits, member.id, 1),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertMemoCountQuota(db, ownerLimits, member.id, 2),
+    ).rejects.toThrow(QuotaExceededError);
+
+    const memoryLimits: UserPlanLimits = {
+      ...ownerLimits,
+      maxMemosPerUser: null,
+      maxMemoryItemsPerUser: 2,
+    };
+    await createMemory(
+      db,
+      owner,
+      { type: "user" },
+      {
+        content: "memory one",
+        type: "semantic",
+        kind: "fact",
+        scopeType: "global",
+        scopeKey: null,
+        tier: "normal",
+        importance: 50,
+        confidence: 50,
+      },
+    );
+    // Owner has 1 memory against a cap of 2: one more fits, two do not.
+    await expect(
+      assertMemoryCountQuota(db, memoryLimits, owner.id, 1),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertMemoryCountQuota(db, memoryLimits, owner.id, 2),
+    ).rejects.toThrow(QuotaExceededError);
+    // Unset limits never constrain.
+    await assertMemoCountQuota(db, null, owner.id);
+    await assertMemoryCountQuota(db, null, owner.id);
+  });
+
   it("reports a per-user section in the plan usage report", async () => {
     await insertAttachment(owner.id, 700);
     await incrementUsageCounter(db, owner, "search_queries", 3);
@@ -222,6 +295,8 @@ describe("plan quota checks", () => {
       attachmentStorageBytes: 1000,
       aiEmbeddingTokensPerMonth: null,
       semanticSearchQueriesPerMonth: 100,
+      maxMemosPerUser: null,
+      maxMemoryItemsPerUser: null,
     };
 
     const report = await reportPlanUsage(db, SELF_HOST_UNLIMITED, {

--- a/packages/domain/src/quotas.ts
+++ b/packages/domain/src/quotas.ts
@@ -1,6 +1,12 @@
 import type { FlareMoDb } from "@flaremo/db";
-import { attachments, usageCounters, users } from "@flaremo/db";
-import { and, eq, sql } from "drizzle-orm";
+import {
+  attachments,
+  memoryItems,
+  memos,
+  usageCounters,
+  users,
+} from "@flaremo/db";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { QuotaExceededError } from "./errors";
 import type { PlanLimits, PlanLimitValue, UserPlanLimits } from "./limits";
 import type { UsageMetric } from "./usage";
@@ -165,6 +171,82 @@ export async function assertAttachmentStorageQuota(
   }
 }
 
+/**
+ * Stock memo count for one user: normal + archived count against the quota;
+ * trash and hard-deleted rows do not.
+ */
+export async function countUserMemos(
+  db: FlareMoDb,
+  userId: string,
+): Promise<number> {
+  const row = await db
+    .select({ total: sql<number>`count(*)` })
+    .from(memos)
+    .where(
+      and(
+        eq(memos.userId, userId),
+        inArray(memos.status, ["normal", "archived"]),
+      ),
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/** Stock memory count for one user: active + archived. */
+export async function countUserMemories(
+  db: FlareMoDb,
+  userId: string,
+): Promise<number> {
+  const row = await db
+    .select({ total: sql<number>`count(*)` })
+    .from(memoryItems)
+    .where(
+      and(
+        eq(memoryItems.userId, userId),
+        inArray(memoryItems.status, ["active", "archived"]),
+      ),
+    )
+    .get();
+  return row?.total ?? 0;
+}
+
+/**
+ * Throws when the user's living-memo stock (plus `additional` about to be
+ * written, e.g. an import bundle) would reach the per-user cap.
+ */
+export async function assertMemoCountQuota(
+  db: FlareMoDb,
+  userLimits: UserPlanLimits | null | undefined,
+  userId: string,
+  additionalCount = 1,
+): Promise<void> {
+  const limit = userLimits?.maxMemosPerUser ?? null;
+  if (limit === null) return;
+  const used = await countUserMemos(db, userId);
+  if (used + additionalCount > limit) {
+    throw new QuotaExceededError(
+      `Memo count quota exceeded (${limit} notes per user)`,
+    );
+  }
+}
+
+/** Same as assertMemoCountQuota for the Agent Memory stock. */
+export async function assertMemoryCountQuota(
+  db: FlareMoDb,
+  userLimits: UserPlanLimits | null | undefined,
+  userId: string,
+  additionalCount = 1,
+): Promise<void> {
+  const limit = userLimits?.maxMemoryItemsPerUser ?? null;
+  if (limit === null) return;
+  const used = await countUserMemories(db, userId);
+  if (used + additionalCount > limit) {
+    throw new QuotaExceededError(
+      `Memory count quota exceeded (${limit} memories per user)`,
+    );
+  }
+}
+
 export async function countFlaremoUsers(db: FlareMoDb): Promise<number> {
   const row = await db
     .select({ total: sql<number>`count(*)` })
@@ -205,6 +287,8 @@ export type UserPlanUsageReport = {
     attachmentStorageBytes: number;
     aiEmbeddingTokensPerMonth: number;
     semanticSearchQueriesPerMonth: number;
+    maxMemosPerUser: number;
+    maxMemoryItemsPerUser: number;
   };
 };
 
@@ -247,6 +331,8 @@ export async function reportPlanUsage(
           scope.userId,
           "search_queries",
         ),
+        maxMemosPerUser: await countUserMemos(db, scope.userId),
+        maxMemoryItemsPerUser: await countUserMemories(db, scope.userId),
       },
     };
   }


### PR DESCRIPTION
Closes #114（条数维度部分）

按上一轮讨论的 B2 档位：免费档主货币从字节换成条数。

- `UserPlanLimits` 新增 `maxMemosPerUser` / `maxMemoryItemsPerUser`（存量口径：memo = normal+archived，memory = active+archived，回收站不算）
- 检查在 domain `createMemo`/`createMemory` 内部（可选 `QuotaScope` 沿 checkpoint / createMemoryFromMemo / promoteMemoryToMemo 透传），六条 createMemo 路由 + memory 三条路由 + 两条导入路径全部接线；导入以 bundle 条数预检
- `additionalCount` 默认 1（一次写入即将发生）：恰好满额允许、超出 429
- parse 放宽为「缺键 = null = 回落到部署级限额」（null 从不等于 unlimited），载荷全部无有效键才视为未配置
- usage 端点 `plan.user` 与账户面板新增「笔记条数 / Agent 记忆条数」两行（zh/en）
- Projects/Tasks/引用/回顾/导入导出/MCP 按设限原则**不限**（零边际成本）

验证：`pnpm verify` 全绿（typecheck + 单测含新增 parse/scoped/worker 429 用例 + build + 24 E2E）。