### PR TITLE
feat(auth): registration email verification via Cloudflare Email Sending

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -118,6 +118,11 @@ const ResetPage = lazy(() =>
     default: module.ResetPage,
   })),
 );
+const VerifyEmailPage = lazy(() =>
+  import("@/pages/verify-email-page").then((module) => ({
+    default: module.VerifyEmailPage,
+  })),
+);
 const RecoverPage = lazy(() =>
   import("@/pages/recover-page").then((module) => ({
     default: module.RecoverPage,
@@ -1165,6 +1170,31 @@ const registerRoute = createRoute({
   component: RegisterRoutePage,
 });
 
+function VerifyEmailRoutePage() {
+  const { token } = verifyEmailRoute.useSearch();
+  if (!token) {
+    return (
+      <Suspense fallback={<RouteLoading />}>
+        <VerifyEmailPage token="" />
+      </Suspense>
+    );
+  }
+  return (
+    <Suspense fallback={<RouteLoading />}>
+      <VerifyEmailPage token={token} />
+    </Suspense>
+  );
+}
+
+const verifyEmailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/verify-email",
+  component: VerifyEmailRoutePage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: typeof search.token === "string" ? search.token : undefined,
+  }),
+});
+
 function ResetRoutePage() {
   const { token } = resetRoute.useSearch();
   return (
@@ -1358,6 +1388,7 @@ const router = createRouter({
     shareRoute,
     loginRoute,
     registerRoute,
+    verifyEmailRoute,
     resetRoute,
     recoverRoute,
     setupRoute,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -131,6 +131,7 @@ export const AUTHENTICATION_REQUIRED_EVENT = "flaremo:authentication-required";
 export type RegistrationStatus = {
   registration_open: boolean;
   initialized: boolean;
+  email_verification_required: boolean;
   captcha: {
     provider: "none" | "tencent" | "http";
     site_key: string | null;
@@ -565,6 +566,14 @@ export async function registerAccount(
           }
         : undefined,
     },
+    { authRequired: false },
+  );
+}
+
+export async function verifyEmail(token: string) {
+  return apiRequest<{ ok: true }>(
+    `/api/auth/flaremo/verify-email?token=${encodeURIComponent(token)}`,
+    {},
     { authRequired: false },
   );
 }

--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -252,6 +252,12 @@ const messages = {
     "auth.captchaRequired": "请先完成验证码。",
     "auth.captchaVerifying": "验证码校验中…",
     "auth.captchaFailed": "验证码校验失败，请重试。",
+    "auth.verifyEmailTitle": "验证邮箱",
+    "auth.verifyEmailSent": "验证邮件已发送到",
+    "auth.verifyEmailHint": "点击邮件里的链接完成验证，然后就可以登录了。",
+    "auth.verifyEmailVerifying": "正在验证…",
+    "auth.verifyEmailSuccess": "邮箱已验证，现在可以登录了。",
+    "auth.verifyEmailInvalid": "验证链接无效或已过期，请重新注册或联系管理员。",
     "auth.registering": "正在注册…",
     "auth.registerFailed": "注册失败，请检查输入后重试。",
     "auth.registrationClosed": "当前未开放注册，请联系管理员。",
@@ -718,6 +724,14 @@ const messages = {
     "auth.captchaRequired": "Complete the captcha first.",
     "auth.captchaVerifying": "Verifying captcha…",
     "auth.captchaFailed": "Captcha verification failed. Try again.",
+    "auth.verifyEmailTitle": "Verify your email",
+    "auth.verifyEmailSent": "A verification email was sent to",
+    "auth.verifyEmailHint":
+      "Click the link in the email to finish verifying, then sign in.",
+    "auth.verifyEmailVerifying": "Verifying…",
+    "auth.verifyEmailSuccess": "Email verified. You can sign in now.",
+    "auth.verifyEmailInvalid":
+      "This verification link is invalid or expired. Please register again or contact the administrator.",
     "auth.registering": "Signing up…",
     "auth.registerFailed": "Sign-up failed. Check your input and try again.",
     "auth.registrationClosed":

--- a/apps/web/src/pages/register-page.tsx
+++ b/apps/web/src/pages/register-page.tsx
@@ -37,6 +37,7 @@ export function RegisterPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [captchaTicket, setCaptchaTicket] = useState<string | null>(null);
   const [captchaRandstr, setCaptchaRandstr] = useState("");
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
 
   if (session.data?.user) {
     return (
@@ -89,6 +90,13 @@ export function RegisterPage() {
       );
       setPassword("");
       setPasswordConfirmation("");
+      // With a transactional-email provider the account needs verification
+      // before it is fully usable; show the check-your-inbox state instead of
+      // silently dropping the user at the login form.
+      if (registrationQuery.data?.email_verification_required) {
+        setRegisteredEmail(email.trim());
+        return;
+      }
       await navigate({ replace: true, to: "/login" });
     } catch (error) {
       setFormError(errorMessage(error, t("auth.registerFailed")));
@@ -96,6 +104,30 @@ export function RegisterPage() {
       setIsSubmitting(false);
     }
   };
+
+  if (registeredEmail) {
+    return (
+      <AuthPageFrame title={t("auth.verifyEmailTitle")}>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm leading-6 text-muted-foreground">
+            {t("auth.verifyEmailSent")}{" "}
+            <span className="font-medium text-foreground">
+              {registeredEmail}
+            </span>
+          </p>
+          <p className="text-sm leading-6 text-muted-foreground">
+            {t("auth.verifyEmailHint")}
+          </p>
+          <Link
+            className="text-sm font-medium text-flame-600 underline-offset-4 hover:underline"
+            to="/login"
+          >
+            {t("auth.signIn")}
+          </Link>
+        </div>
+      </AuthPageFrame>
+    );
+  }
 
   return (
     <AuthPageFrame title={t("auth.registerTitle")}>

--- a/apps/web/src/pages/verify-email-page.tsx
+++ b/apps/web/src/pages/verify-email-page.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { verifyEmail } from "@/api";
+import { AuthPageFrame } from "@/components/auth-page-frame";
+import { useI18n } from "@/i18n";
+
+export function VerifyEmailPage({ token }: { token: string }) {
+  const { t } = useI18n();
+  const [result, setResult] = useState<"pending" | "ok" | "error">("pending");
+
+  const verifyQuery = useQuery({
+    queryKey: ["verify-email", token],
+    queryFn: () => verifyEmail(token),
+    retry: false,
+    enabled: token.length > 0,
+  });
+
+  useEffect(() => {
+    if (token.length === 0) {
+      setResult("error");
+      return;
+    }
+    if (verifyQuery.isSuccess) setResult("ok");
+    if (verifyQuery.isError) setResult("error");
+  }, [token, verifyQuery.isSuccess, verifyQuery.isError]);
+
+  return (
+    <AuthPageFrame title={t("auth.verifyEmailTitle")}>
+      {result === "pending" && (
+        <p className="text-sm text-muted-foreground">
+          {t("auth.verifyEmailVerifying")}
+        </p>
+      )}
+      {result === "ok" && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm leading-6 text-muted-foreground">
+            {t("auth.verifyEmailSuccess")}
+          </p>
+          <Link
+            className="text-sm font-medium text-flame-600 underline-offset-4 hover:underline"
+            to="/login"
+          >
+            {t("auth.signIn")}
+          </Link>
+        </div>
+      )}
+      {result === "error" && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm leading-6 text-destructive">
+            {t("auth.verifyEmailInvalid")}
+          </p>
+          <Link
+            className="text-sm font-medium text-flame-600 underline-offset-4 hover:underline"
+            to="/login"
+          >
+            {t("auth.signIn")}
+          </Link>
+        </div>
+      )}
+    </AuthPageFrame>
+  );
+}

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -1734,6 +1734,77 @@ describe("FlareMo Worker API", () => {
     expect(openRegister.status).toBe(201);
   });
 
+  it("sends a verification email on registration and verifies via token", async () => {
+    const emailApp = createFlareMoApp();
+    const open = await emailApp.fetch(
+      new Request("http://flaremo.test/api/app/admin/settings", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          cookie: sessionCookie,
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ registration_open: true }),
+      }),
+      env,
+    );
+    expect(open.status).toBe(200);
+
+    const emailEnv = {
+      ...env,
+      FLAREMO_EMAIL_PROVIDER: "cloudflare",
+      FLAREMO_EMAIL_FROM: "no-reply@flaremo.test",
+    } as Env;
+    const sent: Array<{ to: string; from: string; subject: string }> = [];
+    const emailBinding = {
+      send: async (msg: { to: string; from: string; subject: string }) => {
+        sent.push(msg);
+        return { ok: true };
+      },
+    };
+    const appWithEmail = createFlareMoApp();
+    const register = await appWithEmail.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/register", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          name: "Member",
+          email: "verify-me@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      { ...emailEnv, EMAIL: emailBinding } as Env,
+    );
+    expect(register.status).toBe(201);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.to).toBe("verify-me@example.com");
+    expect(sent[0]?.from).toBe("no-reply@flaremo.test");
+    expect(sent[0]?.subject).toContain("Verify");
+
+    // The token is not exposed in the response; verify the endpoint rejects
+    // an unknown token and that the status endpoint reports verification
+    // being required.
+    const status = await appWithEmail.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/register/status"),
+      { ...emailEnv, EMAIL: emailBinding } as Env,
+    );
+    const statusBody = (await status.json()) as {
+      email_verification_required: boolean;
+    };
+    expect(statusBody.email_verification_required).toBe(true);
+
+    const bad = await appWithEmail.fetch(
+      new Request(
+        "http://flaremo.test/api/auth/flaremo/verify-email?token=unknown-token",
+      ),
+      { ...emailEnv, EMAIL: emailBinding } as Env,
+    );
+    expect(bad.status).toBe(400);
+  });
+
   it("rejects a registration over the member cap with 429", async () => {
     const quotaApp = createFlareMoApp({
       resolvePlanLimits: () => ({

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -80,6 +80,18 @@ export type FlareMoAuth = {
    * flow without the admin ever learning the plaintext.
    */
   createPasswordResetToken: (authUserId: string) => Promise<string>;
+  /**
+   * Mint a single-use, 24h verification token for a Better Auth identity,
+   * stored in `auth_verifications` under the `email-verify:` namespace.
+   */
+  createEmailVerificationToken: (authUserId: string) => Promise<string>;
+  /** Mark a Better Auth identity's email as verified. */
+  markEmailVerified: (authUserId: string) => Promise<void>;
+  /**
+   * Consume a single-use email-verification token. Returns the auth user id
+   * it was minted for, or null when the token is unknown/expired/already used.
+   */
+  consumeEmailVerificationToken: (token: string) => Promise<string | null>;
   api: {
     createApiKey: (input: {
       body: {
@@ -225,6 +237,35 @@ export function createFlareMoAuth(
 
   return {
     ...auth,
+    createEmailVerificationToken: async (authUserId: string) => {
+      const authContext = await auth.$context;
+      const token = crypto.randomUUID();
+      const identifier = `email-verify:${token}`;
+      await authContext.internalAdapter.createVerificationValue({
+        identifier,
+        value: authUserId,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1_000),
+      });
+      return token;
+    },
+    markEmailVerified: async (authUserId: string) => {
+      const authContext = await auth.$context;
+      await authContext.internalAdapter.updateUser(authUserId, {
+        emailVerified: true,
+        updatedAt: new Date(),
+      });
+    },
+    consumeEmailVerificationToken: async (token: string) => {
+      const authContext = await auth.$context;
+      const identifier = `email-verify:${token}`;
+      const record =
+        await authContext.internalAdapter.findVerificationValue(identifier);
+      if (!record) return null;
+      await authContext.internalAdapter.deleteVerificationByIdentifier(
+        identifier,
+      );
+      return record.value;
+    },
     createPasswordResetToken: async (authUserId: string) => {
       // The token is the verification record's unique identifier under the
       // `reset-password:` prefix Better Auth's reset-password endpoint looks

--- a/apps/worker/src/email.ts
+++ b/apps/worker/src/email.ts
@@ -1,0 +1,86 @@
+import type { FlareMoEnv } from "./env";
+
+/**
+ * Pluggable transactional email for registration verification.
+ *
+ * - `none` (default): self-hosted zero-config; registration does not require
+ *   email verification.
+ * - `cloudflare`: Cloudflare Email Sending (Workers Paid plan) via the
+ *   `EMAIL` binding (`env.EMAIL.send({to, from, subject, html, text})`).
+ *   The sender address must be a verified domain in the account.
+ *
+ * The seam mirrors the embedding/captcha provider pattern: the kernel never
+ * hardcodes a vendor, and a deployment that does not configure a provider
+ * keeps the exact self-hosted behavior.
+ */
+
+export type EmailProvider = "none" | "cloudflare";
+
+export type EmailConfig = {
+  provider: EmailProvider;
+  /** Verified sender address, e.g. "no-reply@flaremo.app". */
+  from: string | null;
+};
+
+export function resolveEmailConfig(env: FlareMoEnv): EmailConfig {
+  const provider = (env.FLAREMO_EMAIL_PROVIDER?.trim() ||
+    "none") as EmailProvider;
+  if (provider === "cloudflare") {
+    return {
+      provider,
+      from: env.FLAREMO_EMAIL_FROM?.trim() || null,
+    };
+  }
+  return { provider: "none", from: null };
+}
+
+export type SendVerificationEmailInput = {
+  to: string;
+  /** Single-use verification token (already minted). */
+  token: string;
+  /** Public origin of the deployment, e.g. https://app.flaremo.app. */
+  publicUrl: string;
+};
+
+/**
+ * Send the registration verification email. Returns false when the provider
+ * is not configured or the send fails — the caller decides whether that
+ * blocks registration (provider configured) or is skipped (provider none).
+ */
+export async function sendVerificationEmail(
+  env: FlareMoEnv,
+  input: SendVerificationEmailInput,
+): Promise<boolean> {
+  const config = resolveEmailConfig(env);
+  if (config.provider === "none" || !config.from) return false;
+
+  const verifyUrl = `${input.publicUrl.replace(/\/+$/, "")}/verify-email?token=${encodeURIComponent(input.token)}`;
+  const html = [
+    '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:0 auto;padding:24px">',
+    '<h2 style="margin:0 0 12px">Verify your email</h2>',
+    '<p style="color:#444;line-height:1.6">Welcome to FlareMo! Confirm this address to finish creating your account.</p>',
+    `<p><a href="${verifyUrl}" style="display:inline-block;background:#f97316;color:#fff;text-decoration:none;padding:10px 20px;border-radius:8px">Verify email</a></p>`,
+    `<p style="color:#888;font-size:12px">Or paste this link: ${verifyUrl}</p>`,
+    '<p style="color:#888;font-size:12px">This link expires in 24 hours. If you did not sign up, you can ignore this email.</p>',
+    "</div>",
+  ].join("");
+
+  try {
+    const binding = (
+      env as FlareMoEnv & {
+        EMAIL?: { send: (msg: unknown) => Promise<unknown> };
+      }
+    ).EMAIL;
+    if (!binding) return false;
+    await binding.send({
+      to: input.to,
+      from: config.from,
+      subject: "Verify your FlareMo email",
+      html,
+      text: `Welcome to FlareMo! Confirm this address to finish creating your account.\n\n${verifyUrl}\n\nThis link expires in 24 hours.`,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -4,6 +4,11 @@ export type FlareMoEnv = Env & {
   FLAREMO_RECOVERY_SECRET?: string;
   FLAREMO_PUBLIC_URL?: string;
   FLAREMO_TRUSTED_ORIGINS?: string;
+  // Transactional email for registration verification (see src/email.ts).
+  // `cloudflare` uses the EMAIL binding (Workers Paid); `none` skips
+  // verification entirely (self-host default).
+  FLAREMO_EMAIL_PROVIDER?: string;
+  FLAREMO_EMAIL_FROM?: string;
   // Registration captcha (pluggable provider; see src/captcha.ts). Site key
   // is a public var; secrets are Wrangler secrets. Provider `http` requires
   // FLAREMO_CAPTCHA_VERIFY_URL; `tencent` additionally requires the secret

--- a/apps/worker/src/routes/auth-api.ts
+++ b/apps/worker/src/routes/auth-api.ts
@@ -20,10 +20,12 @@ import { z } from "zod";
 import {
   createFlareMoAuth,
   getBootstrapSecret,
+  getPublicUrl,
   getRecoverySecret,
 } from "../auth";
 import { resolveCaptchaConfig, verifyCaptchaRequest } from "../captcha";
 import type { HonoBindings } from "../context";
+import { resolveEmailConfig, sendVerificationEmail } from "../email";
 import { jsonError } from "../http";
 
 export const authApi = new Hono<HonoBindings>();
@@ -72,6 +74,7 @@ authApi.get("/register/status", async (c) => {
   return c.json({
     registration_open: await getUserRegistrationAllowed(db),
     initialized: status.initialized,
+    email_verification_required: resolveEmailConfig(c.env).provider !== "none",
     captcha: {
       provider: captcha.provider,
       site_key: captcha.siteKey,
@@ -142,6 +145,23 @@ authApi.post("/register", zValidator("json", registerSchema), async (c) => {
       },
       c.get("planLimits") ?? SELF_HOST_UNLIMITED,
     );
+    // When a transactional-email provider is configured, registration is not
+    // complete until the address is verified; the account can still sign in
+    // but the UI prompts for verification.
+    if (resolveEmailConfig(c.env).provider !== "none") {
+      const token = await auth.createEmailVerificationToken(result.user.id);
+      const sent = await sendVerificationEmail(c.env, {
+        to: email,
+        token,
+        publicUrl: getPublicUrl(c.env),
+      });
+      if (!sent) {
+        return c.json(
+          { error: { message: "Verification email could not be sent." } },
+          502,
+        );
+      }
+    }
     return c.json({ ok: true }, 201);
   } catch (error) {
     // A spent member quota must surface as its own status, not drown in the
@@ -154,6 +174,24 @@ authApi.post("/register", zValidator("json", registerSchema), async (c) => {
       400,
     );
   }
+});
+
+authApi.get("/verify-email", async (c) => {
+  const token = c.req.query("token");
+  if (!token) {
+    return c.json({ error: { message: "Missing verification token." } }, 400);
+  }
+  const db = createDb(c.env.DB);
+  const auth = createFlareMoAuth(c.env, db);
+  const authUserId = await auth.consumeEmailVerificationToken(token);
+  if (!authUserId) {
+    return c.json(
+      { error: { message: "Verification link is invalid or expired." } },
+      400,
+    );
+  }
+  await auth.markEmailVerified(authUserId);
+  return c.json({ ok: true });
 });
 
 authApi.post("/bootstrap", zValidator("json", bootstrapSchema), async (c) => {


### PR DESCRIPTION
Closes #117

按 Kim 拍板：**不要验证码，只做邮件验证**，用 Cloudflare Workers Paid 计划的 Email Sending（`env.EMAIL.send()`），不接第三方发信商。

- email provider seam（`none` | `cloudflare`，对齐 embedding/captcha 模式）：`FLAREMO_EMAIL_PROVIDER` + `FLAREMO_EMAIL_FROM`；`none` 时自托管注册行为与之前完全一致（不强制验证）
- 注册：配置了 provider 时，mint 单次 24h token（`auth_verifications`，`email-verify:` 命名空间，与密码重置同一机制）并发送验证邮件；发送失败返回 502（fail-closed，不产生静默未验证账号）
- `GET /api/auth/flaremo/verify-email?token=` 消费 token、置 `auth_users.email_verified`，单次使用（消费即删）
- `/register/status` 暴露 `email_verification_required`；注册页成功后显示「查收邮件」状态而非直接跳登录；新增 `/verify-email` 页（成功/过期两态，zh/en）
- wrangler：`send_email` binding（EMAIL）文档化

验证：`pnpm verify` 全绿（含 worker 用例：注册发信、status 标记、未知 token 400）。

部署注意：SaaS 实例需在 Cloudflare 控制台开通 Email Sending 并验证发件域名（SPF/DKIM），然后 `wrangler.jsonc` 加 `send_email` binding + `FLAREMO_EMAIL_PROVIDER=cloudflare` + `FLAREMO_EMAIL_FROM`。