### PR TITLE
feat(auth): optional per-IP rate limiting for credential endpoints

### DIFF
--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -2089,6 +2089,63 @@ describe("FlareMo Worker API", () => {
     expect(sent).toHaveLength(5);
   });
 
+  it("throttles credential endpoints when the rate limiter binding is set", async () => {
+    const keys: string[] = [];
+    const limitedEnv = {
+      ...env,
+      RATE_LIMITER: {
+        limit: async (input: { key: string }) => {
+          keys.push(input.key);
+          return { success: false };
+        },
+      },
+    } as Env;
+
+    const denied = await app.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/register", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          "cf-connecting-ip": "203.0.113.7",
+        },
+        body: JSON.stringify({
+          name: "Member",
+          email: "rate-limit@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      limitedEnv,
+    );
+    expect(denied.status).toBe(429);
+    expect(keys[0]).toBe("register:203.0.113.7");
+
+    const signInDenied = await app.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/username", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          "cf-connecting-ip": "203.0.113.7",
+        },
+        body: JSON.stringify({ username: "owner", password: TEST_PASSWORD }),
+      }),
+      limitedEnv,
+    );
+    expect(signInDenied.status).toBe(429);
+    expect(keys).toContain("auth:203.0.113.7");
+
+    // Session reads bypass the limiter entirely.
+    const sessionRead = await app.fetch(
+      new Request("http://flaremo.test/api/auth/get-session", {
+        headers: { "cf-connecting-ip": "203.0.113.7" },
+      }),
+      limitedEnv,
+    );
+    expect(sessionRead.status).toBe(200);
+    expect(keys).toHaveLength(2);
+  });
+
   it("rejects a registration over the member cap with 429", async () => {
     const quotaApp = createFlareMoApp({
       resolvePlanLimits: () => ({

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -1,9 +1,14 @@
+import type { RateLimiterBinding } from "./rate-limit";
+
 export type FlareMoEnv = Env & {
   BETTER_AUTH_SECRET?: string;
   FLAREMO_BOOTSTRAP_SECRET?: string;
   FLAREMO_RECOVERY_SECRET?: string;
   FLAREMO_PUBLIC_URL?: string;
   FLAREMO_TRUSTED_ORIGINS?: string;
+  // Optional Cloudflare rate-limiting binding for credential endpoints
+  // (see src/rate-limit.ts). Unbound deployments skip throttling entirely.
+  RATE_LIMITER?: RateLimiterBinding;
   // Transactional email for registration verification (see src/email.ts).
   // `cloudflare` uses the EMAIL binding (Workers Paid); `none` skips
   // verification entirely (self-host default).

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -27,6 +27,7 @@ import {
 import { createEmbeddingProvider, createVectorIndex } from "./embedding";
 import type { FlareMoEnv } from "./env";
 import { jsonError } from "./http";
+import { betterAuthRateLimitBucket, rateLimitGuard } from "./rate-limit";
 import { accountApi } from "./routes/account-api";
 import { adminApi } from "./routes/admin-api";
 import { appApi } from "./routes/app-api";
@@ -173,7 +174,17 @@ export function createFlareMoApp(
   });
 
   app.route("/api/auth/flaremo", authApi);
-  app.all("/api/auth/*", (c) => createFlareMoAuth(c.env).handler(c.req.raw));
+  app.all("/api/auth/*", async (c) => {
+    // Edge-throttle Better Auth's credential endpoints (sign-in, sign-up,
+    // password reset) per client IP. The bucket is null for session reads
+    // and other non-credential paths.
+    const bucket = betterAuthRateLimitBucket(new URL(c.req.raw.url).pathname);
+    if (bucket) {
+      const throttled = await rateLimitGuard(c, bucket);
+      if (throttled) return throttled;
+    }
+    return createFlareMoAuth(c.env).handler(c.req.raw);
+  });
   app.route("/api/app/account", accountApi);
   app.route("/api/app/admin", adminApi);
   app.route("/api/app/memory", memoryApi);

--- a/apps/worker/src/rate-limit.ts
+++ b/apps/worker/src/rate-limit.ts
@@ -1,0 +1,86 @@
+import type { Context } from "hono";
+import type { HonoBindings } from "./context";
+
+/**
+ * Minimal shape of Cloudflare's rate-limiting binding. Deployments opt in by
+ * binding e.g. `RATE_LIMITER` in wrangler config; unbound deployments keep
+ * the exact previous behavior.
+ */
+export type RateLimiterBinding = {
+  limit: (input: { key: string }) => Promise<{ success: boolean }>;
+};
+
+/**
+ * Best-effort client IP. Cloudflare writes `cf-connecting-ip` before the
+ * Worker runs; the fallbacks only matter for local development.
+ */
+export function clientIpFromRequest(request: Request): string {
+  return (
+    request.headers.get("cf-connecting-ip")?.trim() ||
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "unknown"
+  );
+}
+
+/**
+ * Bucketed per-IP check against the deployment's rate-limiting binding.
+ * Absent binding → allowed. Binding errors fail open: this is deployment
+ * hardening for credential endpoints, not a correctness gate, and taking the
+ * whole auth surface down because a limiter hiccupped is the worse failure.
+ */
+export async function checkRateLimit(
+  limiter: RateLimiterBinding | undefined,
+  bucket: string,
+  request: Request,
+): Promise<boolean> {
+  if (!limiter) return false;
+  try {
+    const result = await limiter.limit({
+      key: `${bucket}:${clientIpFromRequest(request)}`,
+    });
+    return !result.success;
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        message: "Rate limiter binding failed; failing open",
+        error: String(error),
+      }),
+    );
+    return false;
+  }
+}
+
+/**
+ * Apply one rate-limit bucket to the current request; returns a 429 response
+ * when the caller is throttled, or null to continue.
+ */
+export async function rateLimitGuard(
+  c: Context<HonoBindings>,
+  bucket: string,
+): Promise<Response | null> {
+  const limited = await checkRateLimit(c.env.RATE_LIMITER, bucket, c.req.raw);
+  if (!limited) return null;
+  return c.json(
+    { error: { message: "Too many requests. Please try again later." } },
+    429,
+  );
+}
+
+/**
+ * Better Auth credential endpoints worth edge-throttling, by path suffix.
+ * GETs (session reads) are excluded on purpose.
+ */
+const RATE_LIMITED_AUTH_PATHS = [
+  "/sign-in/",
+  "/sign-up/",
+  "/forget-password",
+  "/reset-password",
+];
+
+export function betterAuthRateLimitBucket(pathname: string): string | null {
+  if (!RATE_LIMITED_AUTH_PATHS.some((suffix) => pathname.includes(suffix))) {
+    return null;
+  }
+  return "auth";
+}

--- a/apps/worker/src/routes/auth-api.ts
+++ b/apps/worker/src/routes/auth-api.ts
@@ -35,6 +35,7 @@ import {
   sendVerificationEmail,
 } from "../email";
 import { jsonError } from "../http";
+import { rateLimitGuard } from "../rate-limit";
 
 export const authApi = new Hono<HonoBindings>();
 
@@ -91,6 +92,8 @@ authApi.get("/register/status", async (c) => {
 });
 
 authApi.post("/register", zValidator("json", registerSchema), async (c) => {
+  const throttled = await rateLimitGuard(c, "register");
+  if (throttled) return throttled;
   const db = createDb(c.env.DB);
   const status = await getAuthBootstrapStatus(db);
   if (status.state !== "complete") {
@@ -210,6 +213,8 @@ authApi.post(
   "/resend-verification",
   zValidator("json", emailRequestSchema),
   async (c) => {
+    const throttled = await rateLimitGuard(c, "email");
+    if (throttled) return throttled;
     if (resolveEmailConfig(c.env).provider === "none") {
       return c.json(
         { error: { message: "Email verification is not enabled." } },
@@ -257,6 +262,8 @@ authApi.post(
   "/forgot-password",
   zValidator("json", emailRequestSchema),
   async (c) => {
+    const throttled = await rateLimitGuard(c, "email");
+    if (throttled) return throttled;
     if (resolveEmailConfig(c.env).provider === "none") {
       return c.json(
         { error: { message: "Password reset email is not configured." } },

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -157,7 +157,9 @@ Better Auth 是 FlareMo 的应用层认证事实源，按请求使用当前 Work
 
 PAT 由 cookie session 或 Better Auth session bearer 下的账户接口创建、列出和撤销，明文只在创建响应返回一次；`memos_pat_` 本身只能访问私有业务数据，不能调用账户 PAT 管理接口。`memos_pat_` 是 FlareMo-native credential，用于保护当前兼容 API 子集，不代表 Memos Server 的完整 auth parity。
 
-当前没有 email provider，因此 Better Auth 的自助忘记密码流程保持关闭。密码恢复走管理员兜底：owner 在后台为成员生成一次性重置链接（`auth_verifications` 存 token，用户自行设密，管理员不接触明文）；owner 自己忘记密码时，可用独立 `FLAREMO_RECOVERY_SECRET` 走 `/recover` 页面进入 Better Auth reset-password 流程。恢复成功后撤销全部 session 和 PAT，不创建第二个用户。该 secret 不是登录凭据，恢复结束后必须立即轮换或删除。
+邮件能力是可选 seam（`FLAREMO_EMAIL_PROVIDER`）：`none`（自托管默认，零配置）或 `cloudflare`（Workers Paid 的 `EMAIL` binding）。provider 为 `cloudflare` 时，浏览器注册强制邮箱验证（24 小时一次性 token），并解锁三个自助流程：重发验证邮件、邮件找回密码（1 小时 token，走 Better Auth 原生 reset-password，成功后撤销全部 session）、换邮箱验证新地址（确认前旧邮箱继续有效）。此时 Memos 兼容注册面（current `/api/v1/auth/signup`、Connect `AuthService.SignUp`）返回 403，因为兼容客户端无法完成邮箱验证流程。provider 为 `none` 时这些流程全部退回原行为：注册不验证邮箱、密码恢复走管理员兜底（owner 在后台为成员生成一次性重置链接，`auth_verifications` 存 token，用户自行设密，管理员不接触明文）；owner 自己忘记密码时，可用独立 `FLAREMO_RECOVERY_SECRET` 走 `/recover` 页面进入 Better Auth reset-password 流程。恢复成功后撤销全部 session 和 PAT，不创建第二个用户。该 secret 不是登录凭据，恢复结束后必须立即轮换或删除。
+
+凭据端点支持可选的 per-IP 限频：部署通过 Cloudflare rate-limiting binding 绑定 `RATE_LIMITER` 后，注册、重发验证、忘记密码和 Better Auth 的 sign-in/sign-up/reset 路径按 IP 分桶节流（超限返回 429）；未绑定该 binding 的部署行为不变。binding 故障时 fail-open（放行并记录错误日志），限频是加固手段而非正确性闸门。
 
 Cloudflare Access 可以在这三层之前作为外层 policy。它只负责入口门禁，Access identity 或 Service Token 不会自动提供 FlareMo 应用用户身份；启用时请求仍需 cookie session 或 PAT。公开分享可在 Access 上对最窄路径做 bypass，但不跳过 FlareMo share token 校验。
 


### PR DESCRIPTION
Closes #122

可选 Cloudflare rate-limiting binding（RATE_LIMITER）加固凭据端点：

- /register、/resend-verification、/forgot-password 按 register/email 桶节流
- Better Auth 的 sign-in/sign-up/forget-password/reset-password 路径按 auth 桶节流（session 读取不受影响）
- 未绑定 binding 的部署行为完全不变（自托管默认）；binding 故障 fail-open 并记日志
- 更新 docs/architecture-notes.md 的邮件与恢复段落（顺带修正 #117 后已过时的描述）

验证：pnpm verify（32 worker 测试含新增限频用例、e2e 全过）