### PR TITLE
feat(auth): resend verification, self-service password reset, verified email change

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -123,6 +123,16 @@ const VerifyEmailPage = lazy(() =>
     default: module.VerifyEmailPage,
   })),
 );
+const ForgotPasswordPage = lazy(() =>
+  import("@/pages/forgot-password-page").then((module) => ({
+    default: module.ForgotPasswordPage,
+  })),
+);
+const VerifyEmailChangePage = lazy(() =>
+  import("@/pages/verify-email-change-page").then((module) => ({
+    default: module.VerifyEmailChangePage,
+  })),
+);
 const RecoverPage = lazy(() =>
   import("@/pages/recover-page").then((module) => ({
     default: module.RecoverPage,
@@ -1195,6 +1205,38 @@ const verifyEmailRoute = createRoute({
   }),
 });
 
+function ForgotPasswordRoutePage() {
+  return (
+    <Suspense fallback={<RouteLoading />}>
+      <ForgotPasswordPage />
+    </Suspense>
+  );
+}
+
+const forgotPasswordRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/forgot-password",
+  component: ForgotPasswordRoutePage,
+});
+
+function VerifyEmailChangeRoutePage() {
+  const { token } = verifyEmailChangeRoute.useSearch();
+  return (
+    <Suspense fallback={<RouteLoading />}>
+      <VerifyEmailChangePage token={token ?? ""} />
+    </Suspense>
+  );
+}
+
+const verifyEmailChangeRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/verify-email-change",
+  component: VerifyEmailChangeRoutePage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: typeof search.token === "string" ? search.token : undefined,
+  }),
+});
+
 function ResetRoutePage() {
   const { token } = resetRoute.useSearch();
   return (
@@ -1389,6 +1431,8 @@ const router = createRouter({
     loginRoute,
     registerRoute,
     verifyEmailRoute,
+    forgotPasswordRoute,
+    verifyEmailChangeRoute,
     resetRoute,
     recoverRoute,
     setupRoute,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -578,6 +578,36 @@ export async function verifyEmail(token: string) {
   );
 }
 
+export async function resendVerificationEmail(email: string) {
+  return apiRequest<{ ok: true }>(
+    "/api/auth/flaremo/resend-verification",
+    {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    },
+    { authRequired: false },
+  );
+}
+
+export async function requestPasswordReset(email: string) {
+  return apiRequest<{ ok: true }>(
+    "/api/auth/flaremo/forgot-password",
+    {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    },
+    { authRequired: false },
+  );
+}
+
+export async function verifyEmailChange(token: string) {
+  return apiRequest<{ ok: true }>(
+    `/api/auth/flaremo/verify-email-change?token=${encodeURIComponent(token)}`,
+    {},
+    { authRequired: false },
+  );
+}
+
 export async function getCurrentFlareMoUser() {
   return apiRequest<CurrentFlareMoUser>("/api/app/me");
 }
@@ -716,10 +746,13 @@ export async function changeEmail(input: {
   current_password: string;
   new_email: string;
 }) {
-  return apiRequest<{ ok: true }>("/api/app/account/email", {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
+  return apiRequest<{ ok: true; verification_sent?: boolean }>(
+    "/api/app/account/email",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+  );
 }
 
 export async function createMemo(input: CreateMemoRequest) {

--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -155,7 +155,7 @@ const messages = {
     "detail.revokeShare": "撤销分享",
     "toast.accessRequired": "登录状态已失效，请重新登录",
     "auth.loginTitle": "登录 FlareMo",
-    "auth.forgotPasswordHint": "忘记密码？用部署时配置的恢复密钥重置。",
+    "auth.forgotPasswordHint": "忘记密码？",
     "auth.username": "用户名",
     "auth.password": "密码",
     "auth.signIn": "登录",
@@ -258,6 +258,26 @@ const messages = {
     "auth.verifyEmailVerifying": "正在验证…",
     "auth.verifyEmailSuccess": "邮箱已验证，现在可以登录了。",
     "auth.verifyEmailInvalid": "验证链接无效或已过期，请重新注册或联系管理员。",
+    "auth.forgotPasswordTitle": "重置密码",
+    "auth.forgotPasswordDescription":
+      "输入注册邮箱，我们会发送一封包含重置链接的邮件。",
+    "auth.forgotPasswordSubmit": "发送重置链接",
+    "auth.forgotPasswordSending": "发送中…",
+    "auth.forgotPasswordSent":
+      "如果该邮箱已注册，重置邮件已发出（1 小时内有效）。请到邮箱点击链接设置新密码。",
+    "auth.forgotPasswordSelfHostHint":
+      "此部署未配置邮件服务，请使用恢复密钥重置：",
+    "auth.forgotPasswordRecoverLink": "打开恢复页面",
+    "auth.forgotPasswordFailed": "发送失败，请稍后再试。",
+    "auth.resendVerification": "重新发送验证邮件",
+    "auth.resendVerificationSending": "发送中…",
+    "auth.resendVerificationSent": "验证邮件已重新发送，请查收。",
+    "auth.emailChangeVerificationSent":
+      "确认邮件已发送到新邮箱，点击邮件里的链接后新邮箱才会生效。",
+    "auth.verifyEmailChangeTitle": "确认新邮箱",
+    "auth.verifyEmailChangeSuccess": "新邮箱已生效，下次请使用新邮箱登录。",
+    "auth.verifyEmailChangeInvalid":
+      "链接无效或已过期，请到账户页重新发起修改。",
     "auth.registering": "正在注册…",
     "auth.registerFailed": "注册失败，请检查输入后重试。",
     "auth.registrationClosed": "当前未开放注册，请联系管理员。",
@@ -618,8 +638,7 @@ const messages = {
     "detail.revokeShare": "Revoke share",
     "toast.accessRequired": "Your sign-in has expired. Please sign in again.",
     "auth.loginTitle": "Sign in to FlareMo",
-    "auth.forgotPasswordHint":
-      "Forgot your password? Reset it with the recovery secret from your deployment.",
+    "auth.forgotPasswordHint": "Forgot your password?",
     "auth.username": "Username",
     "auth.password": "Password",
     "auth.signIn": "Sign in",
@@ -732,6 +751,29 @@ const messages = {
     "auth.verifyEmailSuccess": "Email verified. You can sign in now.",
     "auth.verifyEmailInvalid":
       "This verification link is invalid or expired. Please register again or contact the administrator.",
+    "auth.forgotPasswordTitle": "Reset your password",
+    "auth.forgotPasswordDescription":
+      "Enter your account email and we'll send you a reset link.",
+    "auth.forgotPasswordSubmit": "Send reset link",
+    "auth.forgotPasswordSending": "Sending…",
+    "auth.forgotPasswordSent":
+      "If that address is registered, a reset email is on its way. The link expires in 1 hour — click it to choose a new password.",
+    "auth.forgotPasswordSelfHostHint":
+      "This deployment has no email provider configured. Reset with the recovery key instead:",
+    "auth.forgotPasswordRecoverLink": "Open recovery page",
+    "auth.forgotPasswordFailed":
+      "Could not send the reset email. Try again later.",
+    "auth.resendVerification": "Resend verification email",
+    "auth.resendVerificationSending": "Sending…",
+    "auth.resendVerificationSent":
+      "Verification email resent. Check your inbox.",
+    "auth.emailChangeVerificationSent":
+      "A confirmation email was sent to your new address. The change takes effect after you click the link in it.",
+    "auth.verifyEmailChangeTitle": "Confirm new email",
+    "auth.verifyEmailChangeSuccess":
+      "New email confirmed. Use it to sign in from now on.",
+    "auth.verifyEmailChangeInvalid":
+      "This link is invalid or has expired. Start the change again from your account page.",
     "auth.registering": "Signing up…",
     "auth.registerFailed": "Sign-up failed. Check your input and try again.",
     "auth.registrationClosed":

--- a/apps/web/src/pages/account-page.tsx
+++ b/apps/web/src/pages/account-page.tsx
@@ -55,6 +55,8 @@ export function AccountPage() {
   const [accountError, setAccountError] = useState<string | null>(null);
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [emailError, setEmailError] = useState<string | null>(null);
+  const [emailVerificationPending, setEmailVerificationPending] =
+    useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -103,7 +105,10 @@ export function AccountPage() {
   });
   const changeEmailMutation = useMutation({
     mutationFn: changeEmail,
-    onSuccess: async () => {
+    onSuccess: async (result) => {
+      // With an email provider configured the change is only staged: the new
+      // address must confirm ownership before the login identity switches.
+      setEmailVerificationPending(result.verification_sent === true);
       await session.refetch();
     },
   });
@@ -162,6 +167,7 @@ export function AccountPage() {
 
   const handleEmailSubmit = async () => {
     setEmailError(null);
+    setEmailVerificationPending(false);
     try {
       await changeEmailMutation.mutateAsync({
         current_password: emailCurrentPassword,
@@ -403,6 +409,11 @@ export function AccountPage() {
                 <CardTitle>{t("auth.emailTitle")}</CardTitle>
               </CardHeader>
               <CardContent>
+                {emailVerificationPending && (
+                  <p className="mb-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-800 dark:text-emerald-200">
+                    {t("auth.emailChangeVerificationSent")}
+                  </p>
+                )}
                 <form
                   className="grid gap-3 sm:grid-cols-2"
                   onSubmit={(event) => {

--- a/apps/web/src/pages/forgot-password-page.tsx
+++ b/apps/web/src/pages/forgot-password-page.tsx
@@ -1,0 +1,120 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useState } from "react";
+import { getRegistrationStatus, requestPasswordReset } from "@/api";
+import { AuthPageFrame, errorMessage } from "@/components/auth-page-frame";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useI18n } from "@/i18n";
+
+export function ForgotPasswordPage() {
+  const { t } = useI18n();
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // The registration status is public and doubles as the deployment's
+  // "transactional email configured" signal: without an email provider the
+  // only reset path is the self-hosted recovery-key flow.
+  const statusQuery = useQuery({
+    queryKey: ["register-status"],
+    queryFn: getRegistrationStatus,
+    retry: false,
+  });
+  const emailProviderEnabled =
+    statusQuery.data?.email_verification_required === true;
+
+  const handleSubmit = async () => {
+    setFormError(null);
+    setIsSubmitting(true);
+    try {
+      await requestPasswordReset(email.trim());
+      setSent(true);
+    } catch (error) {
+      setFormError(errorMessage(error, t("auth.forgotPasswordFailed")));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (sent) {
+    return (
+      <AuthPageFrame title={t("auth.forgotPasswordTitle")}>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm leading-6 text-muted-foreground">
+            {t("auth.forgotPasswordSent")}
+          </p>
+          <Link
+            className="text-sm font-medium text-flame-600 underline-offset-4 hover:underline"
+            to="/login"
+          >
+            {t("auth.signIn")}
+          </Link>
+        </div>
+      </AuthPageFrame>
+    );
+  }
+
+  return (
+    <AuthPageFrame
+      description={t("auth.forgotPasswordDescription")}
+      title={t("auth.forgotPasswordTitle")}
+    >
+      {!emailProviderEnabled && (
+        <p className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
+          {t("auth.forgotPasswordSelfHostHint")}{" "}
+          <Link className="underline underline-offset-4" to="/recover">
+            {t("auth.forgotPasswordRecoverLink")}
+          </Link>
+        </p>
+      )}
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!emailProviderEnabled) return;
+          void handleSubmit();
+        }}
+      >
+        <label
+          className="flex flex-col gap-1.5 text-sm font-medium"
+          htmlFor="forgot-password-email"
+        >
+          {t("auth.email")}
+          <Input
+            autoComplete="email"
+            disabled={isSubmitting || !emailProviderEnabled}
+            id="forgot-password-email"
+            required
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </label>
+        {formError && (
+          <p className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive">
+            {formError}
+          </p>
+        )}
+        <Button
+          disabled={isSubmitting || !emailProviderEnabled}
+          type="submit"
+          variant="brand"
+        >
+          {isSubmitting
+            ? t("auth.forgotPasswordSending")
+            : t("auth.forgotPasswordSubmit")}
+        </Button>
+        <p className="text-center text-sm">
+          <Link
+            className="text-muted-foreground underline-offset-4 hover:underline"
+            to="/login"
+          >
+            {t("auth.signIn")}
+          </Link>
+        </p>
+      </form>
+    </AuthPageFrame>
+  );
+}

--- a/apps/web/src/pages/login-page.tsx
+++ b/apps/web/src/pages/login-page.tsx
@@ -152,7 +152,7 @@ export function LoginPage() {
         <p className="text-center text-sm">
           <Link
             className="text-muted-foreground underline-offset-4 hover:underline"
-            to="/recover"
+            to="/forgot-password"
           >
             {t("auth.forgotPasswordHint")}
           </Link>

--- a/apps/web/src/pages/register-page.tsx
+++ b/apps/web/src/pages/register-page.tsx
@@ -1,10 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link, Navigate, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import {
   getBootstrapStatus,
   getRegistrationStatus,
   registerAccount,
+  resendVerificationEmail,
 } from "@/api";
 import { authClient } from "@/auth-client";
 import { AuthPageFrame, errorMessage } from "@/components/auth-page-frame";
@@ -38,6 +39,11 @@ export function RegisterPage() {
   const [captchaTicket, setCaptchaTicket] = useState<string | null>(null);
   const [captchaRandstr, setCaptchaRandstr] = useState("");
   const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
+  const [resent, setResent] = useState(false);
+  const resendMutation = useMutation({
+    mutationFn: resendVerificationEmail,
+    onSuccess: () => setResent(true),
+  });
 
   if (session.data?.user) {
     return (
@@ -118,6 +124,24 @@ export function RegisterPage() {
           <p className="text-sm leading-6 text-muted-foreground">
             {t("auth.verifyEmailHint")}
           </p>
+          {resent ? (
+            <p className="text-sm leading-6 text-emerald-700 dark:text-emerald-300">
+              {t("auth.resendVerificationSent")}
+            </p>
+          ) : (
+            <Button
+              disabled={resendMutation.isPending || !registeredEmail}
+              onClick={() =>
+                registeredEmail &&
+                void resendMutation.mutateAsync(registeredEmail)
+              }
+              variant="outline"
+            >
+              {resendMutation.isPending
+                ? t("auth.resendVerificationSending")
+                : t("auth.resendVerification")}
+            </Button>
+          )}
           <Link
             className="text-sm font-medium text-flame-600 underline-offset-4 hover:underline"
             to="/login"

--- a/apps/web/src/pages/verify-email-change-page.tsx
+++ b/apps/web/src/pages/verify-email-change-page.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { verifyEmailChange } from "@/api";
+import { AuthPageFrame } from "@/components/auth-page-frame";
+import { useI18n } from "@/i18n";
+
+export function VerifyEmailChangePage({ token }: { token: string }) {
+  const { t } = useI18n();
+  const [result, setResult] = useState<"pending" | "ok" | "error">("pending");
+
+  const verifyQuery = useQuery({
+    queryKey: ["verify-email-change", token],
+    queryFn: () => verifyEmailChange(token),
+    retry: false,
+    enabled: token.length > 0,
+  });
+
+  useEffect(() => {
+    if (token.length === 0) {
+      setResult("error");
+      return;
+    }
+    if (verifyQuery.isSuccess) setResult("ok");
+    if (verifyQuery.isError) setResult("error");
+  }, [token, verifyQuery.isSuccess, verifyQuery.isError]);
+
+  return (
+    <AuthPageFrame title={t("auth.verifyEmailChangeTitle")}>
+      {result === "pending" && (
+        <p className="text-sm text-muted-foreground">
+          {t("auth.verifyEmailVerifying")}
+        </p>
+      )}
+      {result === "ok" && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm leading-6 text-muted-foreground">
+            {t("auth.verifyEmailChangeSuccess")}
+          </p>
+          <Link
+            className="text-sm font-medium text-flame-600 underline-offset-4 hover:underline"
+            to="/login"
+          >
+            {t("auth.signIn")}
+          </Link>
+        </div>
+      )}
+      {result === "error" && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm leading-6 text-destructive">
+            {t("auth.verifyEmailChangeInvalid")}
+          </p>
+          <Link
+            className="text-sm font-medium text-flame-600 underline-offset-4 hover:underline"
+            to="/login"
+          >
+            {t("auth.signIn")}
+          </Link>
+        </div>
+      )}
+    </AuthPageFrame>
+  );
+}

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -1805,6 +1805,290 @@ describe("FlareMo Worker API", () => {
     expect(bad.status).toBe(400);
   });
 
+  it("supports resend verification, self-service reset, and verified email change", async () => {
+    const emailApp = createFlareMoApp();
+    const open = await emailApp.fetch(
+      new Request("http://flaremo.test/api/app/admin/settings", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          cookie: sessionCookie,
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ registration_open: true }),
+      }),
+      env,
+    );
+    expect(open.status).toBe(200);
+
+    const emailEnv = {
+      ...env,
+      FLAREMO_EMAIL_PROVIDER: "cloudflare",
+      FLAREMO_EMAIL_FROM: "no-reply@flaremo.test",
+    } as Env;
+    const sent: Array<{ to: string; subject: string; text: string }> = [];
+    const emailBinding = {
+      send: async (msg: { to: string; subject: string; text: string }) => {
+        sent.push(msg);
+        return { ok: true };
+      },
+    };
+    const appEnv = { ...emailEnv, EMAIL: emailBinding } as Env;
+
+    const register = (email: string) =>
+      emailApp.fetch(
+        new Request("http://flaremo.test/api/auth/flaremo/register", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            origin: "http://flaremo.test",
+          },
+          body: JSON.stringify({
+            name: "Member",
+            email,
+            password: TEST_PASSWORD,
+          }),
+        }),
+        appEnv,
+      );
+    expect((await register("lifecycle@example.com")).status).toBe(201);
+    expect((await register("other@example.com")).status).toBe(201);
+    expect(sent).toHaveLength(2);
+
+    // Resend hits the known unverified address only; unknown addresses and
+    // already-verified identities share the same success shape.
+    const resend = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/resend-verification", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ email: "lifecycle@example.com" }),
+      }),
+      appEnv,
+    );
+    expect(resend.status).toBe(200);
+    expect(sent).toHaveLength(3);
+    expect(sent[2]?.subject).toContain("Verify");
+
+    const resendUnknown = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/resend-verification", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ email: "nobody@example.com" }),
+      }),
+      appEnv,
+    );
+    expect(resendUnknown.status).toBe(200);
+    expect(sent).toHaveLength(3);
+
+    // Without an email provider both endpoints refuse outright.
+    const resendNone = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/resend-verification", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ email: "lifecycle@example.com" }),
+      }),
+      env,
+    );
+    expect(resendNone.status).toBe(400);
+
+    // Self-service password reset: the mail carries the one-hour token, the
+    // reset goes through Better Auth's own endpoint, and the old password
+    // stops working.
+    const forgot = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/forgot-password", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ email: "lifecycle@example.com" }),
+      }),
+      appEnv,
+    );
+    expect(forgot.status).toBe(200);
+    expect(sent).toHaveLength(4);
+    expect(sent[3]?.subject).toContain("Reset");
+
+    const forgotUnknown = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/forgot-password", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ email: "nobody@example.com" }),
+      }),
+      appEnv,
+    );
+    expect(forgotUnknown.status).toBe(200);
+    expect(sent).toHaveLength(4);
+
+    const resetToken = /reset\?token=([A-Za-z0-9-]+)/.exec(
+      sent[3]?.text ?? "",
+    )?.[1];
+    expect(resetToken).toBeDefined();
+    const reset = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/reset-password", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          newPassword: `${TEST_PASSWORD}-new`,
+          token: resetToken,
+        }),
+      }),
+      appEnv,
+    );
+    expect(reset.status).toBe(200);
+
+    const oldPassword = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          email: "lifecycle@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      appEnv,
+    );
+    expect(oldPassword.status).toBe(401);
+    const newPassword = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          email: "lifecycle@example.com",
+          password: `${TEST_PASSWORD}-new`,
+        }),
+      }),
+      appEnv,
+    );
+    expect(newPassword.status).toBe(200);
+
+    // Verified email change: the current password authorizes the request,
+    // the new address confirms ownership, and only then does the login
+    // identity switch.
+    const signIn = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          email: "other@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      appEnv,
+    );
+    expect(signIn.status).toBe(200);
+    const memberCookie = extractCookieHeader(signIn);
+
+    const changeRequest = await emailApp.fetch(
+      new Request("http://flaremo.test/api/app/account/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          cookie: memberCookie,
+        },
+        body: JSON.stringify({
+          current_password: TEST_PASSWORD,
+          new_email: "changed@example.com",
+        }),
+      }),
+      appEnv,
+    );
+    expect(changeRequest.status).toBe(200);
+    const changeBody = (await changeRequest.json()) as {
+      verification_sent?: boolean;
+    };
+    expect(changeBody.verification_sent).toBe(true);
+    expect(sent).toHaveLength(5);
+    expect(sent[4]?.to).toBe("changed@example.com");
+
+    const changeToken = /verify-email-change\?token=([A-Za-z0-9-]+)/.exec(
+      sent[4]?.text ?? "",
+    )?.[1];
+    expect(changeToken).toBeDefined();
+    const confirm = await emailApp.fetch(
+      new Request(
+        `http://flaremo.test/api/auth/flaremo/verify-email-change?token=${changeToken}`,
+      ),
+      appEnv,
+    );
+    expect(confirm.status).toBe(200);
+
+    const oldEmail = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          email: "other@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      appEnv,
+    );
+    expect(oldEmail.status).toBe(401);
+    const newEmailSignIn = await emailApp.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          email: "changed@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      appEnv,
+    );
+    expect(newEmailSignIn.status).toBe(200);
+
+    // An in-use target address is rejected before any mail is sent.
+    const takenRequest = await emailApp.fetch(
+      new Request("http://flaremo.test/api/app/account/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          cookie: memberCookie,
+        },
+        body: JSON.stringify({
+          current_password: TEST_PASSWORD,
+          new_email: "lifecycle@example.com",
+        }),
+      }),
+      appEnv,
+    );
+    expect(takenRequest.status).toBe(400);
+    expect(sent).toHaveLength(5);
+  });
+
   it("rejects a registration over the member cap with 429", async () => {
     const quotaApp = createFlareMoApp({
       resolvePlanLimits: () => ({

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -11,6 +11,7 @@ import {
 } from "@flaremo/db";
 import { betterAuth } from "better-auth";
 import { username } from "better-auth/plugins";
+import { eq } from "drizzle-orm";
 import type { FlareMoEnv } from "./env";
 
 export const MEMOS_PAT_CONFIG_ID = "memos";
@@ -92,6 +93,34 @@ export type FlareMoAuth = {
    * it was minted for, or null when the token is unknown/expired/already used.
    */
   consumeEmailVerificationToken: (token: string) => Promise<string | null>;
+  /**
+   * Look up a Better Auth identity by email (normalized lowercase, matching
+   * how Better Auth stores addresses).
+   */
+  findAuthUserByEmail: (email: string) => Promise<{
+    id: string;
+    email: string;
+    emailVerified: boolean;
+  } | null>;
+  /**
+   * Mint a single-use, 24h token authorizing a change of the identity's login
+   * email to `newEmail`. The verification value embeds the current and target
+   * address so consumption cannot be redirected to a different identity.
+   */
+  createEmailChangeToken: (
+    authUserId: string,
+    newEmail: string,
+  ) => Promise<string>;
+  /**
+   * Consume an email-change token. Returns the scoped identity plus the
+   * current and approved new address, or null when the token is
+   * unknown/expired/already used.
+   */
+  consumeEmailChangeToken: (token: string) => Promise<{
+    authUserId: string;
+    currentEmail: string;
+    newEmail: string;
+  } | null>;
   api: {
     createApiKey: (input: {
       body: {
@@ -265,6 +294,74 @@ export function createFlareMoAuth(
         identifier,
       );
       return record.value;
+    },
+    findAuthUserByEmail: async (email) => {
+      const normalized = email.trim().toLowerCase();
+      if (!normalized) return null;
+      const row = await db
+        .select({
+          id: authUsers.id,
+          email: authUsers.email,
+          emailVerified: authUsers.emailVerified,
+        })
+        .from(authUsers)
+        .where(eq(authUsers.email, normalized))
+        .get();
+      return row ?? null;
+    },
+    createEmailChangeToken: async (authUserId, newEmail) => {
+      const authContext = await auth.$context;
+      const current = await db
+        .select({ email: authUsers.email })
+        .from(authUsers)
+        .where(eq(authUsers.id, authUserId))
+        .get();
+      if (!current) {
+        throw new Error("Auth identity not found for email change.");
+      }
+      const token = crypto.randomUUID();
+      const identifier = `email-change:${token}`;
+      await authContext.internalAdapter.createVerificationValue({
+        identifier,
+        value: JSON.stringify({
+          authUserId,
+          currentEmail: current.email,
+          newEmail: newEmail.trim().toLowerCase(),
+        }),
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1_000),
+      });
+      return token;
+    },
+    consumeEmailChangeToken: async (token) => {
+      const authContext = await auth.$context;
+      const identifier = `email-change:${token}`;
+      const record =
+        await authContext.internalAdapter.findVerificationValue(identifier);
+      if (!record) return null;
+      await authContext.internalAdapter.deleteVerificationByIdentifier(
+        identifier,
+      );
+      try {
+        const parsed = JSON.parse(record.value) as {
+          authUserId?: unknown;
+          currentEmail?: unknown;
+          newEmail?: unknown;
+        };
+        if (
+          typeof parsed.authUserId !== "string" ||
+          typeof parsed.currentEmail !== "string" ||
+          typeof parsed.newEmail !== "string"
+        ) {
+          return null;
+        }
+        return {
+          authUserId: parsed.authUserId,
+          currentEmail: parsed.currentEmail,
+          newEmail: parsed.newEmail,
+        };
+      } catch {
+        return null;
+      }
     },
     createPasswordResetToken: async (authUserId: string) => {
       // The token is the verification record's unique identifier under the

--- a/apps/worker/src/email.ts
+++ b/apps/worker/src/email.ts
@@ -42,28 +42,24 @@ export type SendVerificationEmailInput = {
   publicUrl: string;
 };
 
+type DeliverEmailInput = {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+};
+
 /**
- * Send the registration verification email. Returns false when the provider
- * is not configured or the send fails — the caller decides whether that
- * blocks registration (provider configured) or is skipped (provider none).
+ * Deliver a transactional email through the configured provider. Returns
+ * false when no provider is configured or the send fails; the caller decides
+ * whether that blocks the flow.
  */
-export async function sendVerificationEmail(
+async function deliverEmail(
   env: FlareMoEnv,
-  input: SendVerificationEmailInput,
+  input: DeliverEmailInput,
 ): Promise<boolean> {
   const config = resolveEmailConfig(env);
   if (config.provider === "none" || !config.from) return false;
-
-  const verifyUrl = `${input.publicUrl.replace(/\/+$/, "")}/verify-email?token=${encodeURIComponent(input.token)}`;
-  const html = [
-    '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:0 auto;padding:24px">',
-    '<h2 style="margin:0 0 12px">Verify your email</h2>',
-    '<p style="color:#444;line-height:1.6">Welcome to FlareMo! Confirm this address to finish creating your account.</p>',
-    `<p><a href="${verifyUrl}" style="display:inline-block;background:#f97316;color:#fff;text-decoration:none;padding:10px 20px;border-radius:8px">Verify email</a></p>`,
-    `<p style="color:#888;font-size:12px">Or paste this link: ${verifyUrl}</p>`,
-    '<p style="color:#888;font-size:12px">This link expires in 24 hours. If you did not sign up, you can ignore this email.</p>',
-    "</div>",
-  ].join("");
 
   try {
     const binding = (
@@ -75,12 +71,108 @@ export async function sendVerificationEmail(
     await binding.send({
       to: input.to,
       from: config.from,
-      subject: "Verify your FlareMo email",
-      html,
-      text: `Welcome to FlareMo! Confirm this address to finish creating your account.\n\n${verifyUrl}\n\nThis link expires in 24 hours.`,
+      subject: input.subject,
+      html: input.html,
+      text: input.text,
     });
     return true;
   } catch {
     return false;
   }
+}
+
+function actionButtonHtml(url: string, label: string) {
+  return `<p><a href="${url}" style="display:inline-block;background:#f97316;color:#fff;text-decoration:none;padding:10px 20px;border-radius:8px">${label}</a></p>`;
+}
+
+function footerHtml(url: string, expiryHours: number, ignoreNote: string) {
+  return [
+    `<p style="color:#888;font-size:12px">Or paste this link: ${url}</p>`,
+    `<p style="color:#888;font-size:12px">This link expires in ${expiryHours} hours. ${ignoreNote}</p>`,
+  ].join("");
+}
+
+/**
+ * Send the registration verification email.
+ */
+export async function sendVerificationEmail(
+  env: FlareMoEnv,
+  input: SendVerificationEmailInput,
+): Promise<boolean> {
+  const verifyUrl = `${input.publicUrl.replace(/\/+$/, "")}/verify-email?token=${encodeURIComponent(input.token)}`;
+  return deliverEmail(env, {
+    to: input.to,
+    subject: "Verify your FlareMo email",
+    html: [
+      '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:0 auto;padding:24px">',
+      '<h2 style="margin:0 0 12px">Verify your email</h2>',
+      '<p style="color:#444;line-height:1.6">Welcome to FlareMo! Confirm this address to finish creating your account.</p>',
+      actionButtonHtml(verifyUrl, "Verify email"),
+      footerHtml(
+        verifyUrl,
+        24,
+        "If you did not sign up, you can ignore this email.",
+      ),
+      "</div>",
+    ].join(""),
+    text: `Welcome to FlareMo! Confirm this address to finish creating your account.\n\n${verifyUrl}\n\nThis link expires in 24 hours.`,
+  });
+}
+
+/**
+ * Send the self-service password reset email. The link opens the existing
+ * /reset page, which submits the token to Better Auth's reset-password
+ * endpoint; the recipient always sets their own new password.
+ */
+export async function sendPasswordResetEmail(
+  env: FlareMoEnv,
+  input: SendVerificationEmailInput,
+): Promise<boolean> {
+  const resetUrl = `${input.publicUrl.replace(/\/+$/, "")}/reset?token=${encodeURIComponent(input.token)}`;
+  return deliverEmail(env, {
+    to: input.to,
+    subject: "Reset your FlareMo password",
+    html: [
+      '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:0 auto;padding:24px">',
+      '<h2 style="margin:0 0 12px">Reset your password</h2>',
+      '<p style="color:#444;line-height:1.6">We received a request to reset the FlareMo password for this address. Click below to choose a new one.</p>',
+      actionButtonHtml(resetUrl, "Reset password"),
+      footerHtml(
+        resetUrl,
+        1,
+        "If you did not request this, you can ignore this email and your password stays unchanged.",
+      ),
+      "</div>",
+    ].join(""),
+    text: `We received a request to reset the FlareMo password for this address.\n\n${resetUrl}\n\nThis link expires in 1 hour. If you did not request this, ignore this email.`,
+  });
+}
+
+/**
+ * Send the "verify your new email address" mail for an email change. The
+ * change only takes effect after the recipient confirms ownership of the new
+ * address through this link.
+ */
+export async function sendEmailChangeVerificationEmail(
+  env: FlareMoEnv,
+  input: SendVerificationEmailInput,
+): Promise<boolean> {
+  const verifyUrl = `${input.publicUrl.replace(/\/+$/, "")}/verify-email-change?token=${encodeURIComponent(input.token)}`;
+  return deliverEmail(env, {
+    to: input.to,
+    subject: "Confirm your new FlareMo email",
+    html: [
+      '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:0 auto;padding:24px">',
+      '<h2 style="margin:0 0 12px">Confirm your new email</h2>',
+      '<p style="color:#444;line-height:1.6">A request was made to use this address as your FlareMo login email. Confirm it to finish the change.</p>',
+      actionButtonHtml(verifyUrl, "Confirm new email"),
+      footerHtml(
+        verifyUrl,
+        24,
+        "Your current email keeps working until you confirm. If this was not you, ignore this email.",
+      ),
+      "</div>",
+    ].join(""),
+    text: `A request was made to use this address as your FlareMo login email.\n\n${verifyUrl}\n\nThis link expires in 24 hours. Your current email keeps working until you confirm.`,
+  });
 }

--- a/apps/worker/src/routes/account-api.ts
+++ b/apps/worker/src/routes/account-api.ts
@@ -1,5 +1,6 @@
 import {
   getMemosPersonalAccessToken,
+  isFlaremoUserEmailTaken,
   listMemosPersonalAccessTokens,
   NotFoundError,
   updateFlaremoUserEmail,
@@ -8,8 +9,9 @@ import {
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-import { createFlareMoAuth, MEMOS_PAT_CONFIG_ID } from "../auth";
+import { createFlareMoAuth, getPublicUrl, MEMOS_PAT_CONFIG_ID } from "../auth";
 import { getBrowserRequestContext, type HonoBindings } from "../context";
+import { resolveEmailConfig, sendEmailChangeVerificationEmail } from "../email";
 import { jsonError } from "../http";
 
 export const accountApi = new Hono<HonoBindings>();
@@ -103,7 +105,7 @@ accountApi.post("/email", zValidator("json", changeEmailSchema), async (c) => {
   try {
     const context = await getBrowserRequestContext(c);
     const input = c.req.valid("json");
-    const newEmail = input.new_email.trim();
+    const newEmail = input.new_email.trim().toLowerCase();
     const auth = createFlareMoAuth(c.env, context.db);
 
     // Changing the login identity re-authenticates the caller with their
@@ -119,8 +121,44 @@ accountApi.post("/email", zValidator("json", changeEmailSchema), async (c) => {
       throw new ValidationError("The current password is incorrect.");
     }
 
-    // The auth credential is updated first so a failed domain write cannot
-    // leave a login identity pointing at a stale address.
+    // When a transactional-email provider is configured, the change only
+    // takes effect after the NEW address confirms ownership through its
+    // verification link, so a typo cannot lock the account out of every
+    // future email flow.
+    if (resolveEmailConfig(c.env).provider !== "none") {
+      const existingAuthUser = await auth.findAuthUserByEmail(newEmail);
+      if (existingAuthUser && existingAuthUser.id !== context.authUserId) {
+        throw new ValidationError("That email is already in use.");
+      }
+      if (
+        await isFlaremoUserEmailTaken(context.db, newEmail, context.user.id)
+      ) {
+        throw new ValidationError("That email is already in use.");
+      }
+      const token = await auth.createEmailChangeToken(
+        context.authUserId,
+        newEmail,
+      );
+      const sent = await sendEmailChangeVerificationEmail(c.env, {
+        to: newEmail,
+        token,
+        publicUrl: getPublicUrl(c.env),
+      });
+      if (!sent) {
+        return c.json(
+          { error: { message: "Verification email could not be sent." } },
+          502,
+        );
+      }
+      const response = c.json({ ok: true, verification_sent: true });
+      response.headers.set("cache-control", "no-store");
+      return response;
+    }
+
+    // Self-hosted deployments without an email provider keep the immediate
+    // change: there is no verification channel, and blocking would strand
+    // operators. The auth credential is updated first so a failed domain
+    // write cannot leave a login identity pointing at a stale address.
     await auth.changeEmail({
       currentEmail: context.user.email,
       newEmail,

--- a/apps/worker/src/routes/auth-api.ts
+++ b/apps/worker/src/routes/auth-api.ts
@@ -6,13 +6,16 @@ import {
   createFlaremoMemberWithLink,
   deriveUniqueUsername,
   getAuthBootstrapStatus,
+  getFlaremoUserByAuthUserId,
   getOwnerAuthUserId,
   getUserRegistrationAllowed,
   listMemosPersonalAccessTokens,
   markOwnerBootstrapRecoveryRequired,
+  NotFoundError,
   QuotaExceededError,
   reconcileOwnerBootstrap,
   SELF_HOST_UNLIMITED,
+  updateFlaremoUserEmail,
 } from "@flaremo/domain";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -25,7 +28,12 @@ import {
 } from "../auth";
 import { resolveCaptchaConfig, verifyCaptchaRequest } from "../captcha";
 import type { HonoBindings } from "../context";
-import { resolveEmailConfig, sendVerificationEmail } from "../email";
+import {
+  resolveEmailConfig,
+  sendEmailChangeVerificationEmail,
+  sendPasswordResetEmail,
+  sendVerificationEmail,
+} from "../email";
 import { jsonError } from "../http";
 
 export const authApi = new Hono<HonoBindings>();
@@ -192,6 +200,143 @@ authApi.get("/verify-email", async (c) => {
   }
   await auth.markEmailVerified(authUserId);
   return c.json({ ok: true });
+});
+
+const emailRequestSchema = z.object({
+  email: z.string().trim().email().max(320),
+});
+
+authApi.post(
+  "/resend-verification",
+  zValidator("json", emailRequestSchema),
+  async (c) => {
+    if (resolveEmailConfig(c.env).provider === "none") {
+      return c.json(
+        { error: { message: "Email verification is not enabled." } },
+        400,
+      );
+    }
+    const db = createDb(c.env.DB);
+    let auth: ReturnType<typeof createFlareMoAuth>;
+    try {
+      auth = createFlareMoAuth(c.env, db);
+    } catch {
+      return c.json(
+        { error: { message: "Native authentication is not configured." } },
+        503,
+      );
+    }
+    try {
+      const input = c.req.valid("json");
+      const user = await auth.findAuthUserByEmail(input.email);
+      // Unknown addresses and already-verified identities share the same
+      // success shape so this endpoint cannot enumerate accounts.
+      if (!user || user.emailVerified) {
+        return c.json({ ok: true });
+      }
+      const token = await auth.createEmailVerificationToken(user.id);
+      const sent = await sendVerificationEmail(c.env, {
+        to: user.email,
+        token,
+        publicUrl: getPublicUrl(c.env),
+      });
+      if (!sent) {
+        return c.json(
+          { error: { message: "Verification email could not be sent." } },
+          502,
+        );
+      }
+      return c.json({ ok: true });
+    } catch (error) {
+      return jsonError(c, error);
+    }
+  },
+);
+
+authApi.post(
+  "/forgot-password",
+  zValidator("json", emailRequestSchema),
+  async (c) => {
+    if (resolveEmailConfig(c.env).provider === "none") {
+      return c.json(
+        { error: { message: "Password reset email is not configured." } },
+        400,
+      );
+    }
+    const db = createDb(c.env.DB);
+    let auth: ReturnType<typeof createFlareMoAuth>;
+    try {
+      auth = createFlareMoAuth(c.env, db);
+    } catch {
+      return c.json(
+        { error: { message: "Native authentication is not configured." } },
+        503,
+      );
+    }
+    try {
+      const input = c.req.valid("json");
+      const user = await auth.findAuthUserByEmail(input.email);
+      // The response never distinguishes known from unknown addresses so the
+      // endpoint cannot be used to enumerate registered emails.
+      if (!user) {
+        return c.json({ ok: true });
+      }
+      const token = await auth.createPasswordResetToken(user.id);
+      const sent = await sendPasswordResetEmail(c.env, {
+        to: user.email,
+        token,
+        publicUrl: getPublicUrl(c.env),
+      });
+      if (!sent) {
+        return c.json(
+          { error: { message: "Password reset email could not be sent." } },
+          502,
+        );
+      }
+      return c.json({ ok: true });
+    } catch (error) {
+      return jsonError(c, error);
+    }
+  },
+);
+
+authApi.get("/verify-email-change", async (c) => {
+  const token = c.req.query("token");
+  if (!token) {
+    return c.json({ error: { message: "Missing verification token." } }, 400);
+  }
+  const db = createDb(c.env.DB);
+  const auth = createFlareMoAuth(c.env, db);
+  const change = await auth.consumeEmailChangeToken(token);
+  if (!change) {
+    return c.json(
+      { error: { message: "Verification link is invalid or expired." } },
+      400,
+    );
+  }
+  try {
+    // Re-check occupancy at confirmation time: the target address may have
+    // been claimed between the change request and this click.
+    const existing = await auth.findAuthUserByEmail(change.newEmail);
+    if (existing && existing.id !== change.authUserId) {
+      return c.json(
+        { error: { message: "That email is already in use." } },
+        409,
+      );
+    }
+    const flaremoUser = await getFlaremoUserByAuthUserId(db, change.authUserId);
+    if (!flaremoUser) {
+      throw new NotFoundError("Account not found");
+    }
+    await auth.changeEmail({
+      currentEmail: change.currentEmail,
+      newEmail: change.newEmail,
+    });
+    await updateFlaremoUserEmail(db, flaremoUser, change.newEmail);
+    return c.json({ ok: true });
+  } catch (error) {
+    return jsonError(c, error);
+  }
 });
 
 authApi.post("/bootstrap", zValidator("json", bootstrapSchema), async (c) => {

--- a/packages/domain/src/users.ts
+++ b/packages/domain/src/users.ts
@@ -172,6 +172,23 @@ export async function deleteFlaremoUser(
  * copy in sync and enforces the table's unique-email constraint. The email is
  * normalized to lowercase so the two unique email columns stay comparable.
  */
+/**
+ * Whether the business `users` table already holds this (lowercased) email.
+ * Used for early conflict feedback on email-change requests; the authoritative
+ * unique-constraint enforcement stays inside updateFlaremoUserEmail.
+ */
+export async function isFlaremoUserEmailTaken(
+  db: FlareMoDb,
+  email: string,
+  excludeUserId?: string,
+): Promise<boolean> {
+  const normalized = email.trim().toLowerCase();
+  const taken = await db.query.users.findFirst({
+    where: eq(users.email, normalized),
+  });
+  return Boolean(taken && taken.id !== excludeUserId);
+}
+
 export async function updateFlaremoUserEmail(
   db: FlareMoDb,
   user: UserRow,


### PR DESCRIPTION
Closes #118

把 #117 上线的邮箱验证补成完整闭环：

- **重发验证邮件**：POST /api/auth/flaremo/resend-verification。未知地址与已验证身份返回同样的成功形态，不可用于枚举账号；provider 未配置时 400。
- **自助找回密码**：POST /forgot-password 发送 1 小时有效的重置邮件，链接走现有 /reset 页面 + Better Auth 原生 /api/auth/reset-password 端点（重置后撤销全部 session）。
- **换邮箱验证新地址**：配置邮件 provider 后，改邮箱只先验证当前密码 + 新地址占用，再发确认邮件；点击 /verify-email-change 链接后才切换 auth 与 domain 两处邮箱。provider 为 none 的自托管保持立即生效。
- 前端：登录页忘记密码入口改指 /forgot-password（自托管无邮件时引导 /recover），注册完成页支持重发，账户页显示待确认状态；中英文案齐全。

验证：pnpm verify（31 worker 测试含新增全链路用例、24 e2e 全过）