### PR TITLE
feat(auth): require email verification for compat signups

### DIFF
--- a/apps/worker/src/memos-transport.test.ts
+++ b/apps/worker/src/memos-transport.test.ts
@@ -41,6 +41,56 @@ describe("Memos native auth and transport boundaries", () => {
     await mf.dispose();
   });
 
+  it("refuses compat signups when email verification is required", async () => {
+    // Open registration first so the email gate, not the closed switch, is
+    // what rejects these signups.
+    const open = await request("/api/app/admin/settings", {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+        cookie: sessionCookie,
+      },
+      body: JSON.stringify({ registration_open: true }),
+    });
+    expect(open.status).toBe(200);
+
+    env.FLAREMO_EMAIL_PROVIDER = "cloudflare";
+    env.FLAREMO_EMAIL_FROM = "no-reply@flaremo.test";
+    (env as unknown as { EMAIL: unknown }).EMAIL = {
+      send: async () => ({ ok: true }),
+    };
+
+    // Memos current REST signup.
+    const currentSignup = await request("/api/v1/auth/signup", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://flaremo.test",
+      },
+      body: JSON.stringify({
+        username: "compat-user",
+        password: TEST_PASSWORD,
+      }),
+    });
+    expect(currentSignup.status).toBe(403);
+
+    // Connect protocol SignUp.
+    const connectSignup = await request("/memos.api.v1.AuthService/SignUp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "connect-protocol-version": "1",
+        origin: "http://flaremo.test",
+      },
+      body: JSON.stringify({
+        username: "compat-user",
+        password: TEST_PASSWORD,
+      }),
+    });
+    expect(connectSignup.status).toBe(403);
+  });
+
   it("rejects malformed, forged, expired, and wrongly-scoped native JWTs", async () => {
     const validClaims = {
       type: "access",

--- a/apps/worker/src/routes/memos-connect-api.ts
+++ b/apps/worker/src/routes/memos-connect-api.ts
@@ -18,6 +18,7 @@ import {
   deleteShortcut,
   deleteUserNotification,
   deleteUserWebhook,
+  ForbiddenError,
   finalizeAttachmentDelete,
   getAttachmentById,
   getAuthBootstrapStatus,
@@ -92,6 +93,7 @@ import {
   getRequestContext,
   type HonoBindings,
 } from "../context";
+import { resolveEmailConfig } from "../email";
 import type { FlareMoEnv } from "../env";
 import { fetchLinkMetadata } from "../memos-link-metadata";
 import {
@@ -2905,6 +2907,15 @@ async function connectAuthSignUp(
         "permission_denied",
         "User registration is disabled",
         403,
+      );
+    }
+    // With a transactional-email provider configured, registration requires
+    // verifying a real mailbox through the web app. This compat surface
+    // cannot complete that flow, so refuse rather than minting unverified
+    // accounts that bypass the deployment's anti-abuse gate.
+    if (resolveEmailConfig(c.env).provider !== "none") {
+      throw new ForbiddenError(
+        "Email verification is required. Please use the FlareMo web app to sign up.",
       );
     }
 

--- a/apps/worker/src/routes/memos-current-api.ts
+++ b/apps/worker/src/routes/memos-current-api.ts
@@ -60,6 +60,7 @@ import {
   getRequestContext,
   type HonoBindings,
 } from "../context";
+import { resolveEmailConfig } from "../email";
 import {
   authenticateMemosAccessToken,
   clearMemosRefreshCookie,
@@ -250,6 +251,15 @@ memosCurrentApi.post("/auth/signup", async (c, next) => {
     assertTrustedCookieMutation(c);
     const input = currentSignupSchema.parse(await c.req.json());
     await assertRegistrationOpen(c);
+    // With a transactional-email provider configured, registration requires
+    // verifying a real mailbox through the web app. This compat surface
+    // cannot complete that flow, so refuse rather than minting unverified
+    // accounts that bypass the deployment's anti-abuse gate.
+    if (resolveEmailConfig(c.env).provider !== "none") {
+      throw new ForbiddenCurrentError(
+        "Email verification is required. Please use the FlareMo web app to sign up.",
+      );
+    }
     await verifyCaptchaRequest(c.env, c.req.raw);
     const username = input.username.trim();
     const email = input.email?.trim() || `${username}@flaremo.local`;


### PR DESCRIPTION
Closes #120

email provider 非 none 时（如 SaaS 部署），Memos 兼容注册面返回 403 并提示走 Web 注册页：

- /api/v1/auth/signup（Memos current REST）
- /memos.api.v1.AuthService/SignUp（Connect JSON/binary/gRPC-Web）

自托管 provider=none 行为完全不变。新增 transport 测试覆盖两个端点在 gate 开启时的 403。

验证：pnpm verify（全部通过）