### PR TITLE
feat(account): self-service account deletion with full data erasure

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -608,6 +608,13 @@ export async function verifyEmailChange(token: string) {
   );
 }
 
+export async function deleteAccount(currentPassword: string) {
+  return apiRequest<{ ok: true }>("/api/app/account", {
+    method: "DELETE",
+    body: JSON.stringify({ current_password: currentPassword }),
+  });
+}
+
 export async function getCurrentFlareMoUser() {
   return apiRequest<CurrentFlareMoUser>("/api/app/me");
 }

--- a/apps/web/src/i18n.tsx
+++ b/apps/web/src/i18n.tsx
@@ -275,6 +275,13 @@ const messages = {
     "auth.emailChangeVerificationSent":
       "确认邮件已发送到新邮箱，点击邮件里的链接后新邮箱才会生效。",
     "auth.verifyEmailChangeTitle": "确认新邮箱",
+    "auth.deleteAccountTitle": "注销账户",
+    "auth.deleteAccountDescription":
+      "永久删除你的账户、全部笔记、附件、智能记忆、项目与配额数据，并撤销所有登录会话和访问令牌。此操作不可撤销。",
+    "auth.deleteAccountPassword": "输入当前密码确认注销",
+    "auth.deleteAccountSubmit": "永久删除我的账户",
+    "auth.deleteAccountSubmitting": "正在删除…",
+    "auth.deleteAccountFailed": "注销失败，请确认密码后重试。",
     "auth.verifyEmailChangeSuccess": "新邮箱已生效，下次请使用新邮箱登录。",
     "auth.verifyEmailChangeInvalid":
       "链接无效或已过期，请到账户页重新发起修改。",
@@ -770,6 +777,14 @@ const messages = {
     "auth.emailChangeVerificationSent":
       "A confirmation email was sent to your new address. The change takes effect after you click the link in it.",
     "auth.verifyEmailChangeTitle": "Confirm new email",
+    "auth.deleteAccountTitle": "Delete account",
+    "auth.deleteAccountDescription":
+      "Permanently delete your account with all notes, attachments, agent memories, projects, and quota data, and revoke every session and access token. This cannot be undone.",
+    "auth.deleteAccountPassword": "Confirm with your current password",
+    "auth.deleteAccountSubmit": "Permanently delete my account",
+    "auth.deleteAccountSubmitting": "Deleting…",
+    "auth.deleteAccountFailed":
+      "Could not delete the account. Check your password and try again.",
     "auth.verifyEmailChangeSuccess":
       "New email confirmed. Use it to sign in from now on.",
     "auth.verifyEmailChangeInvalid":

--- a/apps/web/src/pages/account-page.tsx
+++ b/apps/web/src/pages/account-page.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 import {
   changeEmail,
   createPersonalAccessToken,
+  deleteAccount,
   getCurrentFlareMoUser,
   getVectorUsage,
   listPersonalAccessTokens,
@@ -57,6 +58,17 @@ export function AccountPage() {
   const [emailError, setEmailError] = useState<string | null>(null);
   const [emailVerificationPending, setEmailVerificationPending] =
     useState(false);
+  const [deletePassword, setDeletePassword] = useState("");
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const deleteAccountMutation = useMutation({
+    mutationFn: deleteAccount,
+    onSuccess: async () => {
+      // The server deleted the account; every cached query is stale.
+      queryClient.clear();
+      await authClient.signOut().catch(() => undefined);
+      await navigate({ replace: true, to: "/login" });
+    },
+  });
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -473,6 +485,69 @@ export function AccountPage() {
                 </form>
               </CardContent>
             </Card>
+            {!isOwner && (
+              <Card className="border-destructive/30">
+                <CardHeader>
+                  <CardTitle>{t("auth.deleteAccountTitle")}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <form
+                    className="flex flex-col gap-3"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      setDeleteError(null);
+                      void deleteAccountMutation
+                        .mutateAsync(deletePassword)
+                        .then(() => setDeletePassword(""))
+                        .catch((error: unknown) => {
+                          setDeleteError(
+                            errorMessage(error, t("auth.deleteAccountFailed")),
+                          );
+                        });
+                    }}
+                  >
+                    <p className="text-sm leading-6 text-muted-foreground">
+                      {t("auth.deleteAccountDescription")}
+                    </p>
+                    <label
+                      className="flex flex-col gap-1.5 text-sm font-medium"
+                      htmlFor="account-delete-password"
+                    >
+                      {t("auth.deleteAccountPassword")}
+                      <Input
+                        autoComplete="current-password"
+                        disabled={deleteAccountMutation.isPending}
+                        id="account-delete-password"
+                        required
+                        type="password"
+                        value={deletePassword}
+                        onChange={(event) =>
+                          setDeletePassword(event.target.value)
+                        }
+                      />
+                    </label>
+                    {deleteError && (
+                      <p className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive">
+                        {deleteError}
+                      </p>
+                    )}
+                    <Button
+                      className="w-fit"
+                      disabled={
+                        deleteAccountMutation.isPending ||
+                        deletePassword.length === 0
+                      }
+                      type="submit"
+                      variant="destructive"
+                    >
+                      {deleteAccountMutation.isPending
+                        ? t("auth.deleteAccountSubmitting")
+                        : t("auth.deleteAccountSubmit")}
+                    </Button>
+                  </form>
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
 
           <TabsContent value="tokens" className="mt-4">

--- a/apps/worker/src/api.test.ts
+++ b/apps/worker/src/api.test.ts
@@ -100,6 +100,10 @@ describe("FlareMo Worker API", () => {
       ),
       "utf8",
     );
+    const reactionsSchema = await readFile(
+      resolve(import.meta.dirname, "../../../migrations/0006_silent_kylun.sql"),
+      "utf8",
+    );
     const sseEvents = await readFile(
       resolve(
         import.meta.dirname,
@@ -136,18 +140,27 @@ describe("FlareMo Worker API", () => {
       ),
       "utf8",
     );
+    const projectsSchema = await readFile(
+      resolve(
+        import.meta.dirname,
+        "../../../migrations/0013_nosy_luke_cage.sql",
+      ),
+      "utf8",
+    );
     await applyMigration(db, migration);
     await applyMigration(db, cleanup);
     await applyMigration(db, v020);
     await applyMigration(db, offlineCapture);
     await applyMigration(db, offlineAttachments);
     await applyMigration(db, nativeAuth);
+    await applyMigration(db, reactionsSchema);
     await applyMigration(db, sseEvents);
     await applyMigration(db, userServiceParity);
     await applyMigration(db, webhookOutbox);
     await applyMigration(db, dataTasks);
     await applyMigration(db, memorySchema);
     await applyMigration(db, embeddingSchema);
+    await applyMigration(db, projectsSchema);
     sessionCookie = await bootstrapAndSignIn();
   });
 
@@ -2144,6 +2157,157 @@ describe("FlareMo Worker API", () => {
     );
     expect(sessionRead.status).toBe(200);
     expect(keys).toHaveLength(2);
+  });
+
+  it("lets a member delete their own account after password confirmation", async () => {
+    const open = await app.fetch(
+      new Request("http://flaremo.test/api/app/admin/settings", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          cookie: sessionCookie,
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({ registration_open: true }),
+      }),
+      env,
+    );
+    expect(open.status).toBe(200);
+
+    const register = await app.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/register", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          name: "Doomed",
+          email: "doomed@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      env,
+    );
+    expect(register.status).toBe(201);
+
+    const signIn = await app.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          email: "doomed@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      env,
+    );
+    expect(signIn.status).toBe(200);
+    const memberCookie = extractCookieHeader(signIn);
+
+    const memo = await app.fetch(
+      new Request("http://flaremo.test/api/v1/memos", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          cookie: memberCookie,
+        },
+        body: JSON.stringify({ content: "goodbye" }),
+      }),
+      env,
+    );
+    expect(memo.status).toBe(200);
+
+    // The owner cannot self-delete through the app.
+    const ownerDelete = await app.fetch(
+      new Request("http://flaremo.test/api/app/account", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          cookie: sessionCookie,
+        },
+        body: JSON.stringify({ current_password: TEST_PASSWORD }),
+      }),
+      env,
+    );
+    expect(ownerDelete.status).toBe(403);
+
+    // Wrong password refused; correct password deletes identity and data.
+    const wrongDelete = await app.fetch(
+      new Request("http://flaremo.test/api/app/account", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          cookie: memberCookie,
+        },
+        body: JSON.stringify({ current_password: "wrong-password-123" }),
+      }),
+      env,
+    );
+    expect(wrongDelete.status).toBe(400);
+
+    const deleted = await app.fetch(
+      new Request("http://flaremo.test/api/app/account", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+          cookie: memberCookie,
+        },
+        body: JSON.stringify({ current_password: TEST_PASSWORD }),
+      }),
+      env,
+    );
+    expect(deleted.status).toBe(200);
+
+    const reSignIn = await app.fetch(
+      new Request("http://flaremo.test/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          email: "doomed@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      env,
+    );
+    expect(reSignIn.status).toBe(401);
+
+    // The member's memo is gone with the account.
+    const list = await app.fetch(
+      new Request("http://flaremo.test/api/v1/memos", {
+        headers: { cookie: memberCookie },
+      }),
+      env,
+    );
+    expect(list.status).toBe(401);
+
+    // The freed email can register again.
+    const reRegister = await app.fetch(
+      new Request("http://flaremo.test/api/auth/flaremo/register", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://flaremo.test",
+        },
+        body: JSON.stringify({
+          name: "Doomed",
+          email: "doomed@example.com",
+          password: TEST_PASSWORD,
+        }),
+      }),
+      env,
+    );
+    expect(reRegister.status).toBe(201);
   });
 
   it("rejects a registration over the member cap with 429", async () => {

--- a/apps/worker/src/routes/account-api.ts
+++ b/apps/worker/src/routes/account-api.ts
@@ -1,7 +1,13 @@
 import {
+  chunkIdsForMemo,
+  collectFlaremoAccountArtifacts,
+  deleteFlaremoAccount,
+  type FlaremoAccountArtifacts,
+  ForbiddenError,
   getMemosPersonalAccessToken,
   isFlaremoUserEmailTaken,
   listMemosPersonalAccessTokens,
+  memoryIdVector,
   NotFoundError,
   updateFlaremoUserEmail,
   ValidationError,
@@ -12,6 +18,7 @@ import { z } from "zod";
 import { createFlareMoAuth, getPublicUrl, MEMOS_PAT_CONFIG_ID } from "../auth";
 import { getBrowserRequestContext, type HonoBindings } from "../context";
 import { resolveEmailConfig, sendEmailChangeVerificationEmail } from "../email";
+import type { FlareMoEnv } from "../env";
 import { jsonError } from "../http";
 
 export const accountApi = new Hono<HonoBindings>();
@@ -25,6 +32,45 @@ const changeEmailSchema = z.object({
   current_password: z.string().min(1).max(128),
   new_email: z.string().trim().email().max(320),
 });
+
+const deleteAccountSchema = z.object({
+  current_password: z.string().min(1).max(128),
+});
+
+/**
+ * Remove the account's out-of-D1 artifacts: R2 attachment objects and the
+ * deterministic Vectorize vectors (deleteByIds no-ops unknown ids). The D1
+ * rows themselves go through deleteFlaremoAccount. Bindings are optional —
+ * deployments without R2/vectorize indexes skip the respective cleanup.
+ */
+async function deleteAccountArtifacts(
+  env: FlareMoEnv,
+  artifacts: FlaremoAccountArtifacts,
+): Promise<void> {
+  const keys = artifacts.attachmentR2Keys;
+  if (env.ATTACHMENTS) {
+    for (let index = 0; index < keys.length; index += 500) {
+      await env.ATTACHMENTS.delete(keys.slice(index, index + 500));
+    }
+  }
+  const memoVectorIds = artifacts.memoIds.flatMap((id) => chunkIdsForMemo(id));
+  const memoryVectorIds = artifacts.memoryIds.map((id) => memoryIdVector(id));
+  const vectorTargets: Array<{
+    index: VectorizeIndex | undefined;
+    ids: string[];
+  }> = [
+    { index: env.VECTORIZE_MEMOS, ids: memoVectorIds },
+    { index: env.VECTORIZE_MEMORIES, ids: memoryVectorIds },
+  ];
+  for (const target of vectorTargets) {
+    if (!target.index) continue;
+    for (let offset = 0; offset < target.ids.length; offset += 500) {
+      const batch = target.ids.slice(offset, offset + 500);
+      if (batch.length === 0) continue;
+      await target.index.deleteByIds(batch);
+    }
+  }
+}
 
 accountApi.get("/personal-access-tokens", async (c) => {
   try {
@@ -164,6 +210,45 @@ accountApi.post("/email", zValidator("json", changeEmailSchema), async (c) => {
       newEmail,
     });
     await updateFlaremoUserEmail(context.db, context.user, newEmail);
+
+    const response = c.json({ ok: true });
+    response.headers.set("cache-control", "no-store");
+    return response;
+  } catch (error) {
+    return jsonError(c, error);
+  }
+});
+
+accountApi.delete("/", zValidator("json", deleteAccountSchema), async (c) => {
+  try {
+    const context = await getBrowserRequestContext(c);
+    if (context.user.role === "owner") {
+      throw new ForbiddenError(
+        "The owner account cannot be deleted through the app.",
+      );
+    }
+    const input = c.req.valid("json");
+    const auth = createFlareMoAuth(c.env, context.db);
+    // Self-destruction re-authenticates the caller with their current
+    // password. Better Auth raises on a mismatch, which maps to a plain
+    // "bad password" here, not a server fault.
+    try {
+      await auth.api.verifyPassword({
+        body: { password: input.current_password },
+        headers: c.req.raw.headers,
+      });
+    } catch {
+      throw new ValidationError("The current password is incorrect.");
+    }
+
+    // Snapshot out-of-D1 artifacts first: the batch removes the rows that
+    // name the R2 objects and the vector id sources.
+    const artifacts = await collectFlaremoAccountArtifacts(
+      context.db,
+      context.user.id,
+    );
+    await deleteFlaremoAccount(context.db, context.user.id);
+    await deleteAccountArtifacts(c.env, artifacts);
 
     const response = c.json({ ok: true });
     response.headers.set("cache-control", "no-store");

--- a/packages/domain/src/embedding-outbox.ts
+++ b/packages/domain/src/embedding-outbox.ts
@@ -491,14 +491,16 @@ async function pruneEmbeddingOutbox(db: FlareMoDb, before: Date) {
     );
 }
 
-function chunkIdsForMemo(memoId: string): string[] {
+/** All possible vector ids for a memo (deleteByIds no-ops missing ids). */
+export function chunkIdsForMemo(memoId: string): string[] {
   return Array.from(
     { length: EMBEDDING_MAX_CHUNKS },
     (_, index) => `${memoId}#chunks/${index}`,
   );
 }
 
-function memoryIdVector(memoryId: string): string {
+/** Memories are atomic conclusions (no chunking): vector id = resource id. */
+export function memoryIdVector(memoryId: string): string {
   // Memories are atomic conclusions (no chunking), so the vector id is the
   // resource id itself.
   return memoryId;

--- a/packages/domain/src/users.ts
+++ b/packages/domain/src/users.ts
@@ -1,6 +1,37 @@
 import type { FlareMoDb, UserRow } from "@flaremo/db";
-import { authUserLinks, authUsers, users } from "@flaremo/db";
-import { asc, eq } from "drizzle-orm";
+import {
+  attachments,
+  authAccounts,
+  authApiKeys,
+  authSessions,
+  authUserLinks,
+  authUsers,
+  dataTasks,
+  embeddingTasks,
+  memoRelations,
+  memoRevisions,
+  memoryItems,
+  memoryRelations,
+  memoryResourceLinks,
+  memoryRevisions,
+  memos,
+  memosNotifications,
+  memosSseEvents,
+  memosWebhookDeliveries,
+  memosWebhookEvents,
+  memosWebhooks,
+  memoTags,
+  projects,
+  reactions,
+  settings,
+  shares,
+  shortcuts,
+  taskActivity,
+  tasks,
+  usageCounters,
+  users,
+} from "@flaremo/db";
+import { asc, eq, inArray, or } from "drizzle-orm";
 import {
   ConflictError,
   ForbiddenError,
@@ -163,6 +194,143 @@ export async function deleteFlaremoUser(
     await db.delete(authUsers).where(eq(authUsers.id, link.authUserId));
   }
   await db.delete(users).where(eq(users.id, userId));
+}
+
+/**
+ * Resource identities a caller must clean outside D1 (R2 objects and Vectorize
+ * vectors) before/while the account rows go away.
+ */
+export type FlaremoAccountArtifacts = {
+  memoIds: string[];
+  memoryIds: string[];
+  attachmentR2Keys: string[];
+};
+
+/**
+ * Snapshot the account's out-of-D1 artifacts. Must be called BEFORE
+ * deleteFlaremoAccount: after the batch the attachment rows (R2 keys) and
+ * memo/memory rows (vector id sources) are gone.
+ */
+export async function collectFlaremoAccountArtifacts(
+  db: FlareMoDb,
+  userId: string,
+): Promise<FlaremoAccountArtifacts> {
+  const memoRows = await db
+    .select({ id: memos.id })
+    .from(memos)
+    .where(eq(memos.userId, userId));
+  const memoryRows = await db
+    .select({ id: memoryItems.id })
+    .from(memoryItems)
+    .where(eq(memoryItems.userId, userId));
+  const attachmentRows = await db
+    .select({ key: attachments.r2Key })
+    .from(attachments)
+    .where(eq(attachments.userId, userId));
+  return {
+    memoIds: memoRows.map((row) => row.id),
+    memoryIds: memoryRows.map((row) => row.id),
+    attachmentR2Keys: attachmentRows.map((row) => row.key),
+  };
+}
+
+/**
+ * Self-service account deletion. Every per-user row is deleted explicitly,
+ * children first, so the cleanup never depends on FK enforcement being
+ * enabled in the runtime (D1/SQLite PRAGMAs differ between local and remote)
+ * and cannot leave orphaned rows behind a missing cascade.
+ *
+ * The caller is responsible for the out-of-D1 artifacts returned by
+ * collectFlaremoAccountArtifacts (R2 objects, Vectorize vectors) and for
+ * refusing owner self-deletion.
+ */
+export async function deleteFlaremoAccount(
+  db: FlareMoDb,
+  userId: string,
+): Promise<void> {
+  if (userId === "users/owner") {
+    throw new ForbiddenError("The owner account cannot be deleted.");
+  }
+  const user = await getFlaremoUserById(db, userId);
+  if (!user) throw new NotFoundError("User not found");
+
+  const link = await db.query.authUserLinks.findFirst({
+    where: eq(authUserLinks.flaremoUserId, userId),
+  });
+  const authUserId = link?.authUserId ?? null;
+
+  const userWebhookIds = db
+    .select({ id: memosWebhooks.id })
+    .from(memosWebhooks)
+    .where(eq(memosWebhooks.userId, userId));
+
+  await db.batch([
+    db.delete(taskActivity).where(eq(taskActivity.userId, userId)),
+    db.delete(tasks).where(eq(tasks.userId, userId)),
+    db.delete(projects).where(eq(projects.userId, userId)),
+    // Embedding outbox rows are dropped here: vector cleanup happens
+    // synchronously in the caller via collectFlaremoAccountArtifacts, so a
+    // pending task must not outlive its owner.
+    db.delete(embeddingTasks).where(eq(embeddingTasks.userId, userId)),
+    db.delete(usageCounters).where(eq(usageCounters.userId, userId)),
+    db.delete(dataTasks).where(eq(dataTasks.userId, userId)),
+    db.delete(settings).where(eq(settings.userId, userId)),
+    db.delete(shares).where(eq(shares.userId, userId)),
+    db.delete(attachments).where(eq(attachments.userId, userId)),
+    db.delete(reactions).where(eq(reactions.creatorId, userId)),
+    db
+      .delete(memoRelations)
+      .where(
+        inArray(
+          memoRelations.memoId,
+          db
+            .select({ id: memos.id })
+            .from(memos)
+            .where(eq(memos.userId, userId)),
+        ),
+      ),
+    db.delete(memoRevisions).where(eq(memoRevisions.userId, userId)),
+    db.delete(memoTags).where(eq(memoTags.userId, userId)),
+    db.delete(memos).where(eq(memos.userId, userId)),
+    db.delete(memosSseEvents).where(eq(memosSseEvents.creatorId, userId)),
+    db
+      .delete(memosWebhookDeliveries)
+      .where(inArray(memosWebhookDeliveries.webhookId, userWebhookIds)),
+    db
+      .delete(memosWebhookEvents)
+      .where(eq(memosWebhookEvents.receiverId, userId)),
+    db.delete(memosWebhooks).where(eq(memosWebhooks.userId, userId)),
+    db
+      .delete(memosNotifications)
+      .where(
+        or(
+          eq(memosNotifications.receiverId, userId),
+          eq(memosNotifications.senderId, userId),
+        ),
+      ),
+    db.delete(shortcuts).where(eq(shortcuts.userId, userId)),
+    db
+      .delete(memoryResourceLinks)
+      .where(eq(memoryResourceLinks.userId, userId)),
+    db.delete(memoryRelations).where(eq(memoryRelations.userId, userId)),
+    db.delete(memoryRevisions).where(eq(memoryRevisions.userId, userId)),
+    db.delete(memoryItems).where(eq(memoryItems.userId, userId)),
+  ]);
+
+  // Better Auth identity last: sessions, PATs, accounts, then the user row
+  // itself, then the bridge and the domain user.
+  if (authUserId) {
+    await db.batch([
+      db.delete(authApiKeys).where(eq(authApiKeys.referenceId, authUserId)),
+      db.delete(authSessions).where(eq(authSessions.userId, authUserId)),
+      db.delete(authAccounts).where(eq(authAccounts.userId, authUserId)),
+      db.delete(authUsers).where(eq(authUsers.id, authUserId)),
+    ]);
+  }
+  await db.batch([
+    db.delete(authUserLinks).where(eq(authUserLinks.flaremoUserId, userId)),
+    db.delete(users).where(eq(users.id, userId)),
+  ]);
 }
 
 /**


### PR DESCRIPTION
Closes #124

- DELETE /api/app/account：当前密码确认后彻底删除账号（owner 例外，返回 403）。
- domain 新增 deleteFlaremoAccount：逐表显式删除该用户全部 D1 数据（children-first，不依赖运行时 FK 级联），包括 auth 身份、session、PAT、usage counters、embedding outbox。
- R2 附件对象与 Vectorize 向量同步清除（向量 ID 确定性枚举，deleteByIds 对缺失 id 幂等）；未绑定 R2/Vectorize 的部署自动跳过对应清理。
- 账户页新增危险区（仅成员可见），删除后清空本地缓存并回登录页；中英文案齐全。
- 顺带补齐 api.test.ts 夹具缺失的 0006/0013 migration（reactions/projects/task_activity 表）。

验证：pnpm verify（33 worker 测试含新增注销全链路用例、e2e 全过）